### PR TITLE
ESC-315 only display no payments reported message when no claims present

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ReportPaymentPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ReportPaymentPage.scala.html
@@ -67,7 +67,11 @@
   @formHelper(action = controllers.routes.SubsidyController.postReportPayment) {
     <span class="govuk-caption-xl">@undertaking.name</span>
     @H1(messages("report-payment.title"))
-    @P(messages("report-payment.p1"))
+
+    @if(subsidies.isEmpty || subsidies.get.nonHMRCSubsidyUsage.isEmpty) {
+        @P(messages("report-payment.p1"))
+    }
+
     @P(messages("report-payment.p2"))
 
     <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Quick fix to hide 'no claims reported' message when at least one subsidy claim is present. 