### PR TITLE
ESC-315-further-fixes fix rendering of subsidy values

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ReportPaymentPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ReportPaymentPage.scala.html
@@ -45,9 +45,9 @@
                   Seq(
                       TableRow(content = Text(sub.submissionDate.toString)),
                       TableRow(content = Text(sub.nonHMRCSubsidyAmtEUR.toString())),
-                      TableRow(content = Text(sub.businessEntityIdentifier.toString)),
-                      TableRow(content = Text(sub.publicAuthority.toString)),
-                      TableRow(content = Text(sub.subsidyUsageTransactionID.toString)),
+                      TableRow(content = Text(sub.businessEntityIdentifier.fold("")(_.toString))),
+                      TableRow(content = Text(sub.publicAuthority.fold("")(_.toString))),
+                      TableRow(content = Text(sub.traderReference.fold("")(_.toString))),
                       TableRow(content = HtmlContent(s"<a href=${controllers.routes.SubsidyController.getChangeSubsidyClaim(sub.subsidyUsageTransactionID.get).url}>Change</a>")),
                       TableRow(content = HtmlContent(s"<a href=${controllers.routes.SubsidyController.getRemoveSubsidyClaim(sub.subsidyUsageTransactionID.get).url}>Remove</a>"))
                   )


### PR DESCRIPTION
This fixes the rendering of optional values and also ensures we show the trader reference instead of the transaction ID. 