### PR TITLE
ESC-318 Dynamic dates on date validation error messages

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
@@ -48,7 +48,7 @@ class FinancialDashboardController @Inject()(
     implicit val eori: EORI = request.eoriNumber
 
     // THe search period covers the current tax year to date, and the previous 2 tax years.
-    val searchDateStart = timeProvider.today.minusYears(2).toTaxYearStart
+    val searchDateStart = timeProvider.today.toEarliestTaxYearStart
     val searchDateEnd = timeProvider.today
     val currentTaxYearEnd = timeProvider.today.toTaxYearEnd
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -158,7 +158,7 @@ class SubsidyController @Inject()(
     implicit val eori: EORI = request.eoriNumber
     getPrevious[SubsidyJourney](store).flatMap { previous =>
       claimDateForm.bindFromRequest().fold(
-        formWithErrors => Future(BadRequest(addClaimDatePage(formWithErrors, previous))),
+        formWithErrors => BadRequest(addClaimDatePage(formWithErrors, previous)).toFuture,
         form => for {
           journey <- store.update[SubsidyJourney] { maybeSubsidyJourney =>
             maybeSubsidyJourney.map { subsidyJourney =>

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -20,13 +20,14 @@ import play.api.Configuration
 import play.api.data.Form
 import play.api.data.Forms.mapping
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import play.api.mvc._
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.EscAuthRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, OneOf, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TemplateHelpers

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -20,20 +20,17 @@ import play.api.Configuration
 import play.api.data.Form
 import play.api.data.Forms.mapping
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import play.api.mvc._
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.EscAuthRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, OneOf, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TemplateHelpers
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 
-import java.util.Locale
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
@@ -26,7 +26,7 @@ import java.time.{LocalDate, ZoneId}
 import javax.inject.Inject
 import scala.util.Try
 
-class ClaimDateFormProvider @Inject()(timeProvider: TimeProvider) extends FormProvider[DateFormValues]{
+class ClaimDateFormProvider @Inject()(timeProvider: TimeProvider) extends FormProvider[DateFormValues] {
 
   override val form: Form[DateFormValues] = Form(mapping)
 
@@ -108,6 +108,7 @@ class ClaimDateFormProvider @Inject()(timeProvider: TimeProvider) extends FormPr
       case (d: String, m: String, y: String) => localDateFromValues(d, m, y).map { d =>
         val today = timeProvider.today(ZoneId.of("Europe/London"))
         // We allow claims for the current or previous 2 tax years.
+        // TODO - move this logic into the tax year helpers.
         val earliestAllowedDate = taxYearStartForDate(today).minusYears(2)
         !d.isBefore(earliestAllowedDate)
       }.getOrElse(true)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import java.time.{LocalDate, ZoneId}
 import javax.inject.Inject
 import scala.util.Try
-import uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters.DateFormatter.Syntax._
 
 import java.time.format.DateTimeFormatter
 
@@ -44,61 +43,61 @@ class ClaimDateFormProvider @Inject()(timeProvider: TimeProvider) extends FormPr
     { v: (String, String, String) => v }
   )
   .verifying(
-    "error.date.emptyfields",
+    messageKeyForError("date.emptyfields"),
     _ match {
       case ("", "", "") => false
       case _ => true
     })
   .verifying(
-    "error.date.invalidentry",
+    messageKeyForError("date.invalidentry"),
     _ match {
       case (d, m, y) => Try(s"$d$m$y".toInt).isSuccess
       case _ => false
     })
   .verifying(
-    "error.day.missing",
+    messageKeyForError("day.missing"),
     _ match {
       case ("", _, _) => false
       case _ => true
     })
   .verifying(
-    "error.month.missing",
+    messageKeyForError("month.missing"),
     _ match {
       case (_, "", _) => false
       case _ => true
     })
   .verifying(
-    "error.year.missing",
+    messageKeyForError("year.missing"),
     _ match {
       case (_, _, "") => false
       case _ => true
     })
   .verifying(
-    "error.day-and-month.missing",
+    messageKeyForError("day-and-month.missing"),
     _ match {
       case ("", "", _) => false
       case _ => true
     })
   .verifying(
-    "error.month-and-year.missing",
+    messageKeyForError("month-and-year.missing"),
     _ match {
       case (_, "", "") => false
       case _ => true
     })
   .verifying(
-    "error.day-and-year.missing",
+    messageKeyForError("day-and-year.missing"),
     _ match {
       case ("", _, "") => false
       case _ => true
     })
   .verifying(
-    "error.date.invalid",
+    messageKeyForError("date.invalid"),
     _ match {
       case (d: String, m: String, y: String) => localDateFromValues(d, m, y).isSuccess
       case _ => true
     })
   .verifying(
-    "error.date.in-future",
+    messageKeyForError("date.in-future"),
     _ match {
       case (d: String, m: String, y: String) => localDateFromValues(d, m, y).map { d =>
         val today = timeProvider.today(ZoneId.of("Europe/London"))
@@ -112,7 +111,7 @@ class ClaimDateFormProvider @Inject()(timeProvider: TimeProvider) extends FormPr
         if (parsedDate.isBefore(earliestAllowedDate)) {
           Invalid(Seq(
             ValidationError(
-              "error.date.outside-allowed-tax-year-range",
+              messageKeyForError("date.outside-allowed-tax-year-range"),
               earliestAllowedDate.format(DateTimeFormatter.ofPattern("dd MM yyyy"))
             )))
         }
@@ -123,6 +122,8 @@ class ClaimDateFormProvider @Inject()(timeProvider: TimeProvider) extends FormPr
     { case (d, m, y) => DateFormValues(d,m,y) },
     d => (d.day, d.month, d.year)
   )
+
+  private def messageKeyForError(error: String) = s"add-claim-date.error.$error"
 
   // TODO - this should live on DateValues maybe?
   private def localDateFromValues(d: String, m: String, y: String) = Try(LocalDate.of(y.toInt, m.toInt, d.toInt))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpers.scala
@@ -31,5 +31,9 @@ object TaxYearHelpers {
       .plusYears(1)
       .minusDays(1)
 
+  // Since the allowed date range is the current and previous 2 tax years the earliest allowed date is then the start
+  // of the earliest tax year.
+  def earliestAllowedDate(d: LocalDate): LocalDate = taxYearStartForDate(d).minusYears(2)
+
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearSyntax.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearSyntax.scala
@@ -20,9 +20,10 @@ import java.time.LocalDate
 
 object TaxYearSyntax {
 
-  implicit class LocalDateTaxYearOps(val ld: LocalDate) extends AnyVal {
-    def toTaxYearStart: LocalDate = TaxYearHelpers.taxYearStartForDate(ld)
-    def toTaxYearEnd: LocalDate = TaxYearHelpers.taxYearEndForDate(ld)
+  implicit class LocalDateTaxYearOps(val d: LocalDate) extends AnyVal {
+    def toTaxYearStart: LocalDate = TaxYearHelpers.taxYearStartForDate(d)
+    def toTaxYearEnd: LocalDate = TaxYearHelpers.taxYearEndForDate(d)
+    def toEarliestTaxYearStart: LocalDate = TaxYearHelpers.earliestAllowedDate(d)
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimDatePage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimDatePage.scala.html
@@ -58,8 +58,8 @@
           ErrorSummary(
               Seq(
               ErrorLink(
-                  href = Some(s"#${deriveErrorKey("add-claim-date" + error.message)}"),
-                  content = Text(s"${messages("add-claim-date." + error.message, error.args:_*)}"),
+                  href = Some(s"#${deriveErrorKey(error.message)}"),
+                  content = Text(s"${messages(error.message, error.args:_*)}"),
                   attributes = Map("class" ->"govuk-link")
               )
               ),
@@ -73,7 +73,7 @@
     @govukDateInput(DateInput(
       id = "claim-date",
       errorMessage = if (form.hasErrors) {
-        Some(ErrorMessage(content = Text(messages("add-claim-date." + form.errors.head.message, form.errors.head.args:_*))))
+        Some(ErrorMessage(content = Text(messages(form.errors.head.message, form.errors.head.args:_*))))
       } else None,
       items = Seq(
         InputItem(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimDatePage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimDatePage.scala.html
@@ -70,36 +70,36 @@
 }
 
   @formHelper(action = controllers.routes.SubsidyController.postClaimDate()) {
-    @govukDateInput(DateInput(
-      id = "claim-date",
-      errorMessage = if (form.hasErrors) {
-        Some(ErrorMessage(content = Text(messages(form.errors.head.message, form.errors.head.args:_*))))
-      } else None,
-      items = Seq(
-        InputItem(
-          name = "day",
-          classes = s"govuk-input--width-2${if(inputHasErrors("day")){" govuk-input--error"} else {""}}",
-          value = form.data.get("day")
+    @defining(form.errors.headOption) { maybeError =>
+      @govukDateInput(DateInput(
+        id = "claim-date",
+        errorMessage = maybeError.map(e => ErrorMessage(content = Text(messages(e.message, e.args:_*)))),
+        items = Seq(
+          InputItem(
+            name = "day",
+            classes = s"govuk-input--width-2${if(inputHasErrors("day")){" govuk-input--error"} else {""}}",
+            value = form.data.get("day")
+          ),
+          InputItem(
+            name = "month",
+            classes = s"govuk-input--width-2${if(inputHasErrors("month")){" govuk-input--error"} else {""}}",
+            value = form.data.get("month")
+          ),
+          InputItem(
+            name = "year",
+            classes = s"govuk-input--width-4${if(inputHasErrors("year")){" govuk-input--error"} else {""}}",
+            value = form.data.get("year")
+          )
         ),
-        InputItem(
-          name = "month",
-          classes = s"govuk-input--width-2${if(inputHasErrors("month")){" govuk-input--error"} else {""}}",
-          value = form.data.get("month")
-        ),
-        InputItem(
-          name = "year",
-          classes = s"govuk-input--width-4${if(inputHasErrors("year")){" govuk-input--error"} else {""}}",
-          value = form.data.get("year")
-        )
-      ),
-      fieldset = Some(Fieldset(
-        legend = Some(Legend(
-          content = Text(messages("add-claim-date.title")),
-          classes = "govuk-fieldset__legend--xl",
-          isPageHeading = true
+        fieldset = Some(Fieldset(
+          legend = Some(Legend(
+            content = Text(messages("add-claim-date.title")),
+            classes = "govuk-fieldset__legend--xl",
+            isPageHeading = true
+          ))
         ))
       ))
-    ))
+    }
 
     @button("common.continue")
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimDatePage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimDatePage.scala.html
@@ -53,25 +53,27 @@
 ) {
   
   @if(form.hasErrors) {
+    @defining(form.errors.head) { error =>
       @govukErrorSummary(
           ErrorSummary(
               Seq(
               ErrorLink(
-                  href = Some(s"#${deriveErrorKey("add-claim-date" + form.errors.head.message)}"),
-                  content = Text(s"${messages("add-claim-date." + form.errors.head.message)}"),
+                  href = Some(s"#${deriveErrorKey("add-claim-date" + error.message)}"),
+                  content = Text(s"${messages("add-claim-date." + error.message, error.args:_*)}"),
                   attributes = Map("class" ->"govuk-link")
               )
               ),
               title = Text(messages("common.error.summary.title"))
           )
       )
-  }
+    }
+}
 
   @formHelper(action = controllers.routes.SubsidyController.postClaimDate()) {
     @govukDateInput(DateInput(
       id = "claim-date",
       errorMessage = if (form.hasErrors) {
-        Some(ErrorMessage(content = Text(messages("add-claim-date." + form.errors.head.message))))
+        Some(ErrorMessage(content = Text(messages("add-claim-date." + form.errors.head.message, form.errors.head.args:_*))))
       } else None,
       items = Seq(
         InputItem(

--- a/conf/messages
+++ b/conf/messages
@@ -242,7 +242,7 @@ add-claim-date.error.year.missing=The date you received your payment must includ
 add-claim-date.error.date.invalidentry=Enter a real date, like 23 11 2019
 add-claim-date.error.date.invalid=Enter a real date, like 23 11 2019
 add-claim-date.error.date.outside-allowed-tax-year-range = Enter the date you received payment. Date must be {0}, or later.
-add-claim-date.error.date.in-future = Enter a date within the current tax year, or the previous two (between [Todo: Dynamic Date] 6 April 2019 and 5 April 2021)
+add-claim-date.error.date.in-future = Enter a date within the current tax year, or the previous two (between {0} and {1})
 
 add-claim-public-authority.title=Which public authority granted the payment?
 add-claim-public-authority.hint=For example, Invest NI, NI Direct.

--- a/conf/messages
+++ b/conf/messages
@@ -241,7 +241,7 @@ add-claim-date.error.month-and-year.missing=The date you received your payment m
 add-claim-date.error.year.missing=The date you received your payment must include a year, like 23 11 2019
 add-claim-date.error.date.invalidentry=Enter a real date, like 23 11 2019
 add-claim-date.error.date.invalid=Enter a real date, like 23 11 2019
-add-claim-date.error.date.outside-allowed-tax-year-range = Enter the date you received payment. Date must be [Todo: Dynamic Date] 6 April 2019, or later.
+add-claim-date.error.date.outside-allowed-tax-year-range = Enter the date you received payment. Date must be {0}, or later.
 add-claim-date.error.date.in-future = Enter a date within the current tax year, or the previous two (between [Todo: Dynamic Date] 6 April 2019 and 5 April 2021)
 
 add-claim-public-authority.title=Which public authority granted the payment?

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
@@ -75,7 +75,7 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     }
 
     "return date in future error if date is in the future" in {
-      validateAndCheckError((day+1).toString, "1", "9999")("date.in-future")
+      validateAndCheckError((day+1).toString, "1", "9999")("date.in-future", "06 04 2019", "05 04 2021")
     }
 
     "return date outside of tax year range error for date before the start of the tax year range" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
@@ -35,51 +35,51 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
   "form data validation" must {
 
     "return empty fields error if all date fields are empty" in {
-      validateAndCheckError("", "", "")("error.date.emptyfields")
+      validateAndCheckError("", "", "")("date.emptyfields")
     }
 
     "return empty fields error if all date fields just contain whitespace" in {
-      validateAndCheckError(" ", " ", " ")("error.date.emptyfields")
+      validateAndCheckError(" ", " ", " ")("date.emptyfields")
     }
 
     "return invalid entry error if non-numeric values are entered" in {
-      validateAndCheckError("foo", "bar", "baz")("error.date.invalidentry")
+      validateAndCheckError("foo", "bar", "baz")("date.invalidentry")
     }
 
     "return day missing error if day value not present" in {
-      validateAndCheckError("", "1", "2")("error.day.missing")
+      validateAndCheckError("", "1", "2")("day.missing")
     }
 
     "return month missing error if month value not present" in {
-      validateAndCheckError("1", "", "2")("error.month.missing")
+      validateAndCheckError("1", "", "2")("month.missing")
     }
 
     "return year missing error if year value not present" in {
-      validateAndCheckError("1", "2", "")("error.year.missing")
+      validateAndCheckError("1", "2", "")("year.missing")
     }
 
     "return day and month missing error if only year value present" in {
-      validateAndCheckError("", "", "2")("error.day-and-month.missing")
+      validateAndCheckError("", "", "2")("day-and-month.missing")
     }
 
     "return month and year missing error if only day value present" in {
-      validateAndCheckError("1", "", "")("error.month-and-year.missing")
+      validateAndCheckError("1", "", "")("month-and-year.missing")
     }
 
     "return day and year missing error if only month value present" in {
-      validateAndCheckError("", "1", "")("error.day-and-year.missing")
+      validateAndCheckError("", "1", "")("day-and-year.missing")
     }
 
     "return date invalid if values do not form a valid date" in {
-      validateAndCheckError("50", "20", "2000")("error.date.invalid")
+      validateAndCheckError("50", "20", "2000")("date.invalid")
     }
 
     "return date in future error if date is in the future" in {
-      validateAndCheckError((day+1).toString, "1", "9999")("error.date.in-future")
+      validateAndCheckError((day+1).toString, "1", "9999")("date.in-future")
     }
 
     "return date outside of tax year range error for date before the start of the tax year range" in {
-      validateAndCheckError("1", "1", "1900")("error.date.outside-allowed-tax-year-range", "06 04 2019")
+      validateAndCheckError("1", "1", "1900")("date.outside-allowed-tax-year-range", "06 04 2019")
     }
 
     "return no errors for todays date" in {
@@ -113,7 +113,7 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     ))
 
     val foundExpectedErrorMessage = result.leftSideValue match {
-      case Left(errors) => errors.contains(FormError("", errorMessage, args))
+      case Left(errors) => errors.contains(FormError("", s"add-claim-date.error.$errorMessage", args))
       case _ => false
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
@@ -79,7 +79,7 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     }
 
     "return date outside of tax year range error for date before the start of the tax year range" in {
-      validateAndCheckError("1", "1", "1900")("error.date.outside-allowed-tax-year-range")
+      validateAndCheckError("1", "1", "1900")("error.date.outside-allowed-tax-year-range", "06 04 2019")
     }
 
     "return no errors for todays date" in {
@@ -105,7 +105,7 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     result mustBe Right(DateFormValues(d, m, y))
   }
 
-  private def validateAndCheckError(d: String, m: String, y: String)(errorMessage: String) = {
+  private def validateAndCheckError(d: String, m: String, y: String)(errorMessage: String, args: String*) = {
     val result = underTest.form.mapping.bind(Map(
       "day"   -> d,
       "month" -> m,
@@ -113,7 +113,7 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     ))
 
     val foundExpectedErrorMessage = result.leftSideValue match {
-      case Left(errors) => errors.contains(FormError("", errorMessage))
+      case Left(errors) => errors.contains(FormError("", errorMessage, args))
       case _ => false
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.eusubsidycompliancefrontend.service
+package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import cats.implicits.catsSyntaxOptionId
 import org.scalamock.scalatest.MockFactory
@@ -23,12 +23,11 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, SubsidyRetrieve, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscServiceImpl, SubsidyJourney}
-
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, SubsidyRetrieve, Undertaking}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.CommonTestData._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailServiceSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.eusubsidycompliancefrontend.service
+package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import cats.implicits.catsSyntaxOptionId
 import org.scalamock.scalatest.MockFactory
@@ -25,12 +25,11 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.RetrieveEmailConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.RetrieveEmailServiceImpl
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.CommonTestData._
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class RetrieveEmailServiceSpec extends AnyWordSpec with Matchers with MockFactory {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailServiceSpec.scala
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.eusubsidycompliancefrontend.service
+package uk.gov.hmrc.eusubsidycompliancefrontend.services
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -22,12 +23,11 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.SendEmailConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendRequest, EmailSendResult}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.SendEmailServiceImpl
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.CommonTestData._
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 
 class SendEmailServiceSpec extends AnyWordSpec with Matchers with MockFactory {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpersSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpersSpec.scala
@@ -23,34 +23,67 @@ import java.time.LocalDate
 
 class TaxYearHelpersSpec extends AnyWordSpecLike with Matchers {
 
+  private val BeforeTaxYearEnd = LocalDate.parse("2022-03-01")
+  private val LastDayOfTaxYear = LocalDate.parse("2022-04-05")
+  private val FirstDayOfTaxYear = LocalDate.parse("2022-04-06")
+  private val AfterTaxYearEnd = LocalDate.parse("2022-05-01")
+
   "taxYearStartForDate" must {
 
-    "return a tax year starting in the same year if the date falls on the 6th of April" in {
-      TaxYearHelpers.taxYearStartForDate(LocalDate.parse("2022-04-06")) mustBe LocalDate.parse("2022-04-06")
+    "return a tax year starting in the previous year if the date falls before the end of the tax year" in {
+      TaxYearHelpers.taxYearStartForDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2021-04-06")
     }
 
-    "return a tax year starting in the same year if the date falls after the 6th of April" in {
-      TaxYearHelpers.taxYearStartForDate(LocalDate.parse("2022-12-06")) mustBe LocalDate.parse("2022-04-06")
+    "return a tax year starting in the previous year if the date falls on last day of the old tax year" in {
+      TaxYearHelpers.taxYearStartForDate(LastDayOfTaxYear) mustBe LocalDate.parse("2021-04-06")
     }
 
-    "return a tax year starting in the previous year if the date falls before the 6th of April" in {
-      TaxYearHelpers.taxYearStartForDate(LocalDate.parse("2022-02-06")) mustBe LocalDate.parse("2021-04-06")
+    "return a tax year starting in the same year if the date falls on first day of the new tax year" in {
+      TaxYearHelpers.taxYearStartForDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2022-04-06")
+    }
+
+    "return a tax year starting in the same year if the date falls after the start of the new tax year" in {
+      TaxYearHelpers.taxYearStartForDate(AfterTaxYearEnd) mustBe LocalDate.parse("2022-04-06")
     }
 
   }
 
   "taxYearEndForDate" must {
 
-    "return a tax year ending in the following year if the date falls on the 6th of April" in {
-      TaxYearHelpers.taxYearEndForDate(LocalDate.parse("2022-04-06")) mustBe LocalDate.parse("2023-04-05")
+    "return a tax year ending in the current year if the date falls before the end of the old tax year" in {
+      TaxYearHelpers.taxYearEndForDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2022-04-05")
     }
 
-    "return a tax year ending in the following year if the date falls after the 6th of April" in {
-      TaxYearHelpers.taxYearEndForDate(LocalDate.parse("2022-12-06")) mustBe LocalDate.parse("2023-04-05")
+    "return a tax year ending in the current year if the date falls on the last day of the old tax year" in {
+      TaxYearHelpers.taxYearEndForDate(LastDayOfTaxYear) mustBe LocalDate.parse("2022-04-05")
     }
 
-    "return a tax year ending in the current year if the date falls before the 6th of April" in {
-      TaxYearHelpers.taxYearEndForDate(LocalDate.parse("2022-02-06")) mustBe LocalDate.parse("2022-04-05")
+    "return a tax year ending in the following year if the date falls on the first day of the new tax year" in {
+      TaxYearHelpers.taxYearEndForDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2023-04-05")
+    }
+
+    "return a tax year ending in the following year if the date falls after the first day of the new tax year" in {
+      TaxYearHelpers.taxYearEndForDate(AfterTaxYearEnd) mustBe LocalDate.parse("2023-04-05")
+    }
+
+  }
+
+  "earliestAllowedDate" must {
+
+    "return the start of the earliest allowed date if the date falls before the end of the old tax year" in {
+      TaxYearHelpers.earliestAllowedDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2019-04-06")
+    }
+
+    "return the start of the earliest allowed tax year if the date falls on the last day of the old tax year" in {
+      TaxYearHelpers.earliestAllowedDate(LastDayOfTaxYear) mustBe LocalDate.parse("2019-04-06")
+    }
+
+    "return the start of the earliest allowed tax year if the date falls on the first day of the new tax year" in {
+      TaxYearHelpers.earliestAllowedDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2020-04-06")
+    }
+
+    "return the start of the earliest allowed tax year if the date falls after the first day of the new tax year" in {
+      TaxYearHelpers.earliestAllowedDate(AfterTaxYearEnd) mustBe LocalDate.parse("2020-04-06")
     }
 
   }


### PR DESCRIPTION
Summary of changes
* moved logic that calculates the earliest allowed date into `TaxYearHelpers` and provided an extension method 
* refactored date validation removing boilerplate and grouping the validation checks into logical groups
* revised the validation error rendering to support arbitrary args allowing dates to be passed for those error messages that need to show dynamic date values
* other refactors and tidying including correcting the package on some tests 