### PR TITLE
ESC-332 - change value flow when editing individual values for create undertaking 

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -65,13 +65,9 @@ class UndertakingController @Inject()(
     implicit val eori: EORI = request.eoriNumber
     store.get[UndertakingJourney].map {
       case Some(journey) =>
-        val res = journey
+        journey
           .firstEmpty
-          .fold(
-            Redirect(routes.BusinessEntityController.getAddBusinessEntity())
-          )(identity)
-        println(s"firstEmptyPage returning: $res")
-        res
+          .fold(Redirect(routes.BusinessEntityController.getAddBusinessEntity()))(identity)
       case _ => handleMissingSessionData("Undertaking journey")
     }
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -43,6 +43,7 @@ trait Journey {
   def currentIndex(implicit request: Request[_]): Int =
     formPages.indexWhere(x => request.uri.endsWith(x.uri))
 
+  // TODO - should previous and next return the same types?
   def previous(implicit request: Request[_]): Journey.Uri =
     formPages
       .zipWithIndex

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -21,8 +21,8 @@ import play.api.libs.json.{Format, Json, OFormat}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ContactDetails, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ContactDetails, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.FormUrls
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.FutureSyntax.FutureOps
@@ -48,11 +48,16 @@ case class UndertakingJourney(
 
   override def previous(implicit request: Request[_]): Uri =
     if (isAmend) routes.UndertakingController.getAmendUndertakingDetails().url
+    else if (requiredDetailsProvided) routes.UndertakingController.getCheckAnswers().url
     else super.previous
 
   override def next(implicit request: Request[_]): Future[Result] =
     if (isAmend) Redirect(routes.UndertakingController.getAmendUndertakingDetails()).toFuture
+    else if (requiredDetailsProvided) Redirect(routes.UndertakingController.getCheckAnswers()).toFuture
     else super.next
+
+  private def requiredDetailsProvided =
+    Seq(name, sector, contact).map(_.value.isDefined) == Seq(true, true, true)
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -34,7 +34,7 @@ case class UndertakingJourney(
   sector: FormPage[Sector] = FormPage(FormUrls.Sector),
   contact: FormPage[ContactDetails] = FormPage(FormUrls.Contact),
   cya: FormPage[Boolean] = FormPage(FormUrls.Cya),
-  confirmation: FormPage[Boolean] = FormPage(FormUrls.Cya),
+  confirmation: FormPage[Boolean] = FormPage(FormUrls.Confirmation),
   isAmend: Boolean = false
 ) extends Journey {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -21,13 +21,9 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
-import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData._
-
-import scala.concurrent.Future
 
 class BecomeLeadControllerSpec
   extends ControllerSpec
@@ -35,7 +31,7 @@ class BecomeLeadControllerSpec
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour {
 
-  val mockEscService = mock[EscService]
+  private val mockEscService = mock[EscService]
 
   override def overrideBindings           = List(
     bind[AuthConnector].toInstance(mockAuthConnector),
@@ -43,13 +39,7 @@ class BecomeLeadControllerSpec
     bind[EscService].toInstance(mockEscService)
   )
 
-  val controller = instanceOf[BecomeLeadController]
-
-  def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
-    (mockEscService
-      .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
-      .expects(eori, *)
-      .returning(result)
+  private val controller = instanceOf[BecomeLeadController]
 
   "BecomeLeadControllerSpec" when {
 
@@ -143,10 +133,6 @@ class BecomeLeadControllerSpec
 
       def performAction() = controller.getAcceptPromotionTerms(FakeRequest())
       behave like authBehaviour(() => performAction())
-
-      def update(businessEntityJourneyOpt: Option[BusinessEntityJourney]) = {
-        businessEntityJourneyOpt.map(_.copy(isLeadSelectJourney = None))
-      }
 
       "throw technical error" when {
         val exception = new Exception("oh no!")


### PR DESCRIPTION
Summary of changes
* when the user reaches the check your answers page they can click on change links for name, sector and contact to jump back and edit
* when the form is submitted and if they have already provided answers for name, sector and contact, they are redirected back to the check your answers page, rather than having to follow the remaining create undertaking flow
* removed `getNextJourney` method in Controller and replaced this with the `next` method on the journey, to better encapsulate the journey logic