### PR TITLE
NOJIRA disable duplicate junit reporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ PlayKeys.playDefaultPort := 9093
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
+  .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     majorVersion                     := 0,
     scalaVersion                     := "2.12.13",


### PR DESCRIPTION
This can cause issues with Junit XML output getting mangled causing
unstable builds in Jenkins.

See https://github.com/scalatest/scalatest/issues/1427