### PR TITLE
Esc 263 amend undertaking

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -33,6 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @ImplementedBy(classOf[EscConnectorImpl])
 trait EscConnector {
   def createUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
+  def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
   def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
@@ -53,6 +54,7 @@ class EscConnectorImpl @Inject()(http: HttpClient,
 
   val escURL: String = servicesConfig.baseUrl("esc")
   val createUndertakingPath = "eu-subsidy-compliance/undertaking"
+  val updateUndertakingPath = "eu-subsidy-compliance/undertaking/update"
   val retrieveUndertakingPath = "eu-subsidy-compliance/undertaking/"
   val addMemberPath = "eu-subsidy-compliance/undertaking/member"
   val removeMemberPath = "eu-subsidy-compliance/undertaking/member/remove"
@@ -64,6 +66,16 @@ class EscConnectorImpl @Inject()(http: HttpClient,
     val createUndertakingUrl = s"$escURL/$createUndertakingPath"
     http.
       POST[Undertaking, HttpResponse](createUndertakingUrl, undertaking)
+      .map(Right(_))
+      .recover {
+        case e => Left(Error(e))
+      }
+  }
+
+  override def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] = {
+    val updateUndertakingUrl = s"$escURL/$updateUndertakingPath"
+    http.
+      POST[Undertaking, HttpResponse](updateUndertakingUrl, undertaking)
       .map(Right(_))
       .recover {
         case e => Left(Error(e))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -30,6 +30,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @ImplementedBy(classOf[EscServiceImpl])
 trait EscService {
   def createUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[UndertakingRef]
+  def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[UndertakingRef]
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Option[Undertaking]]
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit hc: HeaderCarrier): Future[UndertakingRef]
   def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
@@ -54,7 +55,16 @@ class EscServiceImpl @Inject() (escConnector: EscConnector)(implicit ec: Executi
       case Right(value) =>
         if(value.status =!= OK) sys.error("Error in creating Undertaking")
         else
-        value.parseJSON[UndertakingRef].fold(_ =>  sys.error("Error in parsing  UndertakingRef"), undertakingRef => undertakingRef)
+        value.parseJSON[UndertakingRef].fold(_ =>  sys.error("Error in parsing  UndertakingRef"), identity)
+    }
+  }
+
+  override def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[UndertakingRef] = {
+    escConnector.updateUndertaking(undertaking).map {
+      case Left(Error(_)) => sys.error(" Error in updating undertaking")
+      case Right(value) =>
+        if(value.status =!= OK) sys.error("Error in Update undertaking as http response came back with non OK status")
+        else value.parseJSON[UndertakingRef].fold(_ =>  sys.error("Error in parsing  UndertakingRef"), identity)
     }
   }
 
@@ -76,7 +86,7 @@ class EscServiceImpl @Inject() (escConnector: EscConnector)(implicit ec: Executi
       case Right(value) =>
         if(value.status =!= OK) sys.error("Error in adding member to the Business Entity")
         else
-        value.parseJSON[UndertakingRef].fold(_ =>  sys.error("Error in parsing  Undertaking Ref"),undertakingRef => undertakingRef)
+        value.parseJSON[UndertakingRef].fold(_ =>  sys.error("Error in parsing  Undertaking Ref"), identity)
     }
   }
 
@@ -86,7 +96,7 @@ class EscServiceImpl @Inject() (escConnector: EscConnector)(implicit ec: Executi
       case Right(value) =>
         if(value.status =!= OK) sys.error("Error in removing member from the Business Entity")
         else
-        value.parseJSON[UndertakingRef].fold(_ => sys.error("Error in parsing  Undertaking Ref"),undertakingRef => undertakingRef)
+        value.parseJSON[UndertakingRef].fold(_ => sys.error("Error in parsing  Undertaking Ref"), identity)
     }
   }
 
@@ -96,7 +106,7 @@ class EscServiceImpl @Inject() (escConnector: EscConnector)(implicit ec: Executi
       case Right(value) =>
         if(value.status =!= OK) sys.error("Error in creating subsidy ")
         else
-          value.parseJSON[UndertakingRef].fold(_ => sys.error("Error in parsing  Undertaking Ref"),undertakingRef => undertakingRef)
+          value.parseJSON[UndertakingRef].fold(_ => sys.error("Error in parsing  Undertaking Ref"), identity)
     }
   }
 
@@ -106,7 +116,7 @@ class EscServiceImpl @Inject() (escConnector: EscConnector)(implicit ec: Executi
       case Right(value) =>
         if(value.status =!= OK) sys.error("Error in retrieving subsidy ")
         else
-          value.parseJSON[UndertakingSubsidies].fold(_ => sys.error("Error in parsing  UndertakingSubsidies "),undertakingSubsidies => undertakingSubsidies)
+          value.parseJSON[UndertakingSubsidies].fold(_ => sys.error("Error in parsing  UndertakingSubsidies "), identity)
     }
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -16,10 +16,13 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
+import cats.implicits.catsSyntaxOptionId
 import play.api.Logger
 import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.{AnyContent, Request, Result}
 import play.api.mvc.Results.Redirect
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ContactDetails
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{PhoneNumber, Sector}
 
 import scala.concurrent.Future
 
@@ -74,8 +77,9 @@ trait Journey {
       formPage.value.isEmpty && index < currentIndex
   }
 
-  def isComplete:Boolean =
+  def isComplete:Boolean = {
     steps.last.exists(x => x.value.isDefined)
+  }
 
   def redirect(implicit request: Request[AnyContent]): Option[Future[Result]] = {
     val firstUnfilledFormUri: Journey.Uri =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -29,7 +29,7 @@ case class UndertakingJourney(
   contact: FormPage[ContactDetails] = FormPage("contact"),
   cya: FormPage[Boolean] = FormPage("check-your-answers"),
   confirmation: FormPage[Boolean] = FormPage("confirmation"),
-  isAmend: FormPage[Boolean] = FormPage("amend-undertaking")
+  isAmend: Option[Boolean] = None
 ) extends Journey {
 
   override def steps: List[Option[FormPage[_]]] =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -37,6 +37,7 @@ case class UndertakingJourney(
       unapply(this)
       .map(_.toList)
       .fold(List.empty[Any])(identity)
+      .filter(_.isInstanceOf[FormPage[_]])
       .map(_.cast[FormPage[_]])
 
 }
@@ -63,7 +64,8 @@ object UndertakingJourney {
         sector = empty.sector.copy(value = undertaking.industrySector.some),
         contact = empty.contact.copy(
           value = cd
-        )
+        ),
+        isAmend = false.some
       )
     case _ => UndertakingJourney()
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -28,7 +28,8 @@ case class UndertakingJourney(
   sector: FormPage[Sector] = FormPage("sector"),
   contact: FormPage[ContactDetails] = FormPage("contact"),
   cya: FormPage[Boolean] = FormPage("check-your-answers"),
-  confirmation: FormPage[Boolean] = FormPage("confirmation")
+  confirmation: FormPage[Boolean] = FormPage("confirmation"),
+  isAmend: FormPage[Boolean] = FormPage("amend-undertaking")
 ) extends Journey {
 
   override def steps: List[Option[FormPage[_]]] =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AccountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AccountPage.scala.html
@@ -60,7 +60,7 @@
     <div class="govuk-card govuk-card--contained govuk-card fixed-min-height-card">
       <h2 class="govuk-heading-s">@messages("account-homepage.cards.card2.heading")</h2>
       <ul class="govuk-list govuk-list--spaced">
-        <li><a href="#" class="govuk-link">[TODO: LINK HREF] @messages("account-homepage.cards.card2.link1")</a></li>
+        <li><a href="@routes.UndertakingController.getAmendUndertakingDetails()" class="govuk-link">@messages("account-homepage.cards.card2.link1")</a></li>
         <li><a href="#" class="govuk-link">[TODO: LINK HREF] @messages("account-homepage.cards.card2.link2")</a></li>
       </ul>
     </div>

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AmendUndertakingPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AmendUndertakingPage.scala.html
@@ -1,0 +1,119 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+@import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+@import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey
+@import uk.gov.hmrc.eusubsidycompliancefrontend.models.types._
+@import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
+@import uk.gov.hmrc.eusubsidycompliancefrontend.models.ContactDetails
+
+
+@this(
+        layout: Layout,
+        formHelper: FormWithCSRF,
+        button: components.Button,
+        govukErrorSummary: GovukErrorSummary,
+        govukRadios : GovukRadios,
+        govukSummaryList : GovukSummaryList
+)
+
+
+@(name: UndertakingName, sector: Sector, contacts: ContactDetails, previous: Journey.Uri)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout(
+    pageTitle = Some(messages("undertaking.amendUndertaking.title")),
+    backLinkEnabled = true,
+    backLink = Some(previous)
+) {
+
+    @defining(
+        contacts match {
+            case ContactDetails(Some(p), Some(m)) => p + "<br>" + m
+            case ContactDetails(None, Some(m)) => m
+            case ContactDetails(Some(p), None) => p
+            case _ => ""
+        }
+    ) { case (phone) =>
+
+        @formHelper(action = controllers.routes.UndertakingController.postAmendUndertaking) {
+            <input type=hidden name=cya value=true>
+
+            <h1 class="govuk-heading-l">@messages("undertaking.amendUndertaking.title")</h1>
+
+            @govukSummaryList(SummaryList(
+                rows = Seq(
+                    SummaryListRow(
+                        key = Key(
+                            content = Text(messages("undertaking.amendUndertaking.summary-list.name.key"))
+                        ),
+                        value = Value(
+                            content = Text(name)
+                        ),
+                        actions = Some(Actions(
+                            items = Seq(
+                                ActionItem(
+                                    href = controllers.routes.UndertakingController.getUndertakingName().toString,
+                                    content = Text("Change"),
+                                    visuallyHiddenText = Some("name")
+                                )
+                            )
+                        ))
+                    ),
+                    SummaryListRow(
+                        key = Key(
+                            content = Text(messages("undertaking.amendUndertaking.summary-list.sector.key"))
+                        ),
+                        value = Value(
+                            content = Text(messages(s"sector.label.$sector"))
+                        ),
+                        actions = Some(Actions(
+                            items = Seq(
+                                ActionItem(
+                                    href = controllers.routes.UndertakingController.getSector().toString,
+                                    content = Text("Change"),
+                                    visuallyHiddenText = Some("contact information")
+                                )
+                            )
+                        ))
+                    ),
+                    SummaryListRow(
+                        key = Key(
+                            content = Text(messages("undertaking.amendUndertaking.summary-list.telephone.key"))
+                        ),
+                        value = Value(
+                            content = HtmlContent(phone)
+                        ),
+                        actions = Some(Actions(
+                            items = Seq(
+                                ActionItem(
+                                    href = controllers.routes.UndertakingController.getContact().toString,
+                                    content = Text("Change"),
+                                    visuallyHiddenText = Some("contact details")
+                                )
+                            )
+                        ))
+                    )
+                )
+            ))
+
+            <p class="govuk-body">@messages("undertaking.amendUndertaking.p")</p>
+
+            @button("common.saveChanges")
+        }
+    }
+}
+

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AmendUndertakingPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AmendUndertakingPage.scala.html
@@ -41,12 +41,7 @@
 ) {
 
     @defining(
-        contacts match {
-            case ContactDetails(Some(p), Some(m)) => p + "<br>" + m
-            case ContactDetails(None, Some(m)) => m
-            case ContactDetails(Some(p), None) => p
-            case _ => ""
-        }
+        List(contacts.phone, contacts.mobile).flatten.mkString("<br>")
     ) { case (phone) =>
 
         @formHelper(action = controllers.routes.UndertakingController.postAmendUndertaking) {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AmendUndertakingPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AmendUndertakingPage.scala.html
@@ -50,7 +50,7 @@
     ) { case (phone) =>
 
         @formHelper(action = controllers.routes.UndertakingController.postAmendUndertaking) {
-            <input type=hidden name=cya value=true>
+            <input type=hidden name=amendUndertaking value=true>
 
             <h1 class="govuk-heading-l">@messages("undertaking.amendUndertaking.title")</h1>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -82,6 +82,9 @@ POST       /add-trader-ref                    uk.gov.hmrc.eusubsidycompliancefro
 GET        /check-your-answers-subsidy                uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getCheckAnswers
 POST       /check-your-answers-subsidy                uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postCheckAnswers
 
+GET        /amend-undertaking        uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getAmendUndertakingDetails
+POST       /amend-undertaking        uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postAmendUndertaking
+
 GET       /update-email-address              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.updateEmailAddress
 
 GET    /subsidy-delete/:transactionId      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getRemoveSubsidyClaim(transactionId)

--- a/conf/messages
+++ b/conf/messages
@@ -6,6 +6,7 @@ generic.errorPrefix = Error:
 
 common.back=Back
 common.sign-out=[TODO] Sign out
+common.saveChanges = Save changes
 common.continue=Save and Continue
 common.accept=Accept and send
 continue.button=Save and Continue
@@ -211,3 +212,9 @@ subsidy.cya.summary-list.authority.key=Public authority
 subsidy.cya.summary-list.traderRef.key=Your reference
 subsidy.cya.p1=By sending these details you are confirming that, to the best of your knowledge, they are correct.
 
+#Amend Undertaking
+undertaking.amendUndertaking.title = Undertaking Details
+undertaking.amendUndertaking.summary-list.name.key = Name of Undertaking
+undertaking.amendUndertaking.summary-list.sector.key = Industry sector
+undertaking.amendUndertaking.summary-list.telephone.key = Telephone number
+undertaking.amendUndertaking.p = By sending these details you are confirming that, to the best of your knowledge, they are correct

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -73,6 +73,16 @@ class EscConnectorSpec
 
     }
 
+    "handling request to update Undertaking" must {
+
+      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/update"
+      behave like connectorBehaviour(
+        mockPost(expectedUrl, Seq.empty, undertaking)(_),
+        () => connector.updateUndertaking(undertaking)
+      )
+
+    }
+
     "handling request to retrieve Undertaking" must {
       val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/$eori1"
       behave like connectorBehaviour(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -279,7 +279,7 @@ class AccountControllerSpec  extends ControllerSpec
                 mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
                 mockRetreiveUndertaking(eori1)(Future.successful(None))
                 mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
-                mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
+                mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete1.some))
                 mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
               }
               checkIsRedirect(performAction(), routes.BusinessEntityController.getAddBusinessEntity())

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
@@ -87,6 +87,25 @@ trait ControllerSpec extends PlaySupport {
       expectedStatus
     )
 
+  def checkFormErrorsAreDisplayed(
+                                   result: Future[Result],
+                                   expectedTitle: String,
+                                   formErrors: List[String],
+                                   expectedStatus: Int = BAD_REQUEST
+                                 ): Unit =
+    checkPageIsDisplayed(
+      result,
+      expectedTitle,
+      { doc =>
+        val errorSummary = doc.select(".govuk-error-summary")
+        errorSummary.select("a").text() shouldBe formErrors(0)
+
+        val inputErrorMessages = doc.select(".govuk-error-message").text()
+        inputErrorMessages shouldBe formErrors.map(e => s"Error: $e").mkString(" ")
+      },
+      expectedStatus
+    )
+
 
   def testRadioButtonOptions(doc: Document, expectedRadioOptionsTexts: List[String]) = {
     val radioOptions = doc.select(".govuk-radios__item")

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -1,0 +1,725 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+
+import cats.implicits.catsSyntaxOptionId
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingControllerSpec.AmendUndertakingRows
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ContactDetails, Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, FormPage, JourneyTraverseService, Store, UndertakingJourney}
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.CommonTestData._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+class UndertakingControllerSpec extends ControllerSpec
+  with AuthSupport
+  with JourneyStoreSupport
+  with AuthAndSessionDataBehaviour
+  with JourneySupport {
+  val mockEscService = mock[EscService]
+
+  override def overrideBindings = List(
+    bind[AuthConnector].toInstance(mockAuthConnector),
+    bind[Store].toInstance(mockJourneyStore),
+    bind[EscService].toInstance(mockEscService),
+    bind[JourneyTraverseService].toInstance(mockJourneyTraverseService)
+  )
+
+  val controller: UndertakingController = instanceOf[UndertakingController]
+
+  def mockRetreiveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
+    (mockEscService
+      .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
+      .expects(eori, *)
+      .returning(result)
+
+  def mockUpdateUndertaking(undertaking: Undertaking)(result: Either[Error, UndertakingRef]) =
+    (mockEscService
+      .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
+      .expects(undertaking, *)
+      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)),Future.successful))
+
+  def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(result: Either[Error, UndertakingRef]) =
+    (mockEscService
+      .addMember(_: UndertakingRef, _:  BusinessEntity)(_: HeaderCarrier))
+      .expects(undertakingRef, businessEntity, *)
+      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)),Future.successful))
+
+  "UndertakingControllerSpec" when {
+
+    "handling request to get Undertaking Name" must {
+
+      def performAction() = controller.getUndertakingName(FakeRequest())
+
+      "throw technical error" when {
+
+        val exception = new Exception("oh no")
+        "call to fetch undertaking journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+        "call to store undertaking journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(None))
+            mockPut[UndertakingJourney](UndertakingJourney(), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+      }
+
+      "display the page" when {
+
+        "no undertaking journey is not there in store" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(None))
+            mockPut[UndertakingJourney](UndertakingJourney(), eori1)(Right(UndertakingJourney()))
+          }
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey("undertakingName.title"),
+            {doc =>
+              val input = doc.select(".govuk-input").attr("value")
+              input shouldBe ""
+
+              val button = doc.select("form")
+              button.attr("action") shouldBe routes.UndertakingController.postUndertakingName().url
+            }
+          )
+        }
+
+      " undertaking journey is there in store" in {
+        inSequence {
+          mockAuthWithNecessaryEnrolment()
+          mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
+        }
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("undertakingName.title"),
+          { doc =>
+            val input = doc.select(".govuk-input").attr("value")
+            input shouldBe "TestUndertaking"
+
+            val button = doc.select("form")
+            button.attr("action") shouldBe routes.UndertakingController.postUndertakingName().url
+          }
+        )
+      }
+      }
+
+    }
+
+    "handling request to post Undertaking Name " must {
+
+      def performAction(data: (String, String)*) = controller
+        .postUndertakingName(
+          FakeRequest("POST",routes.UndertakingController.getUndertakingName().url)
+            .withFormUrlEncodedBody(data: _*))
+
+      "throw technical error" when {
+        val exception = new Exception("oh no")
+        "call to update undertaking journey fails" in {
+
+          def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+            undertakingJourneyOpt.map(_.copy(name = FormPage("undertaking-name", "TestUndertaking123".some)))
+          }
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("undertakingName" -> "TestUndertaking123")))
+        }
+      }
+
+      "display form error" when {
+
+        "nothing is submitted" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+          }
+          checkFormErrorIsDisplayed(performAction("undertakingName" -> ""),
+            messageFromMessageKey("undertakingName.title"),
+            messageFromMessageKey("error.undertakingName.required")
+          )
+        }
+      }
+
+      "redirect to next page" when {
+
+        def test(undertakingJourney: UndertakingJourney, nextCall: String) = {
+          def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+            undertakingJourneyOpt.map(_.copy(name = FormPage("undertaking-name", "TestUndertaking123".some)))
+          }
+
+          val updatedUndertaking = undertakingJourney.copy(name = FormPage("undertaking-name", "TestUndertaking123".some))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourney.some), eori1)(Right(updatedUndertaking))
+          }
+          checkIsRedirect(performAction("undertakingName" -> "TestUndertaking123"), nextCall)
+        }
+
+        "page is reached via amend details page " in {
+          test(undertakingJourneyComplete1, routes.UndertakingController.getAmendUndertakingDetails().url)
+
+        }
+
+        "page is reached via normal undertaking creation process" in {
+          test(undertakingJourneyComplete, "sector")
+        }
+      }
+
+
+    }
+
+    "handling request to get sector" must {
+
+      def performAction() = controller.getSector(FakeRequest("GET",routes.UndertakingController.getSector().url))
+
+      "throw technical error" when {
+
+        val exception = new Exception("oh no")
+        "call to fetch undertaking journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+        "call to fetch undertaking journey passes  but return no undertaking journey" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(None))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+      }
+
+      "display the page" when {
+
+        val allRadioTexts: List[String] = List(
+          s"${messageFromMessageKey("sector.label.3")}" +
+            s" ${messageFromMessageKey("sector.hint.3")}",
+          s"${messageFromMessageKey("sector.label.2")}" +
+            s" ${messageFromMessageKey("sector.hint.2")}",
+          s"${messageFromMessageKey("sector.label.1")}" +
+            s" ${messageFromMessageKey("sector.hint.1")}",
+          messageFromMessageKey("sector.label.0")
+        )
+
+        def test(undertakingJourney: UndertakingJourney, previousCall: String, inputValue: Option[String]) = {
+
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
+          }
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey("undertakingSector.title", undertakingJourney.name.value.getOrElse("")),
+            { doc =>
+              doc.select(".govuk-back-link").attr("href") shouldBe previousCall
+
+              val selectedOptions = doc.select(".govuk-radios__input[checked]")
+              inputValue match {
+                case Some(value) => selectedOptions.attr("value") shouldBe value
+                case None        => selectedOptions.isEmpty       shouldBe true
+              }
+
+              testRadioButtonOptions(doc, allRadioTexts)
+
+              val form = doc.select("form")
+              form
+                .attr("action") shouldBe routes.UndertakingController.postSector().url
+            }
+          )
+
+        }
+
+        "user has not already answered the question (normal add undertaking journey)" in {
+          test(undertakingJourney = UndertakingJourney(name = FormPage("undertaking-name", "TestUndertaking1".some)),
+            previousCall = "undertaking-name",
+            inputValue = None)
+        }
+
+        "user has already answered the question (normal add undertaking journey)" in {
+          test(undertakingJourney = UndertakingJourney(name = FormPage("undertaking-name", "TestUndertaking1".some),
+            sector = FormPage("sector", Sector(2).some)),
+            previousCall = "undertaking-name",
+            inputValue = "2".some)
+        }
+
+        "user has already answered the question and is on Amend journey" in {
+          test(undertakingJourney = undertakingJourneyComplete1,
+            previousCall = routes.UndertakingController.getAmendUndertakingDetails().url,
+            inputValue = "2".some)
+        }
+
+      }
+
+    }
+
+    "handling request to post sector" must {
+      def performAction(data: (String, String)*) = controller
+        .postSector(
+          FakeRequest("POST",routes.UndertakingController.getSector().url)
+            .withFormUrlEncodedBody(data: _*))
+
+
+
+      def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+        undertakingJourneyOpt.map(_.copy(sector = FormPage("sector", Sector(1).some)))
+      }
+
+      "throw technical error" when {
+        val exception = new Exception("oh no")
+
+        "call to get previous url fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("undertakingSector" -> "2")))
+        }
+
+        "call to update undertaking journey fails" in {
+          val currentUndertaking = UndertakingJourney(name = FormPage("undertaking-name", "TestUndertaking".some))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
+            mockUpdate[UndertakingJourney](_ => update(currentUndertaking.some), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("undertakingSector" -> "2")))
+        }
+
+      }
+
+      "display form error" when {
+
+        "nothing is submitted" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
+          }
+          checkFormErrorIsDisplayed(performAction(),
+            messageFromMessageKey("undertakingSector.title",""),
+            messageFromMessageKey("undertakingSector.error.required")
+          )
+
+        }
+
+      }
+
+      "redirect to next page" when {
+
+        def test(undertakingJourney: UndertakingJourney, nextCall: String) = {
+
+          val newSector = FormPage("sector", Sector(3).some)
+          def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+            undertakingJourneyOpt.map(_.copy(sector = newSector))
+          }
+
+          val updatedUndertaking = undertakingJourney.copy(sector = newSector)
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourney.some), eori1)(Right(updatedUndertaking))
+          }
+          checkIsRedirect(performAction("undertakingSector" -> "3"), nextCall)
+        }
+
+        "page is reached via amend details page " in {
+          test(undertakingJourneyComplete1, routes.UndertakingController.getAmendUndertakingDetails().url)
+
+        }
+
+        "page is reached via normal undertaking creation process" in {
+          test(undertakingJourneyComplete, "contact")
+        }
+
+      }
+
+    }
+
+    "handling request to get Contact" must {
+
+      def performAction() = controller.getContact(FakeRequest("GET",routes.UndertakingController.getContact().url))
+
+      "throw technical error" when {
+
+        val exception = new Exception("oh no")
+        "call to fetch undertaking journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+        "call to fetch undertaking journey passes  but return no undertaking journey" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(None))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+      }
+
+      "display the page" when {
+
+        def test(undertakingJourney: UndertakingJourney, previousCall: String): Unit = {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
+          }
+          checkPageIsDisplayed(
+            performAction(),
+            messageFromMessageKey("undertakingContact.title") + " " + undertakingJourney.name.value.getOrElse("") + messageFromMessageKey("undertakingContact.title.end") ,
+            {doc =>
+
+              doc.select(".govuk-back-link").attr("href") shouldBe(previousCall)
+
+              val inputPhone = doc.select("#phone").attr("value")
+              val inputMobile = doc.select("#mobile").attr("value")
+
+              inputPhone shouldBe undertakingJourney.contact.value.flatMap(_.phone).getOrElse("")
+              inputMobile shouldBe undertakingJourney.contact.value.flatMap(_.mobile).getOrElse("")
+
+              val button = doc.select("form")
+              button.attr("action") shouldBe routes.UndertakingController.postContact().url
+            }
+          )
+        }
+
+        "user has not already answered the question(normal add undertaking journey)" in {
+          test(undertakingJourneyComplete.copy(contact = FormPage("contact"), cya = FormPage("check-your-answers")),"sector")
+        }
+
+        "user has  already answered the question(normal add undertaking journey)" in {
+          test(undertakingJourneyComplete.copy(contact = FormPage("contact", contactDetails), cya = FormPage("check-your-answers")),"sector")
+        }
+
+        "user has  already answered the question but it's amend journey" in {
+          test(undertakingJourneyComplete1.copy(contact = FormPage("contact", contactDetails), cya = FormPage("check-your-answers")),routes.UndertakingController.getAmendUndertakingDetails().url)
+        }
+
+      }
+    }
+
+    "handling request to post Contact" must {
+
+      def performAction(data: (String, String)*) = controller
+        .postContact(
+          FakeRequest("POST",routes.UndertakingController.getContact().url)
+            .withFormUrlEncodedBody(data: _*))
+
+      def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+        undertakingJourneyOpt.map(_.copy(contact = FormPage("contact", contactDetails2)))
+      }
+
+      "throw technical error" when {
+        val exception = new Exception("oh no")
+
+        "call to get previous url fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("phone" -> "222", "mobile" -> "333")))
+        }
+
+        "call to update undertaking journey fails" in {
+          val currentUndertaking = undertakingJourneyComplete1.copy(contact = FormPage("contact"), cya = FormPage("cya"))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
+            mockUpdate[UndertakingJourney](_ => update(currentUndertaking.some), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("phone" -> "222", "mobile" -> "333")))
+        }
+      }
+
+      "display form error" when {
+
+        "nothing is submitted" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Right("sector"))
+          }
+          checkFormErrorsAreDisplayed(performAction(),
+            messageFromMessageKey("undertakingContact.title") + " " + "" + messageFromMessageKey("undertakingContact.title.end") ,
+            List(
+              messageFromMessageKey("one.or.other.mustbe.present"),
+              messageFromMessageKey("one.or.other.mustbe.present")
+            )
+          )
+
+        }
+
+      }
+
+      "redirect to next page" when {
+
+
+        def test(undertakingJourney: UndertakingJourney, nextCall: String) = {
+
+          val updatedUndertaking = undertakingJourney.copy(contact = FormPage("contact", contactDetails2))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGetPrevious[UndertakingJourney](eori1)(Right("sector"))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourney.some), eori1)(Right(updatedUndertaking))
+          }
+          checkIsRedirect(performAction("phone" -> "222", "mobile" -> "333"), nextCall)
+        }
+
+        "page is reached via normal create undertaking" in {
+          test(undertakingJourneyComplete.copy(contact = FormPage("contact"), cya = FormPage("cya")), "cya")
+        }
+
+        "page is reached via amend  undertaking journey" in {
+          test(undertakingJourneyComplete1.copy(contact = FormPage("contact"), cya = FormPage("cya")), routes.UndertakingController.getAmendUndertakingDetails().url)
+        }
+
+      }
+
+    }
+
+    "handling request to get Amend Undertaking Details " must {
+
+      def performAction() = controller.getAmendUndertakingDetails(FakeRequest())
+
+      def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+        undertakingJourneyOpt.map(_.copy(isAmend = FormPage("amend-undertaking", true.some)))
+      }
+
+      val contact = contactDetails match {
+        case Some(ContactDetails(Some(number1), Some(number2))) => s"$number1 $number2"
+        case Some(ContactDetails(Some(number1), None)) => s"$number1"
+        case Some(ContactDetails(None, Some(number2))) => s"$number2"
+        case _ => ""
+      }
+
+      val expectedRows = List(
+        AmendUndertakingRows(
+          messageFromMessageKey("undertaking.amendUndertaking.summary-list.name.key"),
+          undertaking.name,
+          routes.UndertakingController.getUndertakingName().url
+        ),
+        AmendUndertakingRows(
+          messageFromMessageKey("undertaking.amendUndertaking.summary-list.sector.key"),
+          messageFromMessageKey(s"sector.label.${undertaking.industrySector.id.toString}"),
+          routes.UndertakingController.getSector().url
+        ),
+        AmendUndertakingRows(
+          messageFromMessageKey("undertaking.amendUndertaking.summary-list.telephone.key"),
+          contact,
+          routes.UndertakingController.getContact().url
+        )
+      )
+
+      "throw technical error" when {
+
+        val exception = new Exception("oh no")
+        "call to get undertaking journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+        "call to get undertaking journey fetches nothing" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(None))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+        "call to update the undertaking journey fails" in {
+
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+      }
+
+      "display the page" in {
+        inSequence {
+          mockAuthWithNecessaryEnrolment()
+          mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
+          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+        }
+
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("undertaking.amendUndertaking.title"),
+          {doc =>
+
+            doc.select(".govuk-back-link").attr("href") shouldBe(routes.AccountController.getAccountPage().url)
+
+            val rows =
+              doc.select(".govuk-summary-list__row").iterator().asScala.toList.map { element =>
+                val question  = element.select(".govuk-summary-list__key").text()
+                val answer    = element.select(".govuk-summary-list__value").text()
+                val changeUrl = element.select(".govuk-link").attr("href")
+                AmendUndertakingRows(question, answer, changeUrl)
+              }
+            rows shouldBe expectedRows
+          }
+        )
+
+      }
+      
+    }
+
+    "handling request to post Amend undertaking" must {
+
+      def performAction(data: (String, String)*) = controller
+        .postAmendUndertaking(
+          FakeRequest("POST",routes.UndertakingController.getAmendUndertakingDetails().url)
+            .withFormUrlEncodedBody(data: _*))
+
+      def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+        undertakingJourneyOpt.map(_.copy(isAmend = FormPage("amend-undertaking", None)))
+      }
+
+      "throw technical error" when {
+        val exception = new Exception("oh no")
+
+        "call to update undertaking journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+
+        }
+
+        "call to update undertaking journey passes but return undertaking with no name" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = FormPage("undertaking-name", None))))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+
+        }
+
+        "call to update undertaking journey passes but return undertaking with no secctor" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = FormPage("sector", None))))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+
+        }
+
+        "call to retrieve undertaking fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = FormPage("amend-undertaking", "true".some))))
+            mockRetreiveUndertaking(eori)(Future.failed(exception))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+        }
+
+        "call to retrieve undertaking passes but no undertaking was fetched" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = FormPage("amend-undertaking", "true".some))))
+            mockRetreiveUndertaking(eori)(Future.successful(None))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+        }
+
+        "call to retrieve undertaking passes but  undertaking was fetched with no undertaking ref" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = FormPage("amend-undertaking", "true".some))))
+            mockRetreiveUndertaking(eori)(Future.successful(undertaking1.copy(reference = None).some))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+        }
+
+        "call to retrieve undertaking passes but retrieve undertaking without Lead Business Entity" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+            mockRetreiveUndertaking(eori)(Future.successful(undertaking1.copy(undertakingBusinessEntity = undertaking1.undertakingBusinessEntity.filterNot(_.leadEORI)).some))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+        }
+
+        "call to update undertaking fails" in {
+          val updatedUndertaking = undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+            mockRetreiveUndertaking(eori)(Future.successful(undertaking1.some))
+            mockUpdateUndertaking(updatedUndertaking)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+        }
+
+        "call to add  member fails" in {
+          val updatedUndertaking = undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+            mockRetreiveUndertaking(eori)(Future.successful(undertaking1.some))
+            mockUpdateUndertaking(updatedUndertaking)(Right(undertakingRef))
+            mockAddMember(undertakingRef, businessEntity1.copy(contacts = contactDetails))(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
+        }
+      }
+
+      "redirect to next page" in {
+        val updatedUndertaking = undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
+        inSequence {
+          mockAuthWithNecessaryEnrolment()
+          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+          mockRetreiveUndertaking(eori)(Future.successful(undertaking1.some))
+          mockUpdateUndertaking(updatedUndertaking)(Right(undertakingRef))
+          mockAddMember(undertakingRef, businessEntity1.copy(contacts = contactDetails))(Right(undertakingRef))
+        }
+        checkIsRedirect(performAction("amendUndertaking" -> "true"), routes.AccountController.getAccountPage().url)
+      }
+
+    }
+  }
+
+}
+
+object UndertakingControllerSpec {
+  final case class AmendUndertakingRows(question: String, answer: String, changeUrl: String)
+}

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -515,7 +515,7 @@ class UndertakingControllerSpec extends ControllerSpec
       def performAction() = controller.getAmendUndertakingDetails(FakeRequest())
 
       def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
-        undertakingJourneyOpt.map(_.copy(isAmend = FormPage("amend-undertaking", true.some)))
+        undertakingJourneyOpt.map(_.copy(isAmend = true.some))
       }
 
       val contact = contactDetails match {
@@ -577,7 +577,7 @@ class UndertakingControllerSpec extends ControllerSpec
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
-          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = true.some)))
         }
 
         checkPageIsDisplayed(
@@ -610,7 +610,7 @@ class UndertakingControllerSpec extends ControllerSpec
             .withFormUrlEncodedBody(data: _*))
 
       def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
-        undertakingJourneyOpt.map(_.copy(isAmend = FormPage("amend-undertaking", None)))
+        undertakingJourneyOpt.map(_.copy(isAmend = None))
       }
 
       "throw technical error" when {
@@ -673,7 +673,7 @@ class UndertakingControllerSpec extends ControllerSpec
         "call to retrieve undertaking passes but retrieve undertaking without Lead Business Entity" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = true.some)))
             mockRetreiveUndertaking(eori)(Future.successful(undertaking1.copy(undertakingBusinessEntity = undertaking1.undertakingBusinessEntity.filterNot(_.leadEORI)).some))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
@@ -683,7 +683,7 @@ class UndertakingControllerSpec extends ControllerSpec
           val updatedUndertaking = undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = true.some)))
             mockRetreiveUndertaking(eori)(Future.successful(undertaking1.some))
             mockUpdateUndertaking(updatedUndertaking)(Left(Error(exception)))
           }
@@ -694,7 +694,7 @@ class UndertakingControllerSpec extends ControllerSpec
           val updatedUndertaking = undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend =  true.some)))
             mockRetreiveUndertaking(eori)(Future.successful(undertaking1.some))
             mockUpdateUndertaking(updatedUndertaking)(Right(undertakingRef))
             mockAddMember(undertakingRef, businessEntity1.copy(contacts = contactDetails))(Left(Error(exception)))
@@ -707,7 +707,7 @@ class UndertakingControllerSpec extends ControllerSpec
         val updatedUndertaking = undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = FormPage("amend-undertaking", true.some))))
+          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(isAmend = true.some)))
           mockRetreiveUndertaking(eori)(Future.successful(undertaking1.some))
           mockUpdateUndertaking(updatedUndertaking)(Right(undertakingRef))
           mockAddMember(undertakingRef, businessEntity1.copy(contacts = contactDetails))(Right(undertakingRef))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/testutil/FakeTimeProvider.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/testutil/FakeTimeProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.eusubsidycompliancefrontend.testutil
 
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -127,7 +127,7 @@ object CommonTestData {
     contact = FormPage("contact", contactDetails1),
     cya = FormPage("check-your-answers", true.some),
     confirmation = FormPage("confirmation", true.some),
-    isAmend = FormPage("amend-undertaking", true.some)
+    isAmend = true.some
   )
 
   val businessEntityJourney = BusinessEntityJourney(

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -32,9 +32,14 @@ object CommonTestData {
   val eori3 = EORI("GB123456789014")
   val eori4 = EORI("GB123456789010")
 
+  val contactDetails = ContactDetails(PhoneNumber("111").some, None).some
+  val contactDetails1 = ContactDetails(PhoneNumber("1121").some, None).some
+  val contactDetails2 = ContactDetails(PhoneNumber("222").some, PhoneNumber("333").some).some
+
   val businessEntity1 = BusinessEntity(EORI(eori1), true, None)
   val businessEntity2 = BusinessEntity(EORI(eori2), true, None)
   val businessEntity3 = BusinessEntity(EORI(eori3), true, None)
+  val businessEntity4 = BusinessEntity(EORI(eori4), false, contactDetails1)
 
 
   val undertakingRef = UndertakingRef("UR123456")
@@ -70,6 +75,13 @@ object CommonTestData {
     LocalDate.of(2021,1,18).some,
     List(businessEntity1, businessEntity2))
 
+  val undertaking1 = Undertaking(undertakingRef.some,
+    UndertakingName("TestUndertaking"),
+    transport,
+    IndustrySectorLimit(12.34).some,
+    LocalDate.of(2021,1,18).some,
+    List(businessEntity1, businessEntity4))
+
   val subsidyRetrieve = SubsidyRetrieve(
     undertakingRef, None
   )
@@ -99,7 +111,7 @@ object CommonTestData {
   createUndertaking = FormPage("create-undertaking", true.some)
   )
 
-  val contactDetails = ContactDetails(PhoneNumber("111").some, None).some
+
 
   val undertakingJourneyComplete =  UndertakingJourney(
     name = FormPage("undertaking-name", "TestUndertaking".some),
@@ -107,6 +119,15 @@ object CommonTestData {
     contact = FormPage("contact", contactDetails),
     cya = FormPage("check-your-answers", true.some),
     confirmation = FormPage("confirmation", true.some)
+  )
+
+  val undertakingJourneyComplete1 =  UndertakingJourney(
+    name = FormPage("undertaking-name", "TestUndertaking1".some),
+    sector = FormPage("sector",Sector(2).some),
+    contact = FormPage("contact", contactDetails1),
+    cya = FormPage("check-your-answers", true.some),
+    confirmation = FormPage("confirmation", true.some),
+    isAmend = FormPage("amend-undertaking", true.some)
   )
 
   val businessEntityJourney = BusinessEntityJourney(


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-263
The attached image in the ticket has four fields in the amend undertaking screen but that is old, now we have only three
undertaking name, sector and contact.
I have added a new link called amen-undertaking details, which is the new screen where user can edit the details already entered.
I have created a new isAmend flag, which take care of the previous and next pages. Since we are reusing the same pages we had while creating undertaking, this time we check the isAmend flag. If yes then the previous and next of the pages is amend screen details only.
There is some code refactoring as well with test cases(only for those controllers methods which are used in this ticket)