### PR TITLE
ESC-344 Do not store form URLs in MongoDB

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -36,20 +36,17 @@ object Undertaking {
 
   implicit class UndertakingOps(private val undertaking: Undertaking) extends AnyVal {
 
-    //Check if the eori entered is Lead EORI or not
     def isLeadEORI(eori: EORI): Boolean = {
-      val leadEORI: BusinessEntity = undertaking.undertakingBusinessEntity
-        .filter(_.leadEORI)
-        .headOption
+      val leadEORI: BusinessEntity = undertaking
+        .undertakingBusinessEntity
+        .find(_.leadEORI)
         .getOrElse(throw new IllegalStateException("Missing Lead EORI"))
-      leadEORI.businessEntityIdentifier.toString == eori.toString
+      leadEORI.businessEntityIdentifier == eori
     }
 
-    //Fetches the Business entity for the given EORI
-    def getBusinessEntityByEORI(eori: EORI): BusinessEntity =
+    def getBusinessEntityByEORI(eori: EORI): BusinessEntity = {
       undertaking.undertakingBusinessEntity
-        .filter(be => be.businessEntityIdentifier == eori)
-        .headOption
+        .find(be => be.businessEntityIdentifier == eori)
         .getOrElse(throw new IllegalStateException(s"BE with eori $eori is missing"))
 
     def getAllNonLeadEORIs(): List[EORI] =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -44,7 +44,7 @@ object Undertaking {
       leadEORI.businessEntityIdentifier == eori
     }
 
-    def getBusinessEntityByEORI(eori: EORI): BusinessEntity = {
+    def getBusinessEntityByEORI(eori: EORI): BusinessEntity =
       undertaking.undertakingBusinessEntity
         .find(be => be.businessEntityIdentifier == eori)
         .getOrElse(throw new IllegalStateException(s"BE with eori $eori is missing"))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.Forms.{BecomeLeadEoriFormPage, ConfirmationFormPage, TermsAndConditionsFormPage}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 
 case class BecomeLeadJourney(
   becomeLeadEori: BecomeLeadEoriFormPage = BecomeLeadEoriFormPage(),
@@ -25,7 +26,7 @@ case class BecomeLeadJourney(
   confirmation: ConfirmationFormPage = ConfirmationFormPage(),
 ) extends Journey {
 
-  override def steps: List[FormPageBase[_]] =
+  override def steps: List[FormPage[_]] =
     List(
       becomeLeadEori,
       acceptTerms,
@@ -35,7 +36,6 @@ case class BecomeLeadJourney(
 }
 
 object BecomeLeadJourney {
-  import Journey._
 
   implicit val format: Format[BecomeLeadJourney] = Json.format[BecomeLeadJourney]
 
@@ -46,9 +46,9 @@ object BecomeLeadJourney {
   }
 
   object Forms {
-    case class BecomeLeadEoriFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.BecomeLead }
-    case class TermsAndConditionsFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.TermsAndConditions }
-    case class ConfirmationFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Confirmation }
+    case class BecomeLeadEoriFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.BecomeLead }
+    case class TermsAndConditionsFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.TermsAndConditions }
+    case class ConfirmationFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.Confirmation }
 
     object BecomeLeadEoriFormPage { implicit val becomeLeadEoriFormPageFormat: OFormat[BecomeLeadEoriFormPage] = Json.format }
     object TermsAndConditionsFormPage { implicit val termsAndConditionsFormPageFormat: OFormat[TermsAndConditionsFormPage] = Json.format }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
@@ -16,16 +16,16 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
-import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormUrls
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.Forms.{BecomeLeadEoriFormPage, ConfirmationFormPage, TermsAndConditionsFormPage}
 
 case class BecomeLeadJourney(
-  becomeLeadEori: FormPage[Boolean] = FormPage(FormUrls.BecomeLead),
-  acceptTerms: FormPage[Boolean] = FormPage(FormUrls.TermsAndConditions),
-  confirmation: FormPage[Boolean] = FormPage(FormUrls.Confirmation)
+  becomeLeadEori: BecomeLeadEoriFormPage = BecomeLeadEoriFormPage(),
+  acceptTerms: TermsAndConditionsFormPage = TermsAndConditionsFormPage(),
+  confirmation: ConfirmationFormPage = ConfirmationFormPage(),
 ) extends Journey {
 
-  override def steps: List[FormPage[_]] =
+  override def steps: List[FormPageBase[_]] =
     List(
       becomeLeadEori,
       acceptTerms,
@@ -40,10 +40,19 @@ object BecomeLeadJourney {
   implicit val format: Format[BecomeLeadJourney] = Json.format[BecomeLeadJourney]
 
   object FormUrls {
-
     val BecomeLead = "become-lead-eori"
     val TermsAndConditions = "accept-promote-to-lead-terms"
     val Confirmation = "lead-promotion-confirmation"
+  }
+
+  object Forms {
+    case class BecomeLeadEoriFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.BecomeLead }
+    case class TermsAndConditionsFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.TermsAndConditions }
+    case class ConfirmationFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Confirmation }
+
+    object BecomeLeadEoriFormPage { implicit val becomeLeadEoriFormPageFormat: OFormat[BecomeLeadEoriFormPage] = Json.format }
+    object TermsAndConditionsFormPage { implicit val termsAndConditionsFormPageFormat: OFormat[TermsAndConditionsFormPage] = Json.format }
+    object ConfirmationFormPage { implicit val confirmationFormPageFormat: OFormat[ConfirmationFormPage] = Json.format }
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms.{AddBusinessCyaFormPage, AddBusinessFormPage, AddEoriFormPage}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 
 case class BusinessEntityJourney(
   addBusiness: AddBusinessFormPage = AddBusinessFormPage(),
@@ -29,7 +30,7 @@ case class BusinessEntityJourney(
   isLeadSelectJourney: Option[Boolean] = None
 ) extends Journey {
 
-  override protected def steps: List[FormPageBase[_]] =
+  override protected def steps: List[FormPage[_]] =
     List(
       addBusiness,
       eori,
@@ -39,8 +40,6 @@ case class BusinessEntityJourney(
 
 object BusinessEntityJourney {
 
-  import Journey._ // N.B. don't let intellij delete this
-  implicit val formPageEoriFormat: OFormat[FormPage[EORI]] = Json.format[FormPage[EORI]]
   implicit val format: Format[BusinessEntityJourney] = Json.format[BusinessEntityJourney]
 
   // TODO populate the Journey[s] from the undertaking, probably need to map them by eori
@@ -62,9 +61,9 @@ object BusinessEntityJourney {
   }
 
   object Forms {
-    case class AddBusinessFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.AddBusiness }
-    case class AddEoriFormPage(value: Form[EORI] = None) extends FormPageBase[EORI] { val uri = FormUrls.Eori }
-    case class AddBusinessCyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Cya }
+    case class AddBusinessFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.AddBusiness }
+    case class AddEoriFormPage(value: Form[EORI] = None) extends FormPage[EORI] { val uri = FormUrls.Eori }
+    case class AddBusinessCyaFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.Cya }
 
     object AddBusinessFormPage { implicit val addBusinessFormPageFormat: OFormat[AddBusinessFormPage] = Json.format }
     object AddEoriFormPage { implicit val addEoriFormPageFormat: OFormat[AddEoriFormPage] = Json.format }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
@@ -35,7 +35,6 @@ case class BusinessEntityJourney(
       eori,
       cya,
     )
-
 }
 
 object BusinessEntityJourney {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
@@ -16,23 +16,25 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
+import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Format, Json, OFormat}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.FormUrls._
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms.{AddBusinessCyaFormPage, AddBusinessFormPage, AddEoriFormPage}
 
 case class BusinessEntityJourney(
-  addBusiness: FormPage[Boolean] = FormPage(AddBusiness),
-  eori: FormPage[EORI] = FormPage(Eori),
-  cya: FormPage[Boolean] = FormPage(Cya),
+  addBusiness: AddBusinessFormPage = AddBusinessFormPage(),
+  eori: AddEoriFormPage = AddEoriFormPage(),
+  cya: AddBusinessCyaFormPage = AddBusinessCyaFormPage(),
   isLeadSelectJourney: Option[Boolean] = None
 ) extends Journey {
 
-  override protected def steps: List[FormPage[_]] = List(
-    addBusiness,
-    eori,
-    cya
-  )
+  override protected def steps: List[FormPageBase[_]] =
+    List(
+      addBusiness,
+      eori,
+      cya,
+    )
 
 }
 
@@ -45,22 +47,29 @@ object BusinessEntityJourney {
   // TODO populate the Journey[s] from the undertaking, probably need to map them by eori
   def fromUndertakingOpt(undertakingOpt: Option[Undertaking]): BusinessEntityJourney = BusinessEntityJourney()
 
-  def businessEntityJourneyForEori(undertakingOpt: Option[Undertaking], eori: EORI): BusinessEntityJourney =
-    undertakingOpt match {
-      case Some(undertaking) =>
-        val empty = BusinessEntityJourney()
-        empty.copy(
-          empty.addBusiness.copy(value = Some(true)),
-          empty.eori.copy(value = Some(eori))
-        )
-      // TODO - what is the correct behaviour here?
-      case None => BusinessEntityJourney()
+  def businessEntityJourneyForEori(undertakingOpt: Option[Undertaking], eori: EORI): BusinessEntityJourney = {
+    undertakingOpt.fold(BusinessEntityJourney()) { _ =>
+      BusinessEntityJourney(
+        addBusiness = AddBusinessFormPage(true.some),
+        eori = AddEoriFormPage(eori.some)
+      )
     }
+  }
 
   object FormUrls {
     val AddBusiness = "add-member"
     val Eori = "add-business-entity-eori"
     val Cya = "check-your-answers-businesses"
+  }
+
+  object Forms {
+    case class AddBusinessFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.AddBusiness }
+    case class AddEoriFormPage(value: Form[EORI] = None) extends FormPageBase[EORI] { val uri = FormUrls.Eori }
+    case class AddBusinessCyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Cya }
+
+    object AddBusinessFormPage { implicit val addBusinessFormPageFormat: OFormat[AddBusinessFormPage] = Json.format }
+    object AddEoriFormPage { implicit val addEoriFormPageFormat: OFormat[AddEoriFormPage] = Json.format }
+    object AddBusinessCyaFormPage { implicit val cyaFormPageFormat: OFormat[AddBusinessCyaFormPage] = Json.format }
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import play.api.libs.json._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls._
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 
 case class EligibilityJourney(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -63,6 +63,7 @@ case class EligibilityJourney(
   private def removeSignOutBadEoriIfEoriCheckPassed(f: FormPage[_]) =
     predicate(f, SignOutBadEori)(eoriCheck.value.contains(true))
 
+  // TODO - review usage of URI here - should be replaced with something else
   private def predicate(f: FormPage[_], uri: String)(p: Boolean) = f.uri == uri && p
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -20,6 +20,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls._
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 
 case class EligibilityJourney(
   customsWaivers: CustomsWaiversFormPage = CustomsWaiversFormPage(),
@@ -45,36 +46,34 @@ case class EligibilityJourney(
     createUndertaking
   )
 
-  override protected def steps: List[FormPageBase[_]] =
+  override protected def steps: List[FormPage[_]] =
     journeySteps
       .filterNot(removeWillYouClaimIfDoYouClaimTrue)
       .filterNot(removeNotEligibleIfCustomsWaiversClaimed)
       .filterNot(removeSignOutIfMainBusinessCheckPassed)
       .filterNot(removeSignOutBadEoriIfEoriCheckPassed)
 
-  private def removeWillYouClaimIfDoYouClaimTrue(f: FormPageBase[_]) =
+  private def removeWillYouClaimIfDoYouClaimTrue(f: FormPage[_]) =
     predicate(f, WillYouClaim)(customsWaivers.value.contains(true))
 
-  private def removeNotEligibleIfCustomsWaiversClaimed(f: FormPageBase[_]) =
+  private def removeNotEligibleIfCustomsWaiversClaimed(f: FormPage[_]) =
     predicate(f, NotEligible)(Seq(customsWaivers.value, willYouClaim.value).flatten.contains(true))
 
-  private def removeSignOutIfMainBusinessCheckPassed(f: FormPageBase[_]) =
+  private def removeSignOutIfMainBusinessCheckPassed(f: FormPage[_]) =
     predicate(f, SignOut)(mainBusinessCheck.value.contains(true))
 
-  private def removeSignOutBadEoriIfEoriCheckPassed(f: FormPageBase[_]) =
+  private def removeSignOutBadEoriIfEoriCheckPassed(f: FormPage[_]) =
     predicate(f, SignOutBadEori)(eoriCheck.value.contains(true))
 
   // TODO - review this - match on types instead of uri string?
-  private def predicate(f: FormPageBase[_], uri: String)(p: Boolean) = f.uri == uri && p
+  private def predicate(f: FormPage[_], uri: String)(p: Boolean) = f.uri == uri && p
 
 }
 
 object EligibilityJourney {
-  import Journey._ // N.B. don't let intellij delete this
 
   implicit val format: Format[EligibilityJourney] = Json.format[EligibilityJourney]
 
-  // TODO - consider introducing form classes for each page
   object FormUrls {
     val CustomsWaivers = routes.EligibilityController.getCustomsWaivers().url
     val WillYouClaim = routes.EligibilityController.getWillYouClaim().url
@@ -88,15 +87,15 @@ object EligibilityJourney {
   }
 
   object Forms {
-    case class CustomsWaiversFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.CustomsWaivers}
-    case class WillYouClaimFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.WillYouClaim}
-    case class NotEligibleFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.NotEligible}
-    case class MainBusinessCheckFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.MainBusinessCheck}
-    case class SignOutFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.SignOut}
-    case class AcceptTermsFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.AcceptTerms}
-    case class EoriCheckFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.EoriCheck}
-    case class SignOutBadEoriFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.SignOutBadEori}
-    case class CreateUndertakingFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.CreateUndertaking}
+    case class CustomsWaiversFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.CustomsWaivers}
+    case class WillYouClaimFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.WillYouClaim}
+    case class NotEligibleFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.NotEligible}
+    case class MainBusinessCheckFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.MainBusinessCheck}
+    case class SignOutFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.SignOut}
+    case class AcceptTermsFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.AcceptTerms}
+    case class EoriCheckFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.EoriCheck}
+    case class SignOutBadEoriFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.SignOutBadEori}
+    case class CreateUndertakingFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.CreateUndertaking}
 
     object CustomsWaiversFormPage { implicit val customsWaiversFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
     object WillYouClaimFormPage { implicit val willYouClaimFormPageFormat: OFormat[WillYouClaimFormPage] = Json.format }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -70,6 +70,7 @@ case class EligibilityJourney(
 
 object EligibilityJourney {
   import Journey._ // N.B. don't let intellij delete this
+
   implicit val format: Format[EligibilityJourney] = Json.format[EligibilityJourney]
 
   // TODO - consider introducing form classes for each page
@@ -97,14 +98,14 @@ object EligibilityJourney {
     case class CreateUndertakingFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.CreateUndertaking}
 
     object CustomsWaiversFormPage { implicit val customsWaiversFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object WillYouClaimFormPage { implicit val willYouClaimFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object NotEligibleFormPage { implicit val notEligibleFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object MainBusinessCheckFormPage { implicit val mainBusinessCheckFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object SignOutBadEoriFormPage { implicit val signOutFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object AcceptTermsFormPage { implicit val acceptTermsFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object EoriCheckFormPage { implicit val eoriCheckFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object SignOutFormPage { implicit val signOutFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
-    object CreateUndertakingFormPage { implicit val createUndertakingFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object WillYouClaimFormPage { implicit val willYouClaimFormPageFormat: OFormat[WillYouClaimFormPage] = Json.format }
+    object NotEligibleFormPage { implicit val notEligibleFormPageFormat: OFormat[NotEligibleFormPage] = Json.format }
+    object MainBusinessCheckFormPage { implicit val mainBusinessCheckFormPageFormat: OFormat[MainBusinessCheckFormPage] = Json.format }
+    object SignOutBadEoriFormPage { implicit val signOutFormPageFormat: OFormat[SignOutBadEoriFormPage] = Json.format }
+    object AcceptTermsFormPage { implicit val acceptTermsFormPageFormat: OFormat[AcceptTermsFormPage] = Json.format }
+    object EoriCheckFormPage { implicit val eoriCheckFormPageFormat: OFormat[EoriCheckFormPage] = Json.format }
+    object SignOutFormPage { implicit val signOutFormPageFormat: OFormat[SignOutFormPage] = Json.format }
+    object CreateUndertakingFormPage { implicit val createUndertakingFormPageFormat: OFormat[CreateUndertakingFormPage] = Json.format }
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -17,19 +17,19 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import play.api.libs.json._
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 
 case class EligibilityJourney(
-  customsWaivers: FormPage[Boolean] = FormPage(CustomsWaivers),
-  willYouClaim: FormPage[Boolean] = FormPage(WillYouClaim),
-  notEligible: FormPage[Boolean] = FormPage(NotEligible),
-  mainBusinessCheck: FormPage[Boolean] = FormPage(MainBusinessCheck),
-  signOut: FormPage[Boolean] = FormPage(SignOut),
-  acceptTerms: FormPage[Boolean] = FormPage(AcceptTerms),
-  eoriCheck: FormPage[Boolean] = FormPage(EoriCheck),
-  signOutBadEori: FormPage[Boolean] = FormPage(SignOutBadEori),
-  createUndertaking: FormPage[Boolean] = FormPage(CreateUndertaking)
+  customsWaivers: CustomsWaiversFormPage = CustomsWaiversFormPage(),
+  willYouClaim: WillYouClaimFormPage = WillYouClaimFormPage(),
+  notEligible: NotEligibleFormPage = NotEligibleFormPage(),
+  mainBusinessCheck: MainBusinessCheckFormPage = MainBusinessCheckFormPage(),
+  signOut: SignOutFormPage = SignOutFormPage(),
+  acceptTerms: AcceptTermsFormPage = AcceptTermsFormPage(),
+  eoriCheck: EoriCheckFormPage = EoriCheckFormPage(),
+  signOutBadEori: SignOutBadEoriFormPage = SignOutBadEoriFormPage(),
+  createUndertaking: CreateUndertakingFormPage = CreateUndertakingFormPage(),
 ) extends Journey {
 
   private val journeySteps = List(
@@ -44,27 +44,27 @@ case class EligibilityJourney(
     createUndertaking
   )
 
-  override protected def steps: List[FormPage[_]] =
+  override protected def steps: List[FormPageBase[_]] =
     journeySteps
       .filterNot(removeWillYouClaimIfDoYouClaimTrue)
       .filterNot(removeNotEligibleIfCustomsWaiversClaimed)
       .filterNot(removeSignOutIfMainBusinessCheckPassed)
       .filterNot(removeSignOutBadEoriIfEoriCheckPassed)
 
-  private def removeWillYouClaimIfDoYouClaimTrue(f: FormPage[_]) =
+  private def removeWillYouClaimIfDoYouClaimTrue(f: FormPageBase[_]) =
     predicate(f, WillYouClaim)(customsWaivers.value.contains(true))
 
-  private def removeNotEligibleIfCustomsWaiversClaimed(f: FormPage[_]) =
+  private def removeNotEligibleIfCustomsWaiversClaimed(f: FormPageBase[_]) =
     predicate(f, NotEligible)(Seq(customsWaivers.value, willYouClaim.value).flatten.contains(true))
 
-  private def removeSignOutIfMainBusinessCheckPassed(f: FormPage[_]) =
+  private def removeSignOutIfMainBusinessCheckPassed(f: FormPageBase[_]) =
     predicate(f, SignOut)(mainBusinessCheck.value.contains(true))
 
-  private def removeSignOutBadEoriIfEoriCheckPassed(f: FormPage[_]) =
+  private def removeSignOutBadEoriIfEoriCheckPassed(f: FormPageBase[_]) =
     predicate(f, SignOutBadEori)(eoriCheck.value.contains(true))
 
-  // TODO - review usage of URI here - should be replaced with something else
-  private def predicate(f: FormPage[_], uri: String)(p: Boolean) = f.uri == uri && p
+  // TODO - review this - match on types instead of uri string?
+  private def predicate(f: FormPageBase[_], uri: String)(p: Boolean) = f.uri == uri && p
 
 }
 
@@ -83,6 +83,28 @@ object EligibilityJourney {
     val EoriCheck = routes.EligibilityController.getEoriCheck().url
     val SignOutBadEori = routes.EligibilityController.getIncorrectEori().url
     val CreateUndertaking = routes.EligibilityController.getCreateUndertaking().url
+  }
+
+  object Forms {
+    case class CustomsWaiversFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.CustomsWaivers}
+    case class WillYouClaimFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.WillYouClaim}
+    case class NotEligibleFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.NotEligible}
+    case class MainBusinessCheckFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.MainBusinessCheck}
+    case class SignOutFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.SignOut}
+    case class AcceptTermsFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.AcceptTerms}
+    case class EoriCheckFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.EoriCheck}
+    case class SignOutBadEoriFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.SignOutBadEori}
+    case class CreateUndertakingFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.CreateUndertaking}
+
+    object CustomsWaiversFormPage { implicit val customsWaiversFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object WillYouClaimFormPage { implicit val willYouClaimFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object NotEligibleFormPage { implicit val notEligibleFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object MainBusinessCheckFormPage { implicit val mainBusinessCheckFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object SignOutBadEoriFormPage { implicit val signOutFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object AcceptTermsFormPage { implicit val acceptTermsFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object EoriCheckFormPage { implicit val eoriCheckFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object SignOutFormPage { implicit val signOutFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
+    object CreateUndertakingFormPage { implicit val createUndertakingFormPageFormat: OFormat[CustomsWaiversFormPage] = Json.format }
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import play.api.Logger
-import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{AnyContent, Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
@@ -25,32 +24,18 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 
 import scala.concurrent.Future
 
-// TODO - Remove once transition to NewFormPage complete.
-trait FormPageBase[+T] {
-  def value: Journey.Form[T]
-  def uri: Journey.Uri
+trait FormPage[+T] {
+  val value: Journey.Form[T]
+  def uri: Uri
 }
 
-// TODO - rename to FormPage once all usages migrated.
-abstract case class NewFormPage[+T](
-  override val value: Journey.Form[T] = None,
-) extends FormPageBase[T] {
-  override val uri: Uri
-}
-
-case class FormPage[+T](
-  override val uri: Journey.Uri,
-  value: Journey.Form[T] = None,
-) extends FormPageBase[T]
-
-// TODO - this needs another pass. Potential scope for simplifying previous/next handling
 trait Journey {
 
   private val logger = Logger(getClass)
 
-  protected def steps: List[FormPageBase[_]]
+  protected def steps: List[FormPage[_]]
 
-  def formPages: List[FormPageBase[_]] = steps
+  def formPages: List[FormPage[_]] = steps
 
   // TODO strip/add the server path prefix instead of endsWith
   // TODO especially as this may not work for listings
@@ -71,7 +56,7 @@ trait Journey {
         Redirect(x._1.uri).withSession(request.session).toFuture
       }
 
-  def isEmptyFormPage(indexedFormPage: (FormPageBase[_], Int))(implicit request: Request[_]): Boolean =
+  def isEmptyFormPage(indexedFormPage: (FormPage[_], Int))(implicit request: Request[_]): Boolean =
     indexedFormPage match {
       case (formPage, index) => formPage.value.isEmpty && index < currentIndex
     }
@@ -99,14 +84,7 @@ trait Journey {
 
 object Journey {
 
-  // TODO - consider renaming this to form value
   type Form[+T] = Option[T]
   type Uri = String
-
-  // TODO - remove these once transition to new form types complete
-  implicit val formPageBooleanFormat: OFormat[FormPage[Boolean]] = Json.format[FormPage[Boolean]]
-  implicit val formPageBigDecimalFormat: OFormat[FormPage[BigDecimal]] = Json.format[FormPage[BigDecimal]]
-  implicit val formPageIntFormat: OFormat[FormPage[Int]] = Json.format[FormPage[Int]]
-  implicit val formPageStringFormat: OFormat[FormPage[String]] = Json.format[FormPage[String]]
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NewLeadJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NewLeadJourney.scala
@@ -18,23 +18,30 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.FormUrls.SelectNewLead
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.SelectNewLeadFormPage
 
-case class NewLeadJourney(selectNewLead: FormPage[EORI] = FormPage(SelectNewLead)) extends Journey {
+case class NewLeadJourney(selectNewLead: SelectNewLeadFormPage = SelectNewLeadFormPage()) extends Journey {
 
-  override def steps: List[FormPage[_]] = List(
+  override def steps: List[FormPageBase[_]] = List(
     selectNewLead
   )
 
 }
 
 object NewLeadJourney {
+  import Journey._ // N.B. don't let intellij delete this
 
   implicit val formPageEoriFormat: OFormat[FormPage[EORI]] = Json.format[FormPage[EORI]]
   implicit val format: Format[NewLeadJourney] = Json.format[NewLeadJourney]
 
   object FormUrls {
     val SelectNewLead = "select-new-lead"
+  }
+
+  object Forms {
+    // TODO - replace uris with routes lookups
+    case class SelectNewLeadFormPage(value: Form[EORI] = None) extends FormPageBase[EORI] { val uri = FormUrls.SelectNewLead }
+    object SelectNewLeadFormPage { implicit val selectNewLeadFormPageFormat: OFormat[SelectNewLeadFormPage] = Json.format }
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NewLeadJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NewLeadJourney.scala
@@ -18,20 +18,17 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.SelectNewLeadFormPage
 
 case class NewLeadJourney(selectNewLead: SelectNewLeadFormPage = SelectNewLeadFormPage()) extends Journey {
 
-  override def steps: List[FormPageBase[_]] = List(
-    selectNewLead
-  )
+  override def steps: List[FormPage[_]] = List(selectNewLead)
 
 }
 
 object NewLeadJourney {
-  import Journey._ // N.B. don't let intellij delete this
 
-  implicit val formPageEoriFormat: OFormat[FormPage[EORI]] = Json.format[FormPage[EORI]]
   implicit val format: Format[NewLeadJourney] = Json.format[NewLeadJourney]
 
   object FormUrls {
@@ -40,7 +37,7 @@ object NewLeadJourney {
 
   object Forms {
     // TODO - replace uris with routes lookups
-    case class SelectNewLeadFormPage(value: Form[EORI] = None) extends FormPageBase[EORI] { val uri = FormUrls.SelectNewLead }
+    case class SelectNewLeadFormPage(value: Form[EORI] = None) extends FormPage[EORI] { val uri = FormUrls.SelectNewLead }
     object SelectNewLeadFormPage { implicit val selectNewLeadFormPageFormat: OFormat[SelectNewLeadFormPage] = Json.format }
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -20,6 +20,7 @@ import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyRef, TraderRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{DateFormValues, NonHmrcSubsidy, OptionalEORI, OptionalTraderRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 
 case class SubsidyJourney(
@@ -33,7 +34,7 @@ case class SubsidyJourney(
   existingTransactionId: Option[SubsidyRef] = None,
 ) extends Journey {
 
-  override protected def steps: List[FormPageBase[_]] = List(
+  override protected def steps: List[FormPage[_]] = List(
     reportPayment,
     claimDate,
     claimAmount,
@@ -47,13 +48,7 @@ case class SubsidyJourney(
 }
 
 object SubsidyJourney {
-  import Journey._ // N.B. don't let intellij delete this
 
-  implicit val formPageClaimDateFormat: OFormat[FormPage[DateFormValues]] = Json.format[FormPage[DateFormValues]]
-  implicit val formPageOptionalEORIFormat: OFormat[FormPage[OptionalEORI]] = Json.format[FormPage[OptionalEORI]]
-  implicit val formPageOptionalTraderRefFormat: OFormat[FormPage[OptionalTraderRef]] =
-    Json.format[FormPage[OptionalTraderRef]]
-  implicit val formPageTraderRefFormat: OFormat[FormPage[TraderRef]] = Json.format[FormPage[TraderRef]]
   implicit val format: Format[SubsidyJourney] = Json.format[SubsidyJourney]
 
   def fromNonHmrcSubsidy(nonHmrcSubsidy: NonHmrcSubsidy): SubsidyJourney =
@@ -86,13 +81,13 @@ object SubsidyJourney {
 
   object Forms {
     // TODO - replace uris with routes lookups
-    case class ReportPaymentFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.ReportPayment }
-    case class ClaimDateFormPage(value: Form[DateFormValues] = None) extends FormPageBase[DateFormValues] { val uri = FormUrls.ClaimDateValues }
-    case class ClaimAmountFormPage(value: Form[BigDecimal] = None) extends FormPageBase[BigDecimal] { val uri = FormUrls.ClaimAmount }
-    case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPageBase[OptionalEORI] { val uri = FormUrls.AddClaimEori }
-    case class PublicAuthorityFormPage(value: Form[String] = None) extends FormPageBase[String] { val uri = FormUrls.PublicAuthority }
-    case class TraderRefFormPage(value: Form[OptionalTraderRef] = None) extends FormPageBase[OptionalTraderRef] { val uri = FormUrls.TraderReference }
-    case class CyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Cya }
+    case class ReportPaymentFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.ReportPayment }
+    case class ClaimDateFormPage(value: Form[DateFormValues] = None) extends FormPage[DateFormValues] { val uri = FormUrls.ClaimDateValues }
+    case class ClaimAmountFormPage(value: Form[BigDecimal] = None) extends FormPage[BigDecimal] { val uri = FormUrls.ClaimAmount }
+    case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPage[OptionalEORI] { val uri = FormUrls.AddClaimEori }
+    case class PublicAuthorityFormPage(value: Form[String] = None) extends FormPage[String] { val uri = FormUrls.PublicAuthority }
+    case class TraderRefFormPage(value: Form[OptionalTraderRef] = None) extends FormPage[OptionalTraderRef] { val uri = FormUrls.TraderReference }
+    case class CyaFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.Cya }
 
     object ReportPaymentFormPage { implicit val reportPaymentFormPageFormat: OFormat[ReportPaymentFormPage] = Json.format }
     object ClaimDateFormPage { implicit val claimDateFormPageFormat: OFormat[ClaimDateFormPage] = Json.format }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -20,20 +20,20 @@ import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyRef, TraderRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{DateFormValues, NonHmrcSubsidy, OptionalEORI, OptionalTraderRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.FormUrls._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 
 case class SubsidyJourney(
-  reportPayment: FormPage[Boolean] = FormPage(ReportPayment),
-  claimDate: FormPage[DateFormValues] = FormPage(ClaimDateValues),
-  claimAmount: FormPage[BigDecimal] = FormPage(ClaimAmount),
-  addClaimEori: FormPage[OptionalEORI] = FormPage(AddClaimEori),
-  publicAuthority: FormPage[String] = FormPage(PublicAuthority),
-  traderRef: FormPage[OptionalTraderRef] = FormPage(TraderReference),
-  cya: FormPage[Boolean] = FormPage(Cya),
-  existingTransactionId: Option[SubsidyRef] = None
+  reportPayment: ReportPaymentFormPage = ReportPaymentFormPage(),
+  claimDate: ClaimDateFormPage = ClaimDateFormPage(),
+  claimAmount: ClaimAmountFormPage = ClaimAmountFormPage(),
+  addClaimEori: AddClaimEoriFormPage = AddClaimEoriFormPage(),
+  publicAuthority: PublicAuthorityFormPage = PublicAuthorityFormPage(),
+  traderRef: TraderRefFormPage = TraderRefFormPage(),
+  cya: CyaFormPage = CyaFormPage(),
+  existingTransactionId: Option[SubsidyRef] = None,
 ) extends Journey {
 
-  override protected def steps: List[FormPage[_]] = List(
+  override protected def steps: List[FormPageBase[_]] = List(
     reportPayment,
     claimDate,
     claimAmount,
@@ -71,10 +71,14 @@ object SubsidyJourney {
       )
   }
 
+  // TODO - refactor these to folds
   private def getAddClaimEORI(eoriOpt: Option[EORI]) =
-    if (eoriOpt.isDefined) OptionalEORI("true", eoriOpt) else OptionalEORI("false", eoriOpt)
+    if(eoriOpt.isDefined) OptionalEORI("true", eoriOpt)
+    else OptionalEORI("false", eoriOpt)
+
   private def getAddTraderRef(traderRefOpt: Option[TraderRef]) =
-    if (traderRefOpt.isDefined) OptionalTraderRef("true", traderRefOpt) else OptionalTraderRef("false", traderRefOpt)
+    if(traderRefOpt.isDefined) OptionalTraderRef("true", traderRefOpt)
+    else OptionalTraderRef("false", traderRefOpt)
 
   object FormUrls {
     val ReportPayment = "claims"
@@ -84,6 +88,25 @@ object SubsidyJourney {
     val PublicAuthority = "add-claim-public-authority"
     val TraderReference = "add-claim-reference"
     val Cya = "check-your-answers-subsidy"
+  }
+
+  object Forms {
+    // TODO - replace uris with routes lookups
+    case class ReportPaymentFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri: Uri = SubsidyJourney.FormUrls.ReportPayment }
+    case class ClaimDateFormPage(value: Form[DateFormValues] = None) extends FormPageBase[DateFormValues] { val uri: Uri = SubsidyJourney.FormUrls.ClaimDateValues }
+    case class ClaimAmountFormPage(value: Form[BigDecimal] = None) extends FormPageBase[BigDecimal] { val uri: Uri = SubsidyJourney.FormUrls.ClaimAmount }
+    case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPageBase[OptionalEORI] { val uri: Uri = SubsidyJourney.FormUrls.AddClaimEori }
+    case class PublicAuthorityFormPage(value: Form[String] = None) extends FormPageBase[String] { val uri: Uri = SubsidyJourney.FormUrls.PublicAuthority }
+    case class TraderRefFormPage(value: Form[OptionalTraderRef] = None) extends FormPageBase[OptionalTraderRef] { val uri: Uri = SubsidyJourney.FormUrls.TraderReference }
+    case class CyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri: Uri = SubsidyJourney.FormUrls.Cya }
+
+    object ReportPaymentFormPage { implicit val reportPaymentFormPageFormat: OFormat[ReportPaymentFormPage] = Json.format }
+    object ClaimDateFormPage { implicit val claimDateFormPageFormat: OFormat[ClaimDateFormPage] = Json.format }
+    object ClaimAmountFormPage { implicit val claimAmountFormPageFormat: OFormat[ClaimAmountFormPage] = Json.format }
+    object AddClaimEoriFormPage { implicit val claimAmountFormPageFormat: OFormat[AddClaimEoriFormPage] = Json.format }
+    object PublicAuthorityFormPage { implicit val claimAmountFormPageFormat: OFormat[PublicAuthorityFormPage] = Json.format }
+    object TraderRefFormPage { implicit val claimAmountFormPageFormat: OFormat[TraderRefFormPage] = Json.format }
+    object CyaFormPage { implicit val claimAmountFormPageFormat: OFormat[CyaFormPage] = Json.format }
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -86,13 +86,13 @@ object SubsidyJourney {
 
   object Forms {
     // TODO - replace uris with routes lookups
-    case class ReportPaymentFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri: Uri = SubsidyJourney.FormUrls.ReportPayment }
-    case class ClaimDateFormPage(value: Form[DateFormValues] = None) extends FormPageBase[DateFormValues] { val uri: Uri = SubsidyJourney.FormUrls.ClaimDateValues }
-    case class ClaimAmountFormPage(value: Form[BigDecimal] = None) extends FormPageBase[BigDecimal] { val uri: Uri = SubsidyJourney.FormUrls.ClaimAmount }
-    case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPageBase[OptionalEORI] { val uri: Uri = SubsidyJourney.FormUrls.AddClaimEori }
-    case class PublicAuthorityFormPage(value: Form[String] = None) extends FormPageBase[String] { val uri: Uri = SubsidyJourney.FormUrls.PublicAuthority }
-    case class TraderRefFormPage(value: Form[OptionalTraderRef] = None) extends FormPageBase[OptionalTraderRef] { val uri: Uri = SubsidyJourney.FormUrls.TraderReference }
-    case class CyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri: Uri = SubsidyJourney.FormUrls.Cya }
+    case class ReportPaymentFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.ReportPayment }
+    case class ClaimDateFormPage(value: Form[DateFormValues] = None) extends FormPageBase[DateFormValues] { val uri = FormUrls.ClaimDateValues }
+    case class ClaimAmountFormPage(value: Form[BigDecimal] = None) extends FormPageBase[BigDecimal] { val uri = FormUrls.ClaimAmount }
+    case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPageBase[OptionalEORI] { val uri = FormUrls.AddClaimEori }
+    case class PublicAuthorityFormPage(value: Form[String] = None) extends FormPageBase[String] { val uri = FormUrls.PublicAuthority }
+    case class TraderRefFormPage(value: Form[OptionalTraderRef] = None) extends FormPageBase[OptionalTraderRef] { val uri = FormUrls.TraderReference }
+    case class CyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Cya }
 
     object ReportPaymentFormPage { implicit val reportPaymentFormPageFormat: OFormat[ReportPaymentFormPage] = Json.format }
     object ClaimDateFormPage { implicit val claimDateFormPageFormat: OFormat[ClaimDateFormPage] = Json.format }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -21,19 +21,19 @@ import play.api.libs.json.{Format, Json, OFormat}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.FormUrls
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 
 import scala.concurrent.Future
 
 case class UndertakingJourney(
-  name: FormPage[String] = FormPage(FormUrls.Name),
-  sector: FormPage[Sector] = FormPage(FormUrls.Sector),
-  cya: FormPage[Boolean] = FormPage(FormUrls.Cya),
-  confirmation: FormPage[Boolean] = FormPage(FormUrls.Confirmation),
+  name: UndertakingNameFormPage = UndertakingNameFormPage(),
+  sector: UndertakingSectorFormPage = UndertakingSectorFormPage(),
+  cya: UndertakingCyaFormPage = UndertakingCyaFormPage(),
+  confirmation: UndertakingConfirmationFormPage = UndertakingConfirmationFormPage(),
   isAmend: Boolean = false
 ) extends Journey {
 
@@ -82,9 +82,20 @@ object UndertakingJourney {
   object FormUrls {
     val Name = "undertaking-name"
     val Sector = "sector"
-    val Contact = "contact"
     val Cya = "check-your-answers"
     val Confirmation = "confirmation"
   }
 
+  object Forms {
+    // TODO - replace uris with routes lookups
+    case class UndertakingNameFormPage(value: Form[String] = None) extends FormPageBase[String] { val uri = FormUrls.Name }
+    case class UndertakingSectorFormPage(value: Form[Sector] = None) extends FormPageBase[Sector] { val uri = FormUrls.Sector }
+    case class UndertakingCyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Cya }
+    case class UndertakingConfirmationFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Confirmation }
+
+    object UndertakingNameFormPage { implicit val undertakingNameFormPage: OFormat[UndertakingNameFormPage] = Json.format }
+    object UndertakingSectorFormPage { implicit val undertakingSectorFormPage: OFormat[UndertakingSectorFormPage] = Json.format }
+    object UndertakingCyaFormPage { implicit val undertakingCyaFormPage: OFormat[UndertakingCyaFormPage] = Json.format }
+    object UndertakingConfirmationFormPage { implicit val undertakingConfirmationFormPage: OFormat[UndertakingConfirmationFormPage] = Json.format }
+  }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -23,7 +23,7 @@ import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.{Form, Uri}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 
@@ -60,9 +60,6 @@ case class UndertakingJourney(
 }
 
 object UndertakingJourney {
-  import Journey._
-
-  implicit val formPageSectorFormat: OFormat[FormPage[Sector]] = Json.format[FormPage[Sector]]
 
   implicit val format: Format[UndertakingJourney] = Json.format[UndertakingJourney]
 
@@ -88,10 +85,10 @@ object UndertakingJourney {
 
   object Forms {
     // TODO - replace uris with routes lookups
-    case class UndertakingNameFormPage(value: Form[String] = None) extends FormPageBase[String] { val uri = FormUrls.Name }
-    case class UndertakingSectorFormPage(value: Form[Sector] = None) extends FormPageBase[Sector] { val uri = FormUrls.Sector }
-    case class UndertakingCyaFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Cya }
-    case class UndertakingConfirmationFormPage(value: Form[Boolean] = None) extends FormPageBase[Boolean] { val uri = FormUrls.Confirmation }
+    case class UndertakingNameFormPage(value: Form[String] = None) extends FormPage[String] { val uri = FormUrls.Name }
+    case class UndertakingSectorFormPage(value: Form[Sector] = None) extends FormPage[Sector] { val uri = FormUrls.Sector }
+    case class UndertakingCyaFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.Cya }
+    case class UndertakingConfirmationFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] { val uri = FormUrls.Confirmation }
 
     object UndertakingNameFormPage { implicit val undertakingNameFormPage: OFormat[UndertakingNameFormPage] = Json.format }
     object UndertakingSectorFormPage { implicit val undertakingSectorFormPage: OFormat[UndertakingSectorFormPage] = Json.format }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -24,12 +24,12 @@ import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormUrls
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.Forms.{BecomeLeadEoriFormPage, TermsAndConditionsFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData._
@@ -164,8 +164,9 @@ class BecomeLeadControllerSpec
 
         "call to update new lead journey fails" in {
 
-          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) =
-            newLeadJourneyOpt.map(_.copy(becomeLeadEori = FormPage("select-new-lead")))
+          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) = {
+            newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
+          }
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Left(Error(exception)))
@@ -362,9 +363,7 @@ class BecomeLeadControllerSpec
             SingleEORIEmailParameter(eori1, undertaking1.name, undertakingRef, "removedAsLeadToOldLead")
           inSequence {
             mockAuthWithEnrolment(eori4)
-            mockGet[BecomeLeadJourney](eori4)(
-              Right(newBecomeLeadJourney.copy(acceptTerms = FormPage(FormUrls.TermsAndConditions, true.some)).some)
-            )
+            mockGet[BecomeLeadJourney](eori4)(Right(newBecomeLeadJourney.copy(acceptTerms = TermsAndConditionsFormPage(true.some)).some))
             mockRetreiveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Right(undertakingRef))
             mockAddMember(undertakingRef, businessEntity1.copy(leadEORI = false))(Right(undertakingRef))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -23,9 +23,9 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.AuditEvent.TermsAndConditionsAccepted
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls.{MainBusinessCheck, _}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EligibilityJourney, FormPage, JourneyTraverseService, Store}
-import utils.CommonTestData.{eligibilityJourney, _}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services._
+import utils.CommonTestData._
 
 class EligibilityControllerSpec
     extends ControllerSpec
@@ -152,7 +152,7 @@ class EligibilityControllerSpec
         "user has already answered te question" in {
           List(true, false).foreach { inputValue =>
             withClue(s" For input value:: $inputValue") {
-              testDisplay(EligibilityJourney(customsWaivers = FormPage(CustomsWaivers, inputValue.some)))
+              testDisplay(EligibilityJourney(customsWaivers = CustomsWaiversFormPage(inputValue.some)))
             }
 
           }
@@ -172,7 +172,7 @@ class EligibilityControllerSpec
       val eligibilityJourney = EligibilityJourney()
 
       def update(eligibilityJourneyOpt: Option[EligibilityJourney]) = eligibilityJourneyOpt
-        .map(_.copy(customsWaivers = FormPage(CustomsWaivers, true.some)))
+        .map(_.copy(customsWaivers = CustomsWaiversFormPage(true.some)))
 
       "throw technical error" when {
 
@@ -207,7 +207,7 @@ class EligibilityControllerSpec
             inSequence {
               mockAuthWithNecessaryEnrolment()
               mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
-                Right(EligibilityJourney(customsWaivers = FormPage(CustomsWaivers, true.some)))
+                Right(EligibilityJourney(customsWaivers = CustomsWaiversFormPage(true.some)))
               )
             }
             checkIsRedirect(performAction("customswaivers" -> inputValue), "/main-business-check")
@@ -277,7 +277,7 @@ class EligibilityControllerSpec
         "user has already answered the question" in {
           List(true, false).foreach { inputValue =>
             withClue(s" For input value :: $inputValue") {
-              testDisplay(EligibilityJourney(willYouClaim = FormPage(WillYouClaim, inputValue.some)))
+              testDisplay(EligibilityJourney(willYouClaim = WillYouClaimFormPage(inputValue.some)))
             }
           }
         }
@@ -295,9 +295,9 @@ class EligibilityControllerSpec
       val previousUrl = routes.EligibilityController.getCustomsWaivers().url
 
       val eligibilityJourney = EligibilityJourney(
-        willYouClaim = FormPage(WillYouClaim, false.some)
+        willYouClaim = WillYouClaimFormPage(false.some)
       )
-      val updatedEligibilityJourney = eligibilityJourney.copy(willYouClaim = FormPage(WillYouClaim, true.some))
+      val updatedEligibilityJourney = eligibilityJourney.copy(willYouClaim = WillYouClaimFormPage(true.some))
 
       def update(ejOpt: Option[EligibilityJourney]) = ejOpt
         .map(ej => ej.copy(willYouClaim = ej.willYouClaim.copy(value = true.some)))
@@ -395,7 +395,6 @@ class EligibilityControllerSpec
 
               eligibilityJourney.mainBusinessCheck.value match {
                 case Some(value) =>
-                  println(" insde some , value is ::" + value)
                   if (value) {
                     doc.select(".govuk-back-link").attr("href") shouldBe previousUrl
                   } else {
@@ -415,13 +414,13 @@ class EligibilityControllerSpec
         }
 
         "user hasn't answered the question" in {
-          testDisplay(EligibilityJourney(mainBusinessCheck = FormPage(MainBusinessCheck, true.some)))
+          testDisplay(EligibilityJourney(mainBusinessCheck = MainBusinessCheckFormPage(true.some)))
         }
 
         "user has already answered the question" in {
           List(true, false).foreach { inputValue =>
             withClue(s" For input value :: $inputValue") {
-              testDisplay(EligibilityJourney(mainBusinessCheck = FormPage(MainBusinessCheck, inputValue.some)))
+              testDisplay(EligibilityJourney(mainBusinessCheck = MainBusinessCheckFormPage(inputValue.some)))
             }
           }
         }
@@ -439,10 +438,10 @@ class EligibilityControllerSpec
 
       val previousUrl = routes.EligibilityController.getWillYouClaim().url
       val eligibilityJourney = EligibilityJourney(
-        customsWaivers = FormPage(CustomsWaivers, false.some)
+        customsWaivers = CustomsWaiversFormPage(false.some)
       )
       val updatedEligibilityJourney =
-        eligibilityJourney.copy(mainBusinessCheck = FormPage(MainBusinessCheck, true.some))
+        eligibilityJourney.copy(mainBusinessCheck = MainBusinessCheckFormPage(true.some))
 
       def update(ejOpt: Option[EligibilityJourney]) = ejOpt
         .map(ej => ej.copy(mainBusinessCheck = ej.mainBusinessCheck.copy(value = true.some)))
@@ -544,11 +543,11 @@ class EligibilityControllerSpec
         )
 
       val eligibilityJourney = EligibilityJourney(
-        customsWaivers = FormPage(CustomsWaivers, true.some),
-        willYouClaim = FormPage(WillYouClaim, true.some),
-        notEligible = FormPage(NotEligible, true.some),
-        mainBusinessCheck = FormPage(MainBusinessCheck, true.some),
-        signOut = FormPage(SignOut, true.some)
+        customsWaivers = CustomsWaiversFormPage(true.some),
+        willYouClaim = WillYouClaimFormPage(true.some),
+        notEligible = NotEligibleFormPage(true.some),
+        mainBusinessCheck = MainBusinessCheckFormPage(true.some),
+        signOut = SignOutFormPage(true.some)
       )
 
       def update(ejOpt: Option[EligibilityJourney]) = ejOpt
@@ -567,7 +566,7 @@ class EligibilityControllerSpec
 
       "redirect to next page" in {
         val expectedAuditEvent = TermsAndConditionsAccepted(eori1)
-        val updatedJourney     = eligibilityJourney.copy(acceptTerms = FormPage(AcceptTerms, true.some))
+        val updatedJourney = eligibilityJourney.copy(acceptTerms = AcceptTermsFormPage(true.some))
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Right(updatedJourney))
@@ -634,7 +633,7 @@ class EligibilityControllerSpec
         }
 
         "user hasn't answered the question" in {
-          testDisplay(EligibilityJourney(acceptTerms = FormPage(AcceptTerms, true.some)))
+          testDisplay(EligibilityJourney(acceptTerms = AcceptTermsFormPage(true.some)))
         }
 
         "user has already answered the question" in {
@@ -642,8 +641,8 @@ class EligibilityControllerSpec
             withClue(s" For input value :: $inputValue") {
               testDisplay(
                 EligibilityJourney(
-                  acceptTerms = FormPage(AcceptTerms, true.some),
-                  eoriCheck = FormPage(EoriCheck, inputValue.some)
+                  acceptTerms = AcceptTermsFormPage(true.some),
+                  eoriCheck = EoriCheckFormPage(inputValue.some)
                 )
               )
             }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{Dou
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms.AddEoriFormPage
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EscService, FormPage, NewLeadJourney, RetrieveEmailService, SendEmailService, Store}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData._
@@ -43,7 +44,7 @@ class SelectNewLeadControllerSpec
     with RetrieveEmailSupport
     with SendEmailSupport {
 
-  val mockEscService = mock[EscService]
+  private val mockEscService = mock[EscService]
 
   override def overrideBindings = List(
     bind[AuthConnector].toInstance(mockAuthConnector),
@@ -68,9 +69,9 @@ class SelectNewLeadControllerSpec
     )
   )
 
-  val controller = instanceOf[SelectNewLeadController]
+  private val controller = instanceOf[SelectNewLeadController]
 
-  def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
+  private def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
     (mockEscService
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
@@ -376,10 +377,7 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockUpdate[BusinessEntityJourney](
-              _ => update(businessEntityJourneyLead.copy(eori = FormPage("add-business-entity-eori", eori4.some)).some),
-              eori1
-            )(Left(Error(exception)))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourneyLead.copy(eori = AddEoriFormPage(eori4.some)).some), eori1)(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -391,15 +389,8 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockUpdate[BusinessEntityJourney](
-              _ =>
-                update(
-                  businessEntityJourneyLead
-                    .copy(eori = FormPage("add-business-entity-eori", eori4.some))
-                    .some
-                ),
-              eori1
-            )(Right(businessEntityJourneyLead))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourneyLead
+              .copy(eori = AddEoriFormPage(eori4.some)).some), eori1)(Right(businessEntityJourneyLead))
 
             mockPut[NewLeadJourney](NewLeadJourney(), eori)(Left(Error(exception)))
           }
@@ -414,15 +405,8 @@ class SelectNewLeadControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
           mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-          mockUpdate[BusinessEntityJourney](
-            _ =>
-              update(
-                businessEntityJourneyLead
-                  .copy(eori = FormPage("add-business-entity-eori", eori4.some))
-                  .some
-              ),
-            eori1
-          )(Right(businessEntityJourneyLead))
+          mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourneyLead
+            .copy(eori = AddEoriFormPage(eori4.some)).some), eori1)(Right(businessEntityJourneyLead))
           mockPut[NewLeadJourney](NewLeadJourney(), eori)(Right(NewLeadJourney()))
         }
         checkPageIsDisplayed(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -21,8 +21,8 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, JourneyTraverseService, Store, SubsidyJourney}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -231,8 +231,8 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(Some(subsidyJourney)))
-            mockUpdate[SubsidyJourney](j => j.map(_.copy(claimDate = FormPage("claim-date", updatedDate.some))), eori1)(
-              Right(subsidyJourney.copy(claimDate = FormPage("claim-date", updatedDate.some)))
+            mockUpdate[SubsidyJourney](j => j.map(_.copy(claimDate = ClaimDateFormPage(updatedDate.some))), eori1)(
+              Right(subsidyJourney.copy(claimDate = ClaimDateFormPage(updatedDate.some)))
             )
           }
           checkIsRedirect(
@@ -316,8 +316,8 @@ class SubsidyControllerSpec
         "user hasn't already answered the question" in {
           test(
             SubsidyJourney(
-              reportPayment = FormPage(ReportPayment, true.some),
-              claimDate = FormPage(ClaimDateValues, DateFormValues("9", "10", "2022").some)
+              reportPayment = ReportPaymentFormPage(true.some),
+              claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some)
             )
           )
         }
@@ -325,9 +325,9 @@ class SubsidyControllerSpec
         "user has already answered the question" in {
           test(
             SubsidyJourney(
-              reportPayment = FormPage(ReportPayment, true.some),
-              claimDate = FormPage(ClaimDateValues, DateFormValues("9", "10", "2022").some),
-              claimAmount = FormPage(ClaimAmount, BigDecimal(123.45).some)
+              reportPayment = ReportPaymentFormPage(true.some),
+              claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some),
+              claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some)
             )
           )
         }
@@ -382,12 +382,12 @@ class SubsidyControllerSpec
         "call to update the subsidy journey fails" in {
 
           val subsidyJourneyOpt = SubsidyJourney(
-            reportPayment = FormPage(ReportPayment, true.some),
-            claimDate = FormPage(ClaimDateValues, DateFormValues("9", "10", "2022").some)
+            reportPayment = ReportPaymentFormPage(true.some),
+            claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some)
           ).some
 
           def update(subsidyJourneyOpt: Option[SubsidyJourney]) =
-            subsidyJourneyOpt.map(_.copy(claimAmount = FormPage(ClaimAmount, BigDecimal(123.45).some)))
+            subsidyJourneyOpt.map(_.copy(claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some)))
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourneyOpt))
@@ -402,8 +402,8 @@ class SubsidyControllerSpec
         def displayError(data: (String, String)*)(errorMessageKey: String) = {
 
           val subsidyJourneyOpt = SubsidyJourney(
-            reportPayment = FormPage(ReportPayment, true.some),
-            claimDate = FormPage(ClaimDateValues, DateFormValues("9", "10", "2022").some)
+            reportPayment = ReportPaymentFormPage(true.some),
+            claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some)
           ).some
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -438,18 +438,18 @@ class SubsidyControllerSpec
       "redirect to next page" in {
 
         val subsidyJourney = SubsidyJourney(
-          reportPayment = FormPage(ReportPayment, true.some),
-          claimDate = FormPage(ClaimDateValues, DateFormValues("9", "10", "2022").some),
-          claimAmount = FormPage(ClaimAmount, BigDecimal(123.45).some)
+          reportPayment = ReportPaymentFormPage(true.some),
+          claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some),
+          claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some)
         )
 
         val subsidyJourneyOpt = SubsidyJourney(
-          reportPayment = FormPage(ReportPayment, true.some),
-          claimDate = FormPage(ClaimDateValues, DateFormValues("9", "10", "2022").some)
+          reportPayment = ReportPaymentFormPage(true.some),
+          claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some)
         ).some
 
         def update(subsidyJourneyOpt: Option[SubsidyJourney]) =
-          subsidyJourneyOpt.map(_.copy(claimAmount = FormPage(ClaimAmount, BigDecimal(123.45).some)))
+          subsidyJourneyOpt.map(_.copy(claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some)))
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockGet[SubsidyJourney](eori1)(Right(subsidyJourneyOpt))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -22,11 +22,11 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{DateFormValues, Error, NonHmrcSubsidy, OptionalEORI, OptionalTraderRef, SubsidyRetrieve, Undertaking, UndertakingSubsidies}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.FormUrls.{ClaimAmount, ClaimDateValues, ReportPayment}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, FormPage, JourneyTraverseService, Store, SubsidyJourney}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, JourneyTraverseService, Store, SubsidyJourney}
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.CommonTestData.{subsidyJourney, _}
+import utils.CommonTestData._
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -237,7 +237,7 @@ class SubsidyControllerSpec
           }
           checkIsRedirect(
             performAction("day" -> updatedDate.day, "month" -> updatedDate.month, "year" -> updatedDate.year),
-            "add-claim-date"
+            SubsidyJourney.FormUrls.ClaimAmount
           )
         }
       }
@@ -492,7 +492,7 @@ class SubsidyControllerSpec
 
       "display the page" when {
 
-        def test(subsidyJourney: SubsidyJourney) = {
+        def test(subsidyJourney: SubsidyJourney): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
@@ -519,22 +519,17 @@ class SubsidyControllerSpec
         }
 
         "the user hasn't already answered the question" in {
-          test(subsidyJourney.copy(addClaimEori = FormPage("add-claim-eori", None)))
-
+          test(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage( None)))
         }
 
         "the user has already answered the question" in {
-          List(
-            subsidyJourney,
-            subsidyJourney.copy(addClaimEori = FormPage("add-claim-eori", OptionalEORI("false", None).some))
-          )
+          List(subsidyJourney,
+            subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(OptionalEORI("false", None).some)))
             .foreach { subsidyJourney =>
               withClue(s" for each subsidy journey $subsidyJourney") {
                 test(subsidyJourney)
               }
-
             }
-
         }
 
       }
@@ -562,15 +557,12 @@ class SubsidyControllerSpec
         "call to update subsidy journey fails" in {
 
           def update(subsidyJourneyOpt: Option[SubsidyJourney]) =
-            subsidyJourneyOpt.map(_.copy(addClaimEori = FormPage("add-claim-eori", OptionalEORI("false", None).some)))
+            subsidyJourneyOpt.map(_.copy(addClaimEori = AddClaimEoriFormPage(OptionalEORI("false", None).some)))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[SubsidyJourney](eori1)(Right("add-claim-amount"))
-            mockUpdate[SubsidyJourney](
-              _ => update(subsidyJourney.copy(addClaimEori = FormPage("add-claim-eori", None)).some),
-              eori1
-            )(Left(Error(exception)))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(None)).some), eori1)(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction("should-claim-eori" -> "false")))
         }
@@ -578,7 +570,10 @@ class SubsidyControllerSpec
 
       "show form error" when {
 
-        def testFormError(inputAnswer: Option[List[(String, String)]], errorMessageKey: String) = {
+        def testFormError(
+          inputAnswer: Option[List[(String, String)]],
+          errorMessageKey: String
+        ): Unit = {
           val answers = inputAnswer.getOrElse(Nil)
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -606,11 +601,10 @@ class SubsidyControllerSpec
       "redirect to next page" when {
 
         def update(subsidyJourneyOpt: Option[SubsidyJourney], formValues: Option[OptionalEORI]) =
-          subsidyJourneyOpt.map(_.copy(addClaimEori = FormPage("add-claim-eori", formValues)))
+          subsidyJourneyOpt.map(_.copy(addClaimEori = AddClaimEoriFormPage(formValues)))
 
-        def testRedirect(optionalEORI: OptionalEORI, inputAnswer: List[(String, String)]) = {
-          val updatedSubsidyJourney =
-            update(subsidyJourney.some, optionalEORI.some).getOrElse(sys.error(" no subsdy journey"))
+        def testRedirect(optionalEORI: OptionalEORI, inputAnswer: List[(String, String)]): Unit = {
+          val updatedSubsidyJourney = update(subsidyJourney.some, optionalEORI.some).getOrElse(sys.error("no subsidy journey"))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -673,12 +667,11 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(Some(subsidyJourney)))
-            mockUpdate[SubsidyJourney](
-              j => j.map(_.copy(publicAuthority = FormPage("add-claim-reference", Some("My Authority")))),
-              eori1
-            )(Right(subsidyJourney.copy(publicAuthority = FormPage("add-claim-reference", Some("My Authority")))))
+            mockUpdate[SubsidyJourney](j => j.map(_.copy(publicAuthority = PublicAuthorityFormPage(Some("My Authority")))), eori1)(
+              Right(subsidyJourney.copy(publicAuthority = PublicAuthorityFormPage(Some("My Authority"))))
+            )
           }
-          checkIsRedirect(performAction("claim-public-authority" -> "My Authority"), "claims")
+          checkIsRedirect(performAction("claim-public-authority" -> "My Authority"), SubsidyJourney.FormUrls.TraderReference)
         }
       }
     }
@@ -709,7 +702,7 @@ class SubsidyControllerSpec
 
       "display the page" when {
 
-        def test(subsidyJourney: SubsidyJourney) = {
+        def test(subsidyJourney: SubsidyJourney): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
@@ -735,18 +728,15 @@ class SubsidyControllerSpec
         }
 
         "the user hasn't already answered the question" in {
-          test(
-            subsidyJourney
-              .copy(traderRef = FormPage("add-claim-reference"), cya = FormPage("check-your-answers-subsidy"))
-          )
-
+          test(subsidyJourney.copy(
+            traderRef = TraderRefFormPage(),
+            cya = CyaFormPage(),
+          ))
         }
 
         "the user has already answered the question" in {
-          List(
-            subsidyJourney,
-            subsidyJourney.copy(traderRef = FormPage("add-claim-reference", OptionalTraderRef("false", None).some))
-          )
+          List(subsidyJourney,
+            subsidyJourney.copy(traderRef = TraderRefFormPage(OptionalTraderRef("false", None).some)))
             .foreach { subsidyJourney =>
               withClue(s" for each subsidy journey $subsidyJourney") {
                 test(subsidyJourney)
@@ -781,7 +771,9 @@ class SubsidyControllerSpec
 
       "show form error" when {
 
-        def testFormError(inputAnswer: Option[List[(String, String)]], errorMessageKey: String) = {
+        def testFormError(
+          inputAnswer: Option[List[(String, String)]],
+          errorMessageKey: String): Unit = {
           val answers = inputAnswer.getOrElse(Nil)
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -801,7 +793,6 @@ class SubsidyControllerSpec
 
         "yes is selected but no trader reference is added" in {
           testFormError(Some(List("should-store-trader-ref" -> "true")), "add-claim-trader-reference.error.isempty")
-
         }
 
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -440,8 +440,6 @@ class UndertakingControllerSpec
           def updateFunc(undertakingJourneyOpt: Option[UndertakingJourney]) =
             undertakingJourneyOpt.map(x => x.copy(cya = x.cya.copy(value = true.some)))
 
-          val updatedUndertakingJourney =
-            undertakingJourneyComplete.copy(cya = FormPage("check-your-answers", false.some))
           val updatedUndertakingJourney = undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
@@ -461,7 +459,7 @@ class UndertakingControllerSpec
             undertakingJourneyOpt.map(x => x.copy(cya = x.cya.copy(value = true.some)))
 
           val updatedUndertakingJourney =
-            undertakingJourneyComplete.copy(cya = FormPage("check-your-answers", false.some))
+            undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Language, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData._
@@ -166,8 +167,9 @@ class UndertakingControllerSpec
         val exception = new Exception("oh no")
         "call to update undertaking journey fails" in {
 
-          def update(undertakingJourneyOpt: Option[UndertakingJourney]) =
-            undertakingJourneyOpt.map(_.copy(name = FormPage("undertaking-name", "TestUndertaking123".some)))
+          def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+            undertakingJourneyOpt.map(_.copy(name = UndertakingNameFormPage("TestUndertaking123".some)))
+          }
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -194,11 +196,11 @@ class UndertakingControllerSpec
       "redirect to next page" when {
 
         def test(undertakingJourney: UndertakingJourney, nextCall: String): Unit = {
-          def update(undertakingJourneyOpt: Option[UndertakingJourney]) =
-            undertakingJourneyOpt.map(_.copy(name = FormPage("undertaking-name", "TestUndertaking123".some)))
+          def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+            undertakingJourneyOpt.map(_.copy(name = UndertakingNameFormPage("TestUndertaking123".some)))
+          }
 
-          val updatedUndertaking =
-            undertakingJourney.copy(name = FormPage("undertaking-name", "TestUndertaking123".some))
+          val updatedUndertaking = undertakingJourney.copy(name = UndertakingNameFormPage("TestUndertaking123".some))
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockUpdate[UndertakingJourney](_ => update(undertakingJourney.some), eori1)(Right(updatedUndertaking))
@@ -288,19 +290,15 @@ class UndertakingControllerSpec
         }
 
         "user has not already answered the question (normal add undertaking journey)" in {
-          test(
-            undertakingJourney = UndertakingJourney(name = FormPage("undertaking-name", "TestUndertaking1".some)),
+          test(undertakingJourney = UndertakingJourney(name = UndertakingNameFormPage("TestUndertaking1".some)),
             previousCall = "undertaking-name",
             inputValue = None
           )
         }
 
         "user has already answered the question (normal add undertaking journey)" in {
-          test(
-            undertakingJourney = UndertakingJourney(
-              name = FormPage("undertaking-name", "TestUndertaking1".some),
-              sector = FormPage("sector", Sector(2).some)
-            ),
+          test(undertakingJourney = UndertakingJourney(name = UndertakingNameFormPage("TestUndertaking1".some),
+            sector = UndertakingSectorFormPage(Sector(2).some)),
             previousCall = routes.UndertakingController.getCheckAnswers().url,
             inputValue = "2".some
           )
@@ -325,8 +323,9 @@ class UndertakingControllerSpec
             .withFormUrlEncodedBody(data: _*)
         )
 
-      def update(undertakingJourneyOpt: Option[UndertakingJourney]) =
-        undertakingJourneyOpt.map(_.copy(sector = FormPage("sector", Sector(1).some)))
+      def update(undertakingJourneyOpt: Option[UndertakingJourney]) = {
+        undertakingJourneyOpt.map(_.copy(sector = UndertakingSectorFormPage(Sector(1).some)))
+      }
 
       "throw technical error" when {
         val exception = new Exception("oh no")
@@ -340,7 +339,7 @@ class UndertakingControllerSpec
         }
 
         "call to update undertaking journey fails" in {
-          val currentUndertaking = UndertakingJourney(name = FormPage("undertaking-name", "TestUndertaking".some))
+          val currentUndertaking = UndertakingJourney(name = UndertakingNameFormPage("TestUndertaking".some))
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
@@ -372,7 +371,7 @@ class UndertakingControllerSpec
 
         def test(undertakingJourney: UndertakingJourney, nextCall: String): Unit = {
 
-          val newSector = FormPage("sector", Sector(3).some)
+          val newSector = UndertakingSectorFormPage(Sector(3).some)
 
           def update(undertakingJourneyOpt: Option[UndertakingJourney]) =
             undertakingJourneyOpt.map(_.copy(sector = newSector))
@@ -431,10 +430,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](
-              _ => updateFunc(undertakingJourneyComplete.copy(cya = FormPage("check-your-answers", false.some)).some),
-              eori1
-            )(Left(Error(exception)))
+            mockUpdate[UndertakingJourney](_ => updateFunc(undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some)).some), eori1)(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
         }
@@ -446,6 +442,7 @@ class UndertakingControllerSpec
 
           val updatedUndertakingJourney =
             undertakingJourneyComplete.copy(cya = FormPage("check-your-answers", false.some))
+          val updatedUndertakingJourney = undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -486,8 +483,7 @@ class UndertakingControllerSpec
           def updateFunc(ujOpt: Option[UndertakingJourney]) =
             ujOpt.map(x => x.copy(cya = x.cya.copy(value = true.some)))
 
-          val updatedUndertakingJourney =
-            undertakingJourneyComplete.copy(cya = FormPage("check-your-answers", false.some))
+          val updatedUndertakingJourney = undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -691,9 +687,7 @@ class UndertakingControllerSpec
         "call to update undertaking journey passes but return undertaking with no name" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(
-              Right(undertakingJourneyComplete.copy(name = FormPage("undertaking-name", None)))
-            )
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage())))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
 
@@ -702,9 +696,7 @@ class UndertakingControllerSpec
         "call to update undertaking journey passes but return undertaking with no secctor" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(
-              Right(undertakingJourneyComplete.copy(name = FormPage("sector", None)))
-            )
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage())))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
 
@@ -713,9 +705,7 @@ class UndertakingControllerSpec
         "call to retrieve undertaking fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(
-              Right(undertakingJourneyComplete.copy(name = FormPage("amend-undertaking", "true".some)))
-            )
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some))))
             mockRetreiveUndertaking(eori)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
@@ -724,9 +714,7 @@ class UndertakingControllerSpec
         "call to retrieve undertaking passes but no undertaking was fetched" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(
-              Right(undertakingJourneyComplete.copy(name = FormPage("amend-undertaking", "true".some)))
-            )
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some))))
             mockRetreiveUndertaking(eori)(Future.successful(None))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
@@ -735,9 +723,7 @@ class UndertakingControllerSpec
         "call to retrieve undertaking passes but  undertaking was fetched with no undertaking ref" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(
-              Right(undertakingJourneyComplete.copy(name = FormPage("amend-undertaking", "true".some)))
-            )
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some))))
             mockRetreiveUndertaking(eori)(Future.successful(undertaking1.copy(reference = None).some))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourneySpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls.{CustomsWaivers, EoriCheck, MainBusinessCheck, WillYouClaim}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms.{CustomsWaiversFormPage, EoriCheckFormPage, MainBusinessCheckFormPage, WillYouClaimFormPage}
 
 class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
@@ -43,7 +44,7 @@ class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
       "remove will you claim and notEligible steps if customs waivers form has true value" in {
         val underTest = EligibilityJourney(
-          customsWaivers = FormPage(CustomsWaivers, Some(true))
+          customsWaivers = CustomsWaiversFormPage(Some(true)),
         )
         underTest.formPages shouldBe List(
           underTest.customsWaivers,
@@ -74,8 +75,8 @@ class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
       "remove sign out step if main business check has true value" in {
         val underTest = EligibilityJourney(
-          willYouClaim = FormPage(WillYouClaim, Some(true)),
-          mainBusinessCheck = FormPage(MainBusinessCheck, Some(true))
+          willYouClaim = WillYouClaimFormPage(Some(true)),
+          mainBusinessCheck = MainBusinessCheckFormPage(Some(true)),
         )
         underTest.formPages shouldBe List(
           underTest.customsWaivers,
@@ -90,9 +91,9 @@ class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
       "remove sign out bad eori step if eori check has true value" in {
         val underTest = EligibilityJourney(
-          willYouClaim = FormPage(WillYouClaim, Some(true)),
-          mainBusinessCheck = FormPage(MainBusinessCheck, Some(true)),
-          eoriCheck = FormPage(EoriCheck, Some(true))
+          willYouClaim = WillYouClaimFormPage(Some(true)),
+          mainBusinessCheck = MainBusinessCheckFormPage(Some(true)),
+          eoriCheck = EoriCheckFormPage(Some(true)),
         )
         underTest.formPages shouldBe List(
           underTest.customsWaivers,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourneySpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls.{CustomsWaivers, EoriCheck, MainBusinessCheck, WillYouClaim}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms.{CustomsWaiversFormPage, EoriCheckFormPage, MainBusinessCheckFormPage, WillYouClaimFormPage}
 
 class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
@@ -59,7 +58,7 @@ class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
       "remove not eligible step if do you claim form has true value" in {
         val underTest = EligibilityJourney(
-          willYouClaim = FormPage(WillYouClaim, Some(true))
+          willYouClaim = WillYouClaimFormPage(Some(true))
         )
         underTest.formPages shouldBe List(
           underTest.customsWaivers,

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -164,7 +164,7 @@ object CommonTestData {
 
   val newLeadJourney = NewLeadJourney(selectNewLead = FormPage("select-new-lead", eori4.some))
 
-  val newBecomeLeadJourney = BecomeLeadJourney(becomeLeadEori = FormPage("become-lead-eori"))
+  val newBecomeLeadJourney = BecomeLeadJourney()
 
   val validEmailAddress         = EmailAddress("user@test.com")
   val inValidEmailAddress       = EmailAddress("invalid@email.com")

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAme
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendRequest
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms.{AddBusinessCyaFormPage, AddBusinessFormPage, AddEoriFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms.{AddClaimEoriFormPage, ClaimAmountFormPage, ClaimDateFormPage, PublicAuthorityFormPage, TraderRefFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 
@@ -145,20 +146,20 @@ object CommonTestData {
   )
 
   val businessEntityJourney = BusinessEntityJourney(
-    addBusiness = FormPage("add-member", true.some),
-    eori = FormPage("add-business-entity-eori", eori1.some),
-    cya = FormPage("check-your-answers-businesses", true.some)
+    addBusiness = AddBusinessFormPage(true.some),
+    eori = AddEoriFormPage(eori1.some),
+    cya = AddBusinessCyaFormPage(true.some)
   )
 
   val businessEntityJourney1 = BusinessEntityJourney(
-    addBusiness = FormPage("add-member", true.some),
-    eori = FormPage("add-business-entity-eori", eori2.some),
-    cya = FormPage("check-your-answers-businesses", true.some)
+    addBusiness = AddBusinessFormPage(true.some),
+    eori = AddEoriFormPage(eori2.some),
+    cya = AddBusinessCyaFormPage(true.some)
   )
   val businessEntityJourneyLead = BusinessEntityJourney(
-    addBusiness = FormPage("add-member", true.some),
-    eori = FormPage("add-business-entity-eori", eori2.some),
-    cya = FormPage("check-your-answers-businesses", true.some),
+    addBusiness = AddBusinessFormPage(true.some),
+    eori = AddEoriFormPage(eori2.some),
+    cya = AddBusinessCyaFormPage(true.some),
     isLeadSelectJourney = true.some
   )
 

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.Sing
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.SelectNewLeadFormPage
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 
@@ -164,7 +165,7 @@ object CommonTestData {
     isLeadSelectJourney = true.some
   )
 
-  val newLeadJourney = NewLeadJourney(selectNewLead = FormPage("select-new-lead", eori4.some))
+  val newLeadJourney = NewLeadJourney(selectNewLead = SelectNewLeadFormPage(eori4.some))
 
   val newBecomeLeadJourney = BecomeLeadJourney()
 

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAme
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendRequest
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.FormUrls.{AcceptTerms, CreateUndertaking, CustomsWaivers, EoriCheck, MainBusinessCheck, NotEligible, SignOut, SignOutBadEori, WillYouClaim}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms.{AddClaimEoriFormPage, ClaimAmountFormPage, ClaimDateFormPage, PublicAuthorityFormPage, TraderRefFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 
 import java.time.{LocalDate, LocalDateTime}
@@ -60,11 +60,11 @@ object CommonTestData {
   )
 
   val subsidyJourney = SubsidyJourney(
-    publicAuthority = FormPage("add-claim-public-authority", "Local Authority".some),
-    traderRef = FormPage("add-claim-reference", optionalTraderRef.some),
-    claimAmount = FormPage("add-claim-date", SubsidyAmount(1234.56).some),
-    addClaimEori = FormPage("add-claim-eori", optionalEORI.some),
-    claimDate = FormPage("add-claim-date", DateFormValues("1", "1", "2022").some)
+    publicAuthority = PublicAuthorityFormPage("Local Authority".some),
+    traderRef = TraderRefFormPage(optionalTraderRef.some),
+    claimAmount = ClaimAmountFormPage(SubsidyAmount(1234.56).some),
+    addClaimEori = AddClaimEoriFormPage(optionalEORI.some),
+    claimDate = ClaimDateFormPage(DateFormValues("1", "1", "2022").some)
   )
 
   val subsidyUpdate = SubsidyUpdate(

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -18,12 +18,13 @@ package utils
 
 import cats.implicits.catsSyntaxOptionId
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.transport
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, IndustrySectorLimit, Sector, SubsidyAmount, TraderRef, UndertakingName, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendRequest
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms.{AddBusinessCyaFormPage, AddBusinessFormPage, AddEoriFormPage}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms.{AddClaimEoriFormPage, ClaimAmountFormPage, ClaimDateFormPage, PublicAuthorityFormPage, TraderRefFormPage}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 
 import java.time.{LocalDate, LocalDateTime}
@@ -116,21 +117,21 @@ object CommonTestData {
   )
 
   val eligibilityJourneyNotComplete = EligibilityJourney(
-    customsWaivers = FormPage("do-you-claim-customs-waivers", true.some),
-    willYouClaim = FormPage("will-you-claim-customs-waivers", true.some),
-    notEligible = FormPage("not-eligible", false.some),
-    mainBusinessCheck = FormPage("main-business-check", true.some),
-    signOut = FormPage("not-eligible-to-lead", false.some),
-    acceptTerms = FormPage("terms-conditions", true.some)
+    customsWaivers = CustomsWaiversFormPage(true.some),
+    willYouClaim = WillYouClaimFormPage(true.some),
+    notEligible = NotEligibleFormPage(false.some),
+    mainBusinessCheck = MainBusinessCheckFormPage(true.some),
+    signOut = SignOutFormPage(false.some),
+    acceptTerms = AcceptTermsFormPage(true.some)
   )
 
   val eligibilityJourneyComplete = eligibilityJourneyNotComplete.copy(
-    eoriCheck = FormPage("eoricheck", true.some),
-    signOutBadEori = FormPage("incorrect-eori", false.some),
-    createUndertaking = FormPage("create-undertaking", true.some)
+    eoriCheck = EoriCheckFormPage(true.some),
+    signOutBadEori = SignOutBadEoriFormPage(false.some),
+    createUndertaking = CreateUndertakingFormPage(true.some)
   )
 
-  val undertakingJourneyComplete = UndertakingJourney(
+  val undertakingJourneyComplete =  UndertakingJourney(
     name = FormPage("undertaking-name", "TestUndertaking".some),
     sector = FormPage("sector", Sector(1).some),
     cya = FormPage("check-your-answers", true.some),

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.Fo
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.SelectNewLeadFormPage
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 
 import java.time.{LocalDate, LocalDateTime}
@@ -133,17 +134,17 @@ object CommonTestData {
   )
 
   val undertakingJourneyComplete =  UndertakingJourney(
-    name = FormPage("undertaking-name", "TestUndertaking".some),
-    sector = FormPage("sector", Sector(1).some),
-    cya = FormPage("check-your-answers", true.some),
-    confirmation = FormPage("confirmation", true.some)
+    name = UndertakingNameFormPage("TestUndertaking".some),
+    sector = UndertakingSectorFormPage(Sector(1).some),
+    cya = UndertakingCyaFormPage(true.some),
+    confirmation = UndertakingConfirmationFormPage(true.some)
   )
 
-  val undertakingJourneyComplete1 = UndertakingJourney(
-    name = FormPage("undertaking-name", "TestUndertaking1".some),
-    sector = FormPage("sector", Sector(2).some),
-    cya = FormPage("check-your-answers", true.some),
-    confirmation = FormPage("confirmation", true.some),
+  val undertakingJourneyComplete1 =  UndertakingJourney(
+    name = UndertakingNameFormPage("TestUndertaking1".some),
+    sector = UndertakingSectorFormPage(Sector(2).some),
+    cya = UndertakingCyaFormPage(true.some),
+    confirmation = UndertakingConfirmationFormPage(true.some),
     isAmend = true
   )
 

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -188,15 +188,15 @@ object CommonTestData {
   val emailSendRequest = EmailSendRequest(List(EmailAddress("user@test.com")), "templateId1", emailParameter)
 
   val eligibilityJourney = EligibilityJourney(
-    customsWaivers = FormPage(CustomsWaivers, true.some),
-    willYouClaim = FormPage(WillYouClaim, true.some),
-    notEligible = FormPage(NotEligible, true.some),
-    mainBusinessCheck = FormPage(MainBusinessCheck, true.some),
-    signOut = FormPage(SignOut, true.some),
-    acceptTerms = FormPage(AcceptTerms, true.some),
-    eoriCheck = FormPage(EoriCheck, true.some),
-    signOutBadEori = FormPage(SignOutBadEori, true.some),
-    createUndertaking = FormPage(CreateUndertaking, true.some)
+    customsWaivers = CustomsWaiversFormPage(true.some),
+    willYouClaim = WillYouClaimFormPage(true.some),
+    notEligible = NotEligibleFormPage(true.some),
+    mainBusinessCheck = MainBusinessCheckFormPage(true.some),
+    signOut = SignOutFormPage(true.some),
+    acceptTerms = AcceptTermsFormPage(true.some),
+    eoriCheck = EoriCheckFormPage(true.some),
+    signOutBadEori = SignOutBadEoriFormPage(true.some),
+    createUndertaking = CreateUndertakingFormPage(true.some)
   )
 
 }


### PR DESCRIPTION
Summary of changes
* revised the form type to make the URL a def so that it's not serialized and stored in mongo DB
* introduced a concrete class for each form and updated the journeys and associated test code
* removed unused implicits
* other minor tidy ups

Note - there will be a PR after this to clean up the URLs and take them from the routes reverse lookup instead of using hardcoded strings. 