### PR TITLE
Esc 227 228 lead removed email

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/config/AppConfig.scala
@@ -39,6 +39,8 @@ class AppConfig @Inject()(config: Configuration) {
     "promoteAsLeadEmailToBE" -> config.get[String](s"email-send.promote-other-as-lead-to-be-template-$langCode"),
     "promoteAsLeadEmailToLead" -> config.get[String](s"email-send.promote-other-as-lead-to-lead-template-$langCode"),
     "removeThemselfEmailToBE" -> config.get[String](s"email-send.member-remove-themself-email-to-be-template-$langCode"),
-    "removeThemselfEmailToLead" -> config.get[String](s"email-send.member-remove-themself-email-to-lead-template-$langCode")
+    "removeThemselfEmailToLead" -> config.get[String](s"email-send.member-remove-themself-email-to-lead-template-$langCode"),
+    "promotedAsLeadToNewLead" -> config.get[String](s"email-send.promoted-themself-email-to-new-lead-template-$langCode"),
+    "removedAsLeadToOldLead" -> config.get[String](s"email-send.removed_as_lead-email-to-old-lead-template-$langCode")
   )
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -17,23 +17,19 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
-import play.api.Configuration
 import play.api.data.Form
 import play.api.data.Forms.mapping
-import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents, Result}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
-import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.EscAuthRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, DoubleEORIEmailParameter, SingleEORIAndDateEmailParameter, SingleEORIEmailParameter}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ContactDetails, EmailAddress, FormValues, OneOf, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingName}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ContactDetails, FormValues, OneOf, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EscService, JourneyTraverseService, RetrieveEmailService, SendEmailService, Store}
-import uk.gov.hmrc.eusubsidycompliancefrontend.util.{EmailTemplateHelpers, TimeProvider}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EscService, JourneyTraverseService, SendEmailHelperService, Store}
+import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters.DateFormatter
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
-import uk.gov.hmrc.http.HeaderCarrier
+
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,11 +41,8 @@ class BusinessEntityController @Inject()(
   store: Store,
   escService: EscService,
   journeyTraverseService: JourneyTraverseService,
-  retrieveEmailService: RetrieveEmailService,
-  sendEmailService: SendEmailService,
   timeProvider: TimeProvider,
-  configuration: Configuration,
-  emailTemplateHelpers: EmailTemplateHelpers,
+  sendEmailHelperService: SendEmailHelperService,
   addBusinessPage: AddBusinessPage,
   eoriPage: BusinessEntityEoriPage,
   removeYourselfBEPage: BusinessEntityRemoveYourselfPage,
@@ -209,13 +202,9 @@ class BusinessEntityController @Inject()(
         leadEORI = false,
         ContactDetails(contactDetails.phone, contactDetails.mobile).some) // resetting the journey as it's final CYA page
       _ <- escService.addMember(undertakingRef, businessEntity)
-      emailAddressBE <- retrieveEmailService.retrieveEmailByEORI(eoriBE).map(_.getOrElse(handleMissingSessionData(" BE Email Address")))
-      emailAddressLead <- retrieveEmailService.retrieveEmailByEORI(eori).map(_.getOrElse(handleMissingSessionData("Lead Email Address")))
-      templateIdBE = emailTemplateHelpers.getEmailTemplateId(configuration, AddMemberEmailToBusinessEntity)
-      templateIdLead = emailTemplateHelpers.getEmailTemplateId(configuration, AddMemberEmailToLead)
-      emailParametersBE = SingleEORIEmailParameter(eoriBE, undertaking.name, undertakingRef,  "Email to BE for being added as a member")
-      emailParametersLead = DoubleEORIEmailParameter(eori, eoriBE,  undertaking.name, undertakingRef,  "Email to Lead  for adding a new member")
-      redirect <- sendEmailAndRedirect(emailAddressBE, emailParametersBE, templateIdBE, emailAddressLead, emailParametersLead, templateIdLead, businessEntityJourney)
+      _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(eoriBE, None, AddMemberEmailToBusinessEntity, undertaking, undertakingRef, None)
+      _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(eori, eoriBE.some, AddMemberEmailToLead, undertaking, undertakingRef, None)
+      redirect <- getNext(businessEntityJourney)(eori)
     } yield redirect
 
     cyaForm.bindFromRequest().fold(
@@ -291,26 +280,15 @@ class BusinessEntityController @Inject()(
         val removeBE: BusinessEntity = undertaking.getBusinessEntityByEORI(EORI(eoriEntered))
         removeBusinessForm.bindFromRequest().fold(
           errors => Future.successful(BadRequest(removeBusinessPage(errors, removeBE))),
-          form => {
+          success = form => {
             form.value match {
               case "true" =>
                 val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today)
-                escService.removeMember(undertakingRef, removeBE)
-                  .flatMap(_ =>
-                    sendEmail(
-                      beEORI = EORI(eoriEntered),
-                      leadEORI = eori,
-                      templateIdParamBE = RemoveMemberEmailToBusinessEntity,
-                      templateIdParamLead = RemoveMemberEmailToLead,
-                      emailParamDescBE = "Email to BE for being removed as a member",
-                      emailParamDescLead = "Email to Lead  for removing a new member",
-                      undertaking = undertaking,
-                      undertakingRef = undertakingRef,
-                      removalEffectiveDateString = removalEffectiveDateString,
-                      nextCall = routes.BusinessEntityController.getAddBusinessEntity()
-                    )
-                  )
-
+                for {
+                  _ <- escService.removeMember(undertakingRef, removeBE)
+                  _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(EORI(eoriEntered), None, RemoveMemberEmailToBusinessEntity, undertaking, undertakingRef, removalEffectiveDateString.some)
+                  _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(eori, EORI(eoriEntered).some, RemoveMemberEmailToLead, undertaking, undertakingRef, removalEffectiveDateString.some)
+                } yield Redirect(routes.BusinessEntityController.getAddBusinessEntity())
               case _ => Future(Redirect(routes.BusinessEntityController.getAddBusinessEntity()))
             }
           }
@@ -333,20 +311,11 @@ class BusinessEntityController @Inject()(
               case "true" =>
                 val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today)
                 val leadEORI = undertaking.getLeadEORI
-                escService.removeMember(undertakingRef, removeBE)
-                  .flatMap(_ =>
-                    sendEmail(
-                      beEORI = loggedInEORI,
-                      leadEORI = leadEORI,
-                      templateIdParamBE = RemoveThemselfEmailToBusinessEntity,
-                      templateIdParamLead = RemoveThemselfEmailToLead,
-                      emailParamDescBE = "Email to BE for removing themself from undertaking",
-                      emailParamDescLead = "Email to Lead  informing that a Business Entity has removed itself from Undertaking",
-                      undertaking = undertaking,
-                      undertakingRef = undertakingRef,
-                      removalEffectiveDateString = removalEffectiveDateString,
-                      nextCall = routes.SignOutController.signOut()
-                    ))
+                for {
+                  _ <- escService.removeMember(undertakingRef, removeBE)
+                  _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(loggedInEORI, None, RemoveThemselfEmailToBusinessEntity, undertaking, undertakingRef, removalEffectiveDateString.some)
+                  _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(leadEORI, loggedInEORI.some, RemoveThemselfEmailToLead, undertaking, undertakingRef, removalEffectiveDateString.some)
+                } yield Redirect(routes.SignOutController.signOut())
               case _ => Future(Redirect(routes.AccountController.getAccountPage()))
             }
           }
@@ -363,44 +332,6 @@ class BusinessEntityController @Inject()(
         .map(_ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()))
     }
   }
-
-  private def sendEmailAndRedirect(
-  emailAddressBE: EmailAddress,
-  emailParametersBE: EmailParameters,
-  templateIdBE: String,
-  emailAddressLead: EmailAddress,
-  emailParametersLead: EmailParameters,
-  templateIdLead: String,
-  businessEntityJourney: BusinessEntityJourney)(implicit hc: HeaderCarrier, eori: EORI): Future[Result] = {
-    sendEmailService.sendEmail(emailAddressBE, emailParametersBE, templateIdBE)
-    sendEmailService.sendEmail(emailAddressLead, emailParametersLead, templateIdLead)
-    getNext(businessEntityJourney)(eori)
-  }
-
-  private def sendEmail(
-   beEORI: EORI,
-   leadEORI: EORI,
-   templateIdParamBE: String,
-   templateIdParamLead: String,
-   emailParamDescBE: String,
-   emailParamDescLead: String,
-   undertaking: Undertaking,
-   undertakingRef: UndertakingRef,
-   removalEffectiveDateString: String,
-   nextCall: Call
-   )(implicit hc: HeaderCarrier, request: EscAuthRequest[_]) = for {
-    emailAddressBE <- retrieveEmailService.retrieveEmailByEORI(beEORI).map(_.getOrElse(handleMissingSessionData("Business entity Email")))
-    emailAddressLead <- retrieveEmailService.retrieveEmailByEORI(leadEORI).map(_.getOrElse(handleMissingSessionData("Lead EORI Email Address")))
-    templateIdBE = emailTemplateHelpers.getEmailTemplateId(configuration, templateIdParamBE)
-    templateIdLead = emailTemplateHelpers.getEmailTemplateId(configuration, templateIdParamLead)
-    emailParametersBE = SingleEORIAndDateEmailParameter(beEORI, undertaking.name, undertakingRef, removalEffectiveDateString, emailParamDescBE)
-    emailParametersLead = DoubleEORIAndDateEmailParameter(leadEORI, beEORI,  undertaking.name, undertakingRef, removalEffectiveDateString, emailParamDescLead)
-  } yield {
-    sendEmailService.sendEmail(emailAddressBE, emailParametersBE, templateIdBE)
-    sendEmailService.sendEmail(emailAddressLead, emailParametersLead, templateIdLead)
-    Redirect(nextCall)
-  }
-
 
 
   lazy val addBusinessForm: Form[FormValues] = Form(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -333,7 +333,6 @@ class BusinessEntityController @Inject()(
               case "true" =>
                 val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today)
                 val leadEORI = undertaking.getLeadEORI
-
                 escService.removeMember(undertakingRef, removeBE)
                   .flatMap(_ =>
                     sendEmail(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailHelperService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailHelperService.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.services
+
+import play.api.Configuration
+import play.api.i18n.I18nSupport.RequestWithMessagesApi
+import play.api.i18n.MessagesApi
+import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.EscAuthRequest
+import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
+import com.google.inject.Inject
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, DoubleEORIEmailParameter, SingleEORIAndDateEmailParameter, SingleEORIEmailParameter}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendResult}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.util.Locale
+import javax.inject.Singleton
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SendEmailHelperService @Inject() (
+    appConfig: AppConfig,
+    retrieveEmailService: RetrieveEmailService,
+    sendEmailService: SendEmailService,
+    configuration: Configuration) {
+
+
+  def retrieveEmailAddressAndSendEmail(eori1: EORI,
+     eori2: Option[EORI],
+     key: String,
+     undertaking: Undertaking,
+     undertakingRef: UndertakingRef,
+     removeEffectiveDate: Option[String]
+  )(implicit hc: HeaderCarrier,
+     executionContext: ExecutionContext,
+     request: EscAuthRequest[_],
+     messagesApi: MessagesApi
+  ): Future[EmailSendResult] = {
+    for {
+      emailAddress <- retrieveEmailService.retrieveEmailByEORI(eori1).map(_.getOrElse(sys.error("Email Address")))
+      templateId  = getEmailTemplateId(configuration, key)
+      emailParameter =   getEmailParams(key, eori1, eori2, undertaking, undertakingRef, removeEffectiveDate)
+      result <- sendEmailService.sendEmail(emailAddress, emailParameter, templateId)
+    } yield result
+
+  }
+
+
+  private def getEmailParams(key: String,
+                        eori1: EORI,
+                        eori2: Option[EORI],
+                        undertaking: Undertaking,
+                        undertakingRef: UndertakingRef,
+                        removeEffectiveDate: Option[String]): EmailParameters =
+    (eori2, removeEffectiveDate) match {
+      case (None, None) => SingleEORIEmailParameter(eori1, undertaking.name, undertakingRef,  key)
+      case(None, Some(date)) => SingleEORIAndDateEmailParameter(eori1, undertaking.name, undertakingRef, date, key)
+      case (Some(eori), None) => DoubleEORIEmailParameter(eori1, eori,  undertaking.name, undertakingRef,  key)
+      case (Some(eori), Some(date)) => DoubleEORIAndDateEmailParameter(eori1, eori,  undertaking.name, undertakingRef, date, key)
+    }
+
+  private def getLanguage(implicit request: EscAuthRequest[_], messagesApi: MessagesApi): Language =
+    request.request.messages(messagesApi).lang.code.toLowerCase(Locale.UK) match {
+      case English.code => English
+      case Welsh.code   => Welsh
+      case other        => sys.error(s"Found unsupported language code $other")
+    }
+
+  private def getEmailTemplateId(configuration: Configuration, inputKey: String
+                        )(implicit request: EscAuthRequest[_], messagesApi: MessagesApi) = {
+    val lang = getLanguage
+    appConfig.templateIdsMap(configuration, lang.code).get(inputKey).getOrElse(s"no template for $inputKey")
+  }
+
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/EmailTemplateHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/EmailTemplateHelpers.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 
 import java.util.Locale
 import javax.inject.{Inject, Singleton}
-
 @Singleton
 class EmailTemplateHelpers @Inject()(appConfig: AppConfig) {
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminConfirmatinPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminConfirmatinPage.scala.html
@@ -36,7 +36,7 @@
 
     <div class="govuk-panel govuk-panel--confirmation">
         <h1 class="govuk-panel__title">
-            You have requested to become the administrator for this single undertaking
+            @messages("become-admin-confirmation.title")
         </h1>
 
     </div>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -197,4 +197,8 @@ email-send {
     member-remove-themself-email-to-be-template-cy ="member_remove_themself_email_to_be"
     member-remove-themself-email-to-lead-template-en = "member_remove_themself_email_to_lead"
     member-remove-themself-email-to-lead-template-cy = "member_remove_themself_email_to_lead"
+    promoted-themself-email-to-new-lead-template-en = "promoted_themself_as_lead_email_to_lead"
+    promoted-themself-email-to-new-lead-template-cy = "promoted_themself_as_lead_email_to_lead"
+    removed_as_lead-email-to-old-lead-template-en = "removed_as_lead_email_to_previous_lead"
+    removed_as_lead-email-to-old-lead-template-cy = "removed_as_lead_email_to_previous_lead"
 }

--- a/conf/messages
+++ b/conf/messages
@@ -345,5 +345,6 @@ updateEmail.p3.list3 = some financial notifications, including Direct Debit noti
 
 become-admin.title=[TODO - become admin title]
 become-admin.hint=[TODO - become admin hint]
+become-admin-confirmation.title = You have requested to become the administrator for this single undertaking
 
 become-admin-terms-and-conditions.title=[TODO - become admin terms and conditions title]

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -67,7 +67,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
                                    |play.i18n.langs = ["en", "cy", "fr"]
                                    | email-send {
                                    |     add-member-to-be-template-en = "template_add_be_EN"
-                                   |     add-member-to-be-template-cy = "template_add__be_CY"
+                                   |     add-member-to-be-template-cy = "template_add_be_CY"
                                    |     add-member-to-lead-template-en = "template_add_lead_EN"
                                    |     add-member-to-lead-template-cy = "template_add_lead_CY"
                                    |     remove-member-to-be-template-en = "template_remove_be_EN"
@@ -676,6 +676,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
 
       "throw technical error" when {
         val exception = new Exception("oh no")
+        val emailParametersBE =  SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef,  "addMemberEmailToBE")
 
         "call to get undertaking fails" in {
           inSequence{
@@ -785,6 +786,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(validEmailAddress.some))
+            mockSendEmail(validEmailAddress, emailParametersBE, "template_add_be_EN")(Right(EmailSendResult.EmailSent))
             mockRetrieveEmail(eori1)(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
@@ -799,6 +801,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(validEmailAddress.some))
+            mockSendEmail(validEmailAddress, emailParametersBE, "template_add_be_EN")(Right(EmailSendResult.EmailSent))
             mockRetrieveEmail(eori1)(Right(None))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
@@ -821,16 +824,16 @@ class BusinessEntityControllerSpec  extends ControllerSpec
 
         def testRedirection(businessEntityJourney: BusinessEntityJourney, nextCall: String, resettedBusinessJourney: BusinessEntityJourney) = {
           val businessEntity = BusinessEntity(eori2, leadEORI = false, contactDetails.some)
-          val emailParametersBE =  SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef,  "Email to BE for being added as a member")
-          val emailParametersLead =  DoubleEORIEmailParameter(eori1, eori2, undertaking.name, undertakingRef,  "Email to Lead  for adding a new member")
+          val emailParametersBE =  SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef,  "addMemberEmailToBE")
+          val emailParametersLead =  DoubleEORIEmailParameter(eori1, eori2, undertaking.name, undertakingRef,  "addMemberEmailToLead")
           inSequence{
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(validEmailAddress.some))
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersBE, "template_add_be_EN")(Right(EmailSendResult.EmailSent))
+            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersLead, "template_add_lead_EN")(Right(EmailSendResult.EmailSent))
             mockPut[BusinessEntityJourney](resettedBusinessJourney, eori1)(Right(BusinessEntityJourney()))
           }
@@ -839,8 +842,8 @@ class BusinessEntityControllerSpec  extends ControllerSpec
 
         def testRedirectionLang(lang: String, templateIdBE: String, templateIdLead: String) = {
 
-          val emailParametersBE =  SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef,  "Email to BE for being added as a member")
-          val emailParametersLead =  DoubleEORIEmailParameter(eori1, eori2, undertaking.name, undertakingRef,  "Email to Lead  for adding a new member")
+          val emailParametersBE =  SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef,  "addMemberEmailToBE")
+          val emailParametersLead =  DoubleEORIEmailParameter(eori1, eori2, undertaking.name, undertakingRef,  "addMemberEmailToLead")
 
           val businessEntity = BusinessEntity(eori2, false, contactDetails.some)
           inSequence{
@@ -849,8 +852,8 @@ class BusinessEntityControllerSpec  extends ControllerSpec
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(validEmailAddress.some))
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersBE, templateIdBE)(Right(EmailSendResult.EmailSent))
+            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersLead, templateIdLead)(Right(EmailSendResult.EmailSent))
             mockPut[BusinessEntityJourney](BusinessEntityJourney(), eori1)(Right(BusinessEntityJourney()))
           }
@@ -862,7 +865,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
         }
 
         "all api calls are successful and Welsh language is selected" in {
-          testRedirectionLang(Language.Welsh.code, "template_add__be_CY", "template_add_lead_CY")
+          testRedirectionLang(Language.Welsh.code, "template_add_be_CY", "template_add_lead_CY")
         }
 
         "all api calls are successful and is Select lead journey " in {
@@ -1021,6 +1024,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
 
       "throw a technical error" when {
         val exception = new Exception("oh no!")
+        val emailParamBE = SingleEORIAndDateEmailParameter(eori4, undertaking.name, undertakingRef, "9 October 2022", "removeThemselfEmailToBE" )
 
         "call to retrieved undertaking fails" in {
           inSequence {
@@ -1074,6 +1078,7 @@ class BusinessEntityControllerSpec  extends ControllerSpec
             mockTimeToday(currentDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
             mockRetrieveEmail(eori4)(Right(validEmailAddress.some))
+            mockSendEmail(validEmailAddress, emailParamBE, "template_remove_yourself_be_EN")(Right(EmailSendResult.EmailSent))
             mockRetrieveEmail(eori1)(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction("removeYourselfBusinessEntity" -> "true")(English.code)))
@@ -1086,7 +1091,6 @@ class BusinessEntityControllerSpec  extends ControllerSpec
             mockTimeToday(currentDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
             mockRetrieveEmail(eori4)(Right(validEmailAddress.some))
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
           }
           assertThrows[Exception](await(performAction("removeYourselfBusinessEntity" -> "true")("fr")))
         }
@@ -1117,16 +1121,16 @@ class BusinessEntityControllerSpec  extends ControllerSpec
 
          def  testRedirection(lang: String, templateIdBe: String, templateIdLead: String, effectiveRemovalDate: String)= {
 
-           val emailParamBE = SingleEORIAndDateEmailParameter(eori4, undertaking.name, undertakingRef, effectiveRemovalDate, "Email to BE for removing themself from undertaking" )
-           val emailParamLead = DoubleEORIAndDateEmailParameter(eori1, eori4, undertaking.name, undertakingRef, effectiveRemovalDate, "Email to Lead  informing that a Business Entity has removed itself from Undertaking" )
+           val emailParamBE = SingleEORIAndDateEmailParameter(eori4, undertaking.name, undertakingRef, effectiveRemovalDate, "removeThemselfEmailToBE" )
+           val emailParamLead = DoubleEORIAndDateEmailParameter(eori1, eori4, undertaking.name, undertakingRef, effectiveRemovalDate, "removeThemselfEmailToLead" )
            inSequence {
              mockAuthWithEnrolment(eori4)
              mockRetreiveUndertaking(eori4)(Future.successful(undertaking1.some))
              mockTimeToday(currentDate)
              mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
              mockRetrieveEmail(eori4)(Right(validEmailAddress.some))
-             mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
              mockSendEmail(validEmailAddress, emailParamBE, templateIdBe)(Right(EmailSendResult.EmailSent))
+             mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
              mockSendEmail(validEmailAddress, emailParamLead, templateIdLead)(Right(EmailSendResult.EmailSent))
            }
            checkIsRedirect(performAction("removeYourselfBusinessEntity" -> "true")(lang), routes.SignOutController.signOut().url)
@@ -1276,12 +1280,19 @@ class BusinessEntityControllerSpec  extends ControllerSpec
         }
 
         "call to fetch LeadEORI email address fails" in {
+          val emailParameterBE = SingleEORIAndDateEmailParameter(
+            eori4,
+            undertaking.name,
+            undertakingRef,
+            "9 October 2022",  "removeMemberEmailToBE")
+
           inSequence {
             mockAuthWithEnrolment(eori1)
             mockRetreiveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
             mockRetrieveEmail(eori4)(Right(validEmailAddress.some))
+            mockSendEmail(validEmailAddress,emailParameterBE, "template_remove_be_EN")(Right(EmailSendResult.EmailSent ))
             mockRetrieveEmail(eori1)(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction("removeBusiness" -> "true")(eori4)))
@@ -1315,8 +1326,8 @@ class BusinessEntityControllerSpec  extends ControllerSpec
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
             mockRetrieveEmail(eori4)(Right(validEmailAddress.some))
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersBE, templateIdBE)(Right(EmailSendResult.EmailSent))
+            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersLead, templateIdLead)(Right(EmailSendResult.EmailSent))
           }
           checkIsRedirect(performAction("removeBusiness" -> "true")(eori4, lang), routes.BusinessEntityController.getAddBusinessEntity().url)
@@ -1330,13 +1341,13 @@ class BusinessEntityControllerSpec  extends ControllerSpec
               eori4,
               undertaking.name,
               undertakingRef,
-              "9 October 2022",  "Email to BE for being removed as a member")
+              "9 October 2022",  "removeMemberEmailToBE")
             val emailParameterLead = DoubleEORIAndDateEmailParameter(
               eori1,
               eori4,
               undertaking.name,
               undertakingRef,
-              "9 October 2022",  "Email to Lead  for removing a new member")
+              "9 October 2022",  "removeMemberEmailToLead")
             testRedirection(emailParameterBE, emailParameterLead, "template_remove_be_EN", "template_remove_lead_EN", English.code)
 
           }
@@ -1347,13 +1358,13 @@ class BusinessEntityControllerSpec  extends ControllerSpec
               eori4,
               undertaking.name,
               undertakingRef,
-              "9 Hydref 2022",  "Email to BE for being removed as a member")
+              "9 Hydref 2022",  "removeMemberEmailToBE")
             val emailParameterLead = DoubleEORIAndDateEmailParameter(
               eori1,
               eori4,
               undertaking.name,
               undertakingRef,
-              "9 Hydref 2022",  "Email to Lead  for removing a new member")
+              "9 Hydref 2022",  "removeMemberEmailToLead")
             testRedirection(emailParameterBE, emailParameterLead, "template_remove_be_CY", "template_remove_lead_CY", Welsh.code)
 
           }

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -195,7 +195,7 @@ object CommonTestData {
     None, None,
     List(businessEntity5))
 
-  val emailParameter   = SingleEORIEmailParameter(eori1, undertaking.name, undertakingRef, "undertaking Created by Lead EORI")
+  val emailParameter   = SingleEORIEmailParameter(eori1, undertaking.name, undertakingRef, "createUndertaking")
   val emailSendRequest = EmailSendRequest(List(EmailAddress("user@test.com")), "templateId1", emailParameter)
 
 }


### PR DESCRIPTION
- Email when a business entity promote themself as lead , it should send email to both new lead and old lead.
- Did some refactoring. All the email stuff - getting params, template id, language code is now under SendEmailHelperService