### PR TITLE
Esc 305 bug testcase

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -430,7 +430,7 @@ class SubsidyController @Inject()(
       optionalTraderRef => if (optionalTraderRef.setValue == "false") optionalTraderRef.copy(value = None) else optionalTraderRef,
       identity
     ).verifying(
-      "error.isempty", a => a.setValue == "false" || a.value.nonEmpty
+      "error.isempty", optionalTraderRef => optionalTraderRef.setValue == "false" || optionalTraderRef.value.nonEmpty
     )
   )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -188,6 +188,7 @@ class SubsidyController @Inject()(
   }
 
   def getAddClaimEori: Action[AnyContent] = escAuthentication.async { implicit request =>
+
     implicit val eori: EORI = request.eoriNumber
     store.get[SubsidyJourney].flatMap {
       case Some(journey) =>
@@ -201,8 +202,8 @@ class SubsidyController @Inject()(
   }
 
   def postAddClaimEori: Action[AnyContent] = escAuthentication.async { implicit request =>
-    implicit val eori: EORI = request.eoriNumber
 
+    implicit val eori: EORI = request.eoriNumber
     journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
       claimEoriForm.bindFromRequest().fold(
         formWithErrors => Future.successful(BadRequest(addClaimEoriPage(formWithErrors, previous))),
@@ -261,8 +262,8 @@ class SubsidyController @Inject()(
   }
 
   def getAddClaimReference: Action[AnyContent] = escAuthentication.async { implicit request =>
-    implicit val eori: EORI = request.eoriNumber
 
+    implicit val eori: EORI = request.eoriNumber
     store.get[SubsidyJourney].flatMap {
       case Some(journey) =>
         val form = journey.traderRef.value.fold(claimTraderRefForm
@@ -273,6 +274,7 @@ class SubsidyController @Inject()(
   }
 
   def postAddClaimReference: Action[AnyContent] = escAuthentication.async { implicit request =>
+
     implicit val eori: EORI = request.eoriNumber
     journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
       claimTraderRefForm.bindFromRequest().fold(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -266,6 +266,7 @@ class SubsidyController @Inject()(
     implicit val eori: EORI = request.eoriNumber
     store.get[SubsidyJourney].flatMap {
       case Some(journey) =>
+        // //changed form values to store the setValue, earlier it was not filing the set value
         val form = journey.traderRef.value.fold(claimTraderRefForm
         )(optionalTraderRef => claimTraderRefForm.fill(OptionalTraderRef(optionalTraderRef.setValue, optionalTraderRef.value)))
         Future.successful(Ok(addTraderReferencePage(form, journey.previous)))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -266,7 +266,6 @@ class SubsidyController @Inject()(
     implicit val eori: EORI = request.eoriNumber
     store.get[SubsidyJourney].flatMap {
       case Some(journey) =>
-        // //changed form values to store the setValue, earlier it was not filing the set value
         val form = journey.traderRef.value.fold(claimTraderRefForm
         )(optionalTraderRef => claimTraderRefForm.fill(OptionalTraderRef(optionalTraderRef.setValue, optionalTraderRef.value)))
         Future.successful(Ok(addTraderReferencePage(form, journey.previous)))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -202,6 +202,7 @@ class SubsidyController @Inject()(
 
   def postAddClaimEori: Action[AnyContent] = escAuthentication.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
+
     journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
       claimEoriForm.bindFromRequest().fold(
         formWithErrors => Future.successful(BadRequest(addClaimEoriPage(formWithErrors, previous))),
@@ -261,6 +262,7 @@ class SubsidyController @Inject()(
 
   def getAddClaimReference: Action[AnyContent] = escAuthentication.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
+
     store.get[SubsidyJourney].flatMap {
       case Some(journey) =>
         val form = journey.traderRef.value.fold(claimTraderRefForm
@@ -421,7 +423,7 @@ class SubsidyController @Inject()(
 
   val claimTraderRefForm: Form[OptionalTraderRef] = Form(
     mapping(
-      "should-store-trader-ref" -> mandatory("should-claim-eori"),
+      "should-store-trader-ref" -> mandatory("should-store-trader-ref"),
       "claim-trader-ref" -> optional(text)
     )(OptionalTraderRef.apply)(OptionalTraderRef.unapply)
     .transform[OptionalTraderRef](

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -27,9 +27,9 @@ case class SubsidyJourney(
    reportPayment: FormPage[Boolean] = FormPage("claims"),
    claimDate: FormPage[DateFormValues] = FormPage("add-claim-date"),
    claimAmount: FormPage[BigDecimal] = FormPage("add-claim-amount"),
-   addClaimEori: FormPage[OptionalEORI] = FormPage("add-claim-eori"),//changed it to OptionalEORI from Option[EORI]
+   addClaimEori: FormPage[OptionalEORI] = FormPage("add-claim-eori"),
    publicAuthority: FormPage[String] = FormPage("add-claim-public-authority"),
-   traderRef: FormPage[OptionalTraderRef] = FormPage("add-claim-reference"),//changed it to OptionalTraderRef from Option[Traderref]
+   traderRef: FormPage[OptionalTraderRef] = FormPage("add-claim-reference"),
    cya: FormPage[Boolean] = FormPage("check-your-answers-subsidy"),
    existingTransactionId: Option[SubsidyRef] = None,
 
@@ -51,10 +51,9 @@ object SubsidyJourney {
   implicit val formPageClaimDateFormat: OFormat[FormPage[DateFormValues]] =
     Json.format[FormPage[DateFormValues]]
 
-//added formatting for FormPage[OptionalEORI]
   implicit val formPageOptionalEORIFormat: OFormat[FormPage[OptionalEORI]] =
     Json.format[FormPage[OptionalEORI]]
-  //added formatting for FormPage[OptionalTraderRef]
+
   implicit val formPageOptionalTraderRefFormat: OFormat[FormPage[OptionalTraderRef]] =
     Json.format[FormPage[OptionalTraderRef]]
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -27,9 +27,9 @@ case class SubsidyJourney(
    reportPayment: FormPage[Boolean] = FormPage("claims"),
    claimDate: FormPage[DateFormValues] = FormPage("add-claim-date"),
    claimAmount: FormPage[BigDecimal] = FormPage("add-claim-amount"),
-   addClaimEori: FormPage[OptionalEORI] = FormPage("add-claim-eori"),
+   addClaimEori: FormPage[OptionalEORI] = FormPage("add-claim-eori"),//changed it to OptionalEORI from Option[EORI]
    publicAuthority: FormPage[String] = FormPage("add-claim-public-authority"),
-   traderRef: FormPage[OptionalTraderRef] = FormPage("add-claim-reference"),
+   traderRef: FormPage[OptionalTraderRef] = FormPage("add-claim-reference"),//changed it to OptionalTraderRef from Option[Traderref]
    cya: FormPage[Boolean] = FormPage("check-your-answers-subsidy"),
    existingTransactionId: Option[SubsidyRef] = None,
 
@@ -51,10 +51,10 @@ object SubsidyJourney {
   implicit val formPageClaimDateFormat: OFormat[FormPage[DateFormValues]] =
     Json.format[FormPage[DateFormValues]]
 
-
+//added formatting for FormPage[OptionalEORI]
   implicit val formPageOptionalEORIFormat: OFormat[FormPage[OptionalEORI]] =
     Json.format[FormPage[OptionalEORI]]
-
+  //added formatting for FormPage[OptionalTraderRef]
   implicit val formPageOptionalTraderRefFormat: OFormat[FormPage[OptionalTraderRef]] =
     Json.format[FormPage[OptionalTraderRef]]
 
@@ -73,7 +73,6 @@ object SubsidyJourney {
         addClaimEori = newJourney.addClaimEori.copy(value =  getAddClaimEORI(nonHmrcSubsidy.businessEntityIdentifier).some),
         publicAuthority = newJourney.publicAuthority.copy(value = Some(nonHmrcSubsidy.publicAuthority.getOrElse(""))),
         traderRef = newJourney.traderRef.copy(value = getAddTraderRef(nonHmrcSubsidy.traderReference).some),
-//        traderRef = newJourney.traderRef.copy(value = Some(nonHmrcSubsidy.traderReference)),
         existingTransactionId = nonHmrcSubsidy.subsidyUsageTransactionID
     )
   }

--- a/conf/messages
+++ b/conf/messages
@@ -250,7 +250,7 @@ add-claim-trader-reference.title=Would you like to add a reference?
 add-claim-trader-reference.hint=This is for your own records. It is not a mandatory field.
 add-claim-trader-reference.label=Enter the reference you would like to add
 add-claim-trader-reference.error.required=Select yes if you would like to add a reference
-add-claim-trader-reference.error.traderRefMissing=Enter the trader reference you would like to add
+add-claim-trader-reference.error.isempty=Enter the trader reference you would like to add
 
 subsidy.cya.title=Check your answers
 subsidy.cya.summary-list.claimDate.key=Payment date

--- a/conf/messages
+++ b/conf/messages
@@ -245,10 +245,12 @@ add-claim-eori.hint=This is for your own records. It is not a mandatory field.
 add-claim-eori.error.format=GB EORI number must be 12 or 15 digits
 add-claim-eori.error.required=Select yes if you would like to add a valid EORI number
 
+
 add-claim-trader-reference.title=Would you like to add a reference?
 add-claim-trader-reference.hint=This is for your own records. It is not a mandatory field.
 add-claim-trader-reference.label=Enter the reference you would like to add
 add-claim-trader-reference.error.required=Select yes if you would like to add a reference
+add-claim-trader-reference.error.traderRefMissing=Enter the trader reference you would like to add
 
 subsidy.cya.title=Check your answers
 subsidy.cya.summary-list.claimDate.key=Payment date

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -500,7 +500,7 @@ class SubsidyControllerSpec extends ControllerSpec
         }
 
         "the user hasn't already answered the question" in {
-          test(subsidyJourney.copy(traderRef = FormPage("add-claim-reference", None)))
+          test(subsidyJourney.copy(traderRef = FormPage("add-claim-reference"), cya = FormPage("check-your-answers-subsidy")))
 
         }
 
@@ -527,9 +527,6 @@ class SubsidyControllerSpec extends ControllerSpec
             .withFormUrlEncodedBody(data: _*))
 
       "throw technical error" when {
-
-        def update(subsidyJourneyOpt: Option[SubsidyJourney]) =
-          subsidyJourneyOpt.map(_.copy(traderRef = FormPage("add-claim-reference", OptionalTraderRef("false", None).some)))
 
         val exception = new Exception("oh no")
         "call to get previous fails" in {
@@ -564,7 +561,7 @@ class SubsidyControllerSpec extends ControllerSpec
         }
 
         "yes is selected but no trader reference is added" in {
-          testFormError(Some(List("should-store-trader-ref" -> "true")), "add-claim-trader-reference.error.traderRefMissing")
+          testFormError(Some(List("should-store-trader-ref" -> "true")), "add-claim-trader-reference.error.isempty")
 
         }
 


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-305
There was this bug on the add claim eori page and  trader ref page on subsidy payment journey where the option selected by user were not getting retained if user clicks on back link or change link on cya page.
I accidentally pushed the code to main branch 🤦‍♀️ , so I have added comments at the parts which were changed as a part of bug fix. I have done some changes and added unit test cases for those changes.
