### PR TITLE
Esc 364 65 66 67 68 subsidy journey audit events

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -73,7 +73,7 @@ class NoClaimNotificationController @Inject() (
               val result = for {
                 reference <- undertaking.reference.toContext
                 _ <- escService
-                  .createSubsidy(reference, SubsidyUpdate(reference, NilSubmissionDate(timeProvider.today)))
+                  .createSubsidy(reference, SubsidyUpdate(reference, NilSubmissionDate(nilSubmissionDate)))
                   .toContext
                 _ = auditService
                   .sendEvent(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -353,7 +353,7 @@ class SubsidyController @Inject() (
       _ = auditService.sendEvent[NonCustomsSubsidyUpdated](
         AuditEvent.NonCustomsSubsidyUpdated(request.authorityId, reference, subsidyJourney, timeProvider)
       )
-    } yield Redirect(routes.SubsidyController.getCheckAnswers())
+    } yield Redirect(routes.SubsidyController.c())
     result.fold(handleMissingSessionData("nonHMRC subsidy"))(identity)
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
+import cats.data.OptionT
 import play.api.data.Form
 import play.api.data.Forms.mapping
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
@@ -28,6 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, Under
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax.{FutureOptionToOptionTOps, OptionToOptionTOps}
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 import cats.data.OptionT

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -17,15 +17,18 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.audit
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{NonHmrcSubsidy, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityAddeed.BusinessDetailsAdded
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoteItself.BusinessEntityPromoteItselfDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoted.LeadPromoteDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityUpdated.BusinessDetailsUpdated
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyAmount, SubsidyRef, TraderRef, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney
+import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 
-import java.time.LocalDateTime
+import java.time.{LocalDate, LocalDateTime}
 
 sealed trait AuditEvent {
 
@@ -146,4 +149,106 @@ object AuditEvent {
     implicit val writes: Writes[BusinessEntityPromotedSelf] = Json.writes
   }
 
+  final case class NonCustomsSubsidyAdded(
+    ggDetails: String,
+    leadEori: EORI,
+    undertakingIdentifier: UndertakingRef,
+    allocationDate: LocalDate,
+    submissionDate: LocalDate,
+    publicAuthority: Option[String],
+    traderReference: Option[TraderRef],
+    nonHMRCSubsidyAmtEUR: SubsidyAmount,
+    businessEntityIdentifier: Option[EORI],
+    subsidyUsageTransactionId: Option[SubsidyRef]
+  ) extends AuditEvent {
+    override val auditType: String = "NonCustomsSubsidyAdded"
+    override val transactionName: String = "NonCustomsSubsidyAdded"
+  }
+
+  object NonCustomsSubsidyAdded {
+    def apply(
+      ggDetails: String,
+      leadEori: EORI,
+      undertakingRef: UndertakingRef,
+      subsidyJourney: SubsidyJourney,
+      timeProvider: TimeProvider
+    ): NonCustomsSubsidyAdded =
+      AuditEvent.NonCustomsSubsidyAdded(
+        ggDetails = ggDetails,
+        leadEori = leadEori,
+        undertakingIdentifier = undertakingRef,
+        allocationDate = subsidyJourney.claimDate.value
+          .map(_.toLocalDate)
+          .getOrElse(sys.error("No claimdate on SubsidyJourney")),
+        submissionDate = timeProvider.today,
+        publicAuthority = subsidyJourney.publicAuthority.value.fold(sys.error("public Authority missing"))(Some(_)),
+        traderReference =
+          subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
+        nonHMRCSubsidyAmtEUR =
+          SubsidyAmount(subsidyJourney.claimAmount.value.getOrElse(sys.error("claimAmount missing from journey"))),
+        businessEntityIdentifier =
+          subsidyJourney.addClaimEori.value.fold(sys.error("eori value missing"))(optionalEORI =>
+            optionalEORI.value.map(EORI(_))
+          ),
+        subsidyUsageTransactionId = subsidyJourney.existingTransactionId
+      )
+
+    implicit val writes: Writes[NonCustomsSubsidyAdded] = Json.writes
+  }
+
+  final case class NonCustomsSubsidyRemoved(
+    ggDetails: String,
+    undertakingIdentifier: UndertakingRef
+  ) extends AuditEvent {
+    override val auditType: String = "NonCustomsSubsidyRemoved"
+    override val transactionName: String = "NonCustomsSubsidyRemoved"
+  }
+
+  object NonCustomsSubsidyRemoved {
+    implicit val writes: Writes[NonCustomsSubsidyRemoved] = Json.writes
+  }
+
+  final case class NonCustomsSubsidyUpdated(
+    ggDetails: String,
+    undertakingIdentifier: UndertakingRef,
+    allocationDate: LocalDate,
+    submissionDate: LocalDate,
+    publicAuthority: Option[String],
+    traderReference: Option[TraderRef],
+    nonHMRCSubsidyAmtEUR: SubsidyAmount,
+    businessEntityIdentifier: Option[EORI],
+    subsidyUsageTransactionId: Option[SubsidyRef]
+  ) extends AuditEvent {
+    override val auditType: String = "NonCustomsSubsidyUpdated"
+    override val transactionName: String = "NonCustomsSubsidyUpdated"
+  }
+
+  object NonCustomsSubsidyUpdated {
+    def apply(
+      ggDetails: String,
+      undertakingRef: UndertakingRef,
+      subsidyJourney: SubsidyJourney,
+      timeProvider: TimeProvider
+    ): NonCustomsSubsidyUpdated =
+      AuditEvent.NonCustomsSubsidyUpdated(
+        ggDetails = ggDetails,
+        undertakingIdentifier = undertakingRef,
+        allocationDate = subsidyJourney.claimDate.value
+          .map(_.toLocalDate)
+          .getOrElse(sys.error("No claimdate on SubsidyJourney")),
+        submissionDate = timeProvider.today,
+        publicAuthority = subsidyJourney.publicAuthority.value.fold(sys.error("public Authority missing"))(Some(_)),
+        traderReference =
+          subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
+        nonHMRCSubsidyAmtEUR =
+          SubsidyAmount(subsidyJourney.claimAmount.value.getOrElse(sys.error("claimAmount missing from journey"))),
+        businessEntityIdentifier =
+          subsidyJourney.addClaimEori.value.fold(sys.error("eori value missing"))(optionalEORI =>
+            optionalEORI.value.map(EORI(_))
+          ),
+        subsidyUsageTransactionId = subsidyJourney.existingTransactionId
+      )
+
+    implicit val writes: Writes[NonCustomsSubsidyUpdated] = Json.writes
+  }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityUpdate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyAmount, SubsidyRef, TraderRef, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney
-import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 
 import java.time.{LocalDate, LocalDateTime}
 
@@ -170,7 +169,7 @@ object AuditEvent {
       leadEori: EORI,
       undertakingRef: UndertakingRef,
       subsidyJourney: SubsidyJourney,
-      timeProvider: TimeProvider
+      currentDate: LocalDate
     ): NonCustomsSubsidyAdded =
       AuditEvent.NonCustomsSubsidyAdded(
         ggDetails = ggDetails,
@@ -179,7 +178,7 @@ object AuditEvent {
         allocationDate = subsidyJourney.claimDate.value
           .map(_.toLocalDate)
           .getOrElse(sys.error("No claimdate on SubsidyJourney")),
-        submissionDate = timeProvider.today,
+        submissionDate = currentDate,
         publicAuthority = subsidyJourney.publicAuthority.value.fold(sys.error("public Authority missing"))(Some(_)),
         traderReference =
           subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
@@ -227,7 +226,7 @@ object AuditEvent {
       ggDetails: String,
       undertakingRef: UndertakingRef,
       subsidyJourney: SubsidyJourney,
-      timeProvider: TimeProvider
+      currentDate: LocalDate
     ): NonCustomsSubsidyUpdated =
       AuditEvent.NonCustomsSubsidyUpdated(
         ggDetails = ggDetails,
@@ -235,7 +234,7 @@ object AuditEvent {
         allocationDate = subsidyJourney.claimDate.value
           .map(_.toLocalDate)
           .getOrElse(sys.error("No claimdate on SubsidyJourney")),
-        submissionDate = timeProvider.today,
+        submissionDate = currentDate,
         publicAuthority = subsidyJourney.publicAuthority.value.fold(sys.error("public Authority missing"))(Some(_)),
         traderReference =
           subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -17,14 +17,13 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.audit
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{NonHmrcSubsidy, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityAddeed.BusinessDetailsAdded
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoteItself.BusinessEntityPromoteItselfDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoted.LeadPromoteDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityUpdated.BusinessDetailsUpdated
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyAmount, SubsidyRef, TraderRef, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 
@@ -250,5 +249,19 @@ object AuditEvent {
       )
 
     implicit val writes: Writes[NonCustomsSubsidyUpdated] = Json.writes
+  }
+
+  final case class NonCustomsSubsidyNilReturn(
+    ggDetails: String,
+    leadEori: EORI,
+    undertakingIdentifier: UndertakingRef,
+    nilSubmissionDate: LocalDate
+  ) extends AuditEvent {
+    override val auditType: String = "NonCustomsSubsidyNilReturn"
+    override val transactionName: String = "NonCustomsSubsidyNilReturn"
+  }
+
+  object NonCustomsSubsidyNilReturn {
+    implicit val writes: Writes[NonCustomsSubsidyNilReturn] = Json.writes
   }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -20,7 +20,7 @@ import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import play.api.http.Status.{NOT_FOUND, OK}
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, NonHmrcSubsidy, SubsidyRetrieve, Undertaking, UndertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.HttpResponseSyntax.HttpResponseOps
 import uk.gov.hmrc.http.HeaderCarrier
@@ -40,7 +40,7 @@ trait EscService {
   def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier
   ): Future[UndertakingRef]
-  def createSubsidy(undertakingRef: UndertakingRef, journey: SubsidyJourney)(implicit
+  def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
     hc: HeaderCarrier
   ): Future[UndertakingRef]
   def retrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(implicit hc: HeaderCarrier): Future[UndertakingSubsidies]
@@ -107,10 +107,10 @@ class EscServiceImpl @Inject() (escConnector: EscConnector)(implicit
           value.parseJSON[UndertakingRef].fold(_ => sys.error("Error in parsing  Undertaking Ref"), identity)
     }
 
-  override def createSubsidy(undertakingRef: UndertakingRef, journey: SubsidyJourney)(implicit
+  override def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
     hc: HeaderCarrier
   ): Future[UndertakingRef] =
-    escConnector.createSubsidy(undertakingRef, journey).map {
+    escConnector.createSubsidy(undertakingRef, subsidyUpdate).map {
       case Left(Error(_)) => sys.error("Error in creating subsidy")
       case Right(value) =>
         if (value.status =!= OK) sys.error("Error in creating subsidy ")

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -98,10 +98,10 @@ POST       /amend-undertaking                       uk.gov.hmrc.eusubsidycomplia
 GET        /update-email-address                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.updateEmailAddress
 POST       /update-email-address                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.postUpdateEmailAddress
 
-GET        /subsidy-delete/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getRemoveSubsidyClaim(transactionId)
-POST       /subsidy-delete/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postRemoveSubsidyClaim(transactionId)
+GET        /remove-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getRemoveSubsidyClaim(transactionId)
+POST       /remove-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postRemoveSubsidyClaim(transactionId)
 
-GET        /subsidy-change/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getChangeSubsidyClaim(transactionId)
+GET        /update-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getChangeSubsidyClaim(transactionId)
 
 GET        /no-claims-notification                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimNotification
 POST       /no-claims-notification                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.postNoClaimNotification

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -103,8 +103,8 @@ POST       /remove-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusu
 
 GET        /update-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getChangeSubsidyClaim(transactionId)
 
-GET        /no-claims-notification                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimNotification
-POST       /no-claims-notification                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.postNoClaimNotification
+GET        /non-customs-subsidy-nil-return         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimNotification
+POST       /non-customs-subsidy-nil-return         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.postNoClaimNotification
 
 GET        /no-claims-confirmation                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimConfirmation
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnectorImpl
+import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
@@ -53,7 +54,7 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
     (mockTimeProvider.today _).expects().returning(today)
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
-  val responseHeaders            = Map.empty[String, Seq[String]]
+  val responseHeaders = Map.empty[String, Seq[String]]
 
   "EscConnectorSpec" when {
 
@@ -108,7 +109,11 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
       val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/subsidy/update"
       behave like connectorBehaviourWithMockTime(
         mockPost(expectedUrl, Seq.empty, subsidyUpdate)(_),
-        () => connector.createSubsidy(undertakingRef, subsidyJourney),
+        () =>
+          connector.createSubsidy(
+            undertakingRef,
+            SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, LocalDate.now())
+          ),
         mockTimeProviderToday
       )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -22,14 +22,12 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnectorImpl
-import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import utils.CommonTestData._
 
-import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with HttpSupport with ConnectorSpec {
@@ -49,9 +47,6 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
   val mockTimeProvider = mock[TimeProvider]
 
   val connector = new EscConnectorImpl(mockHttp, new ServicesConfig(config), mockTimeProvider)
-
-  private def mockTimeProviderToday(today: LocalDate) =
-    (mockTimeProvider.today _).expects().returning(today)
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
   val responseHeaders = Map.empty[String, Seq[String]]
@@ -107,14 +102,13 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
 
     "handling request to create subsidy" must {
       val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/subsidy/update"
-      behave like connectorBehaviourWithMockTime(
+      behave like connectorBehaviour(
         mockPost(expectedUrl, Seq.empty, subsidyUpdate)(_),
         () =>
           connector.createSubsidy(
             undertakingRef,
-            SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, LocalDate.now())
-          ),
-        mockTimeProviderToday
+            subsidyUpdate
+          )
       )
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -755,10 +755,10 @@ class BusinessEntityControllerSpec
       "edit post successful for edit" when {
 
         def testRedirection(
-                             businessEntityJourney: BusinessEntityJourney,
-                             nextCall: String,
-                             resettedBusinessJourney: BusinessEntityJourney
-                           ) = {
+          businessEntityJourney: BusinessEntityJourney,
+          nextCall: String,
+          resettedBusinessJourney: BusinessEntityJourney
+        ) = {
           val businessEntity = BusinessEntity(eori2, leadEORI = false)
           val emailParametersBE =
             SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef, "addMemberEmailToBE")
@@ -768,7 +768,10 @@ class BusinessEntityControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
-            mockRemoveMember(undertakingRef, businessEntity.copy(businessEntityIdentifier = businessEntityJourney.oldEORI.get))(Right(undertakingRef))
+            mockRemoveMember(
+              undertakingRef,
+              businessEntity.copy(businessEntityIdentifier = businessEntityJourney.oldEORI.get)
+            )(Right(undertakingRef))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(validEmailAddress.some))
             mockSendEmail(validEmailAddress, emailParametersBE, "template_add_be_EN")(Right(EmailSendResult.EmailSent))
@@ -776,7 +779,7 @@ class BusinessEntityControllerSpec
             mockSendEmail(validEmailAddress, emailParametersLead, "template_add_lead_EN")(
               Right(EmailSendResult.EmailSent)
             )
-            mockSendAuditEvent(businessEntityAddedEvent)
+            mockSendAuditEvent(businessEntityUpdatedEvent)
             mockPut[BusinessEntityJourney](resettedBusinessJourney, eori1)(Right(BusinessEntityJourney()))
           }
           checkIsRedirect(performAction("cya" -> "true")(English.code), nextCall)
@@ -834,7 +837,6 @@ class BusinessEntityControllerSpec
             Future.successful(undertaking1.copy(undertakingBusinessEntity = List(be)).some)
           )
           mockPut[BusinessEntityJourney](businessEntityJourney, eori1)(Right(businessEntityJourney))
-          mockSendAuditEvent(AuditEvent.BusinessEntityUpdated("1123", eori1, eori4))
         }
         checkPageIsDisplayed(
           performAction(eori4),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -22,11 +22,14 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.NonCustomsSubsidyRemoved
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyRef, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, JourneyTraverseService, Store, SubsidyJourney}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EscService, JourneyTraverseService, Store, SubsidyJourney}
+import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.CommonTestData._
+import utils.CommonTestData.{undertakingRef, _}
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -37,15 +40,19 @@ class SubsidyControllerSpec
     with AuthSupport
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour
-    with JourneySupport {
+    with JourneySupport
+    with AuditServiceSupport {
 
   private val mockEscService = mock[EscService]
+  private val mockTimeProvider = mock[TimeProvider]
 
   override def overrideBindings = List(
     bind[AuthConnector].toInstance(mockAuthConnector),
     bind[Store].toInstance(mockJourneyStore),
     bind[EscService].toInstance(mockEscService),
-    bind[JourneyTraverseService].toInstance(mockJourneyTraverseService)
+    bind[JourneyTraverseService].toInstance(mockJourneyTraverseService),
+    bind[AuditService].toInstance(mockAuditService),
+    bind[TimeProvider].toInstance(mockTimeProvider)
   )
 
   private def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(result: Future[UndertakingSubsidies]) =
@@ -54,7 +61,34 @@ class SubsidyControllerSpec
       .expects(subsidyRetrieve, *)
       .returning(result)
 
+  private def mockRetreiveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
+    (mockEscService
+      .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
+      .expects(eori, *)
+      .returning(result)
+
+  private def mockRemoveSubsidy(reference: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(
+    result: Either[Error, UndertakingRef]
+  ) =
+    (mockEscService
+      .removeSubsidy(_: UndertakingRef, _: NonHmrcSubsidy)(_: HeaderCarrier))
+      .expects(reference, nonHmrcSubsidy, *)
+      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful(_)))
+
+  private def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
+    result: Either[Error, UndertakingRef]
+  ) =
+    (mockEscService
+      .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
+      .expects(reference, subsidyUpdate, *)
+      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful(_)))
+
+  private def mockTimeProviderToday(today: LocalDate) =
+    (mockTimeProvider.today _).expects().returning(today)
+
   private val controller = instanceOf[SubsidyController]
+  private val exception = new Exception("oh no!")
+  private val currentDate = LocalDate.of(2022, 10, 9)
 
   "SubsidyControllerSpec" when {
 
@@ -91,9 +125,11 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(SubsidyJourney().some))
             mockGet[Undertaking](eori1)(Right(undertaking.some))
+            mockTimeProviderToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieve)(
               Future(undertakingSubsidies.copy(nonHMRCSubsidyUsage = nonHMRCSubsidyUsage))
             )
+
           }
 
         "user hasn't already answered the question" in {
@@ -502,7 +538,7 @@ class SubsidyControllerSpec
             messageFromMessageKey("add-claim-eori.title"),
             { doc =>
               val selectedOptions = doc.select(".govuk-radios__input[checked]")
-              val inputText       = doc.select(".govuk-input").attr("value")
+              val inputText = doc.select(".govuk-input").attr("value")
 
               subsidyJourney.addClaimEori.value match {
                 case Some(OptionalEORI(input, eori)) =>
@@ -518,12 +554,14 @@ class SubsidyControllerSpec
         }
 
         "the user hasn't already answered the question" in {
-          test(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage( None)))
+          test(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(None)))
         }
 
         "the user has already answered the question" in {
-          List(subsidyJourney,
-            subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(OptionalEORI("false", None).some)))
+          List(
+            subsidyJourney,
+            subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(OptionalEORI("false", None).some))
+          )
             .foreach { subsidyJourney =>
               withClue(s" for each subsidy journey $subsidyJourney") {
                 test(subsidyJourney)
@@ -561,7 +599,10 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[SubsidyJourney](eori1)(Right("add-claim-amount"))
-            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(None)).some), eori1)(Left(Error(exception)))
+            mockUpdate[SubsidyJourney](
+              _ => update(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(None)).some),
+              eori1
+            )(Left(Error(exception)))
           }
           assertThrows[Exception](await(performAction("should-claim-eori" -> "false")))
         }
@@ -603,7 +644,8 @@ class SubsidyControllerSpec
           subsidyJourneyOpt.map(_.copy(addClaimEori = AddClaimEoriFormPage(formValues)))
 
         def testRedirect(optionalEORI: OptionalEORI, inputAnswer: List[(String, String)]): Unit = {
-          val updatedSubsidyJourney = update(subsidyJourney.some, optionalEORI.some).getOrElse(sys.error("no subsidy journey"))
+          val updatedSubsidyJourney =
+            update(subsidyJourney.some, optionalEORI.some).getOrElse(sys.error("no subsidy journey"))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -666,7 +708,10 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[SubsidyJourney](eori1)(Right(Some(subsidyJourney)))
-            mockUpdate[SubsidyJourney](j => j.map(_.copy(publicAuthority = PublicAuthorityFormPage(Some("My Authority")))), eori1)(
+            mockUpdate[SubsidyJourney](
+              j => j.map(_.copy(publicAuthority = PublicAuthorityFormPage(Some("My Authority")))),
+              eori1
+            )(
               Right(subsidyJourney.copy(publicAuthority = PublicAuthorityFormPage(Some("My Authority"))))
             )
           }
@@ -714,7 +759,7 @@ class SubsidyControllerSpec
             messageFromMessageKey("add-claim-trader-reference.title"),
             { doc =>
               val selectedOptions = doc.select(".govuk-radios__input[checked]")
-              val inputText       = doc.select(".govuk-input").attr("value")
+              val inputText = doc.select(".govuk-input").attr("value")
 
               subsidyJourney.traderRef.value match {
                 case Some(OptionalTraderRef(input, traderRef)) =>
@@ -730,15 +775,19 @@ class SubsidyControllerSpec
         }
 
         "the user hasn't already answered the question" in {
-          test(subsidyJourney.copy(
-            traderRef = TraderRefFormPage(),
-            cya = CyaFormPage(),
-          ))
+          test(
+            subsidyJourney.copy(
+              traderRef = TraderRefFormPage(),
+              cya = CyaFormPage()
+            )
+          )
         }
 
         "the user has already answered the question" in {
-          List(subsidyJourney,
-            subsidyJourney.copy(traderRef = TraderRefFormPage(OptionalTraderRef("false", None).some)))
+          List(
+            subsidyJourney,
+            subsidyJourney.copy(traderRef = TraderRefFormPage(OptionalTraderRef("false", None).some))
+          )
             .foreach { subsidyJourney =>
               withClue(s" for each subsidy journey $subsidyJourney") {
                 test(subsidyJourney)
@@ -773,9 +822,7 @@ class SubsidyControllerSpec
 
       "show form error" when {
 
-        def testFormError(
-          inputAnswer: Option[List[(String, String)]],
-          errorMessageKey: String): Unit = {
+        def testFormError(inputAnswer: Option[List[(String, String)]], errorMessageKey: String): Unit = {
           val answers = inputAnswer.getOrElse(Nil)
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -800,6 +847,252 @@ class SubsidyControllerSpec
       }
 
     }
+
+    "handling post remove subsidy claim" must {
+
+      def performAction(data: (String, String)*)(transactionId: String) = controller
+        .postRemoveSubsidyClaim(transactionId)(
+          FakeRequest("POST", routes.SubsidyController.getRemoveSubsidyClaim(transactionId).url)
+            .withFormUrlEncodedBody(data: _*)
+        )
+
+      "throw technical error" when {
+
+        "call to get undertaking fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
+        }
+
+        "call to get undertaking passes but comes back empty" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(None))
+          }
+          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
+        }
+
+        "call to get undertaking passes but comes back with No reference" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(undertaking1.copy(reference = None).some))
+          }
+          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
+        }
+
+        "call to retrieve subsidy fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
+            mockRetrieveSubsidy(SubsidyRetrieve(undertakingRef, None))(Future.failed(exception))
+          }
+          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
+        }
+
+        "call to remove subsidy fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
+            mockRetrieveSubsidy(SubsidyRetrieve(undertakingRef, None))(Future.successful(undertakingSubsidies1))
+            mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
+        }
+
+      }
+
+      "display page error" when {
+
+        "nothing is submitted" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
+            mockRetrieveSubsidy(SubsidyRetrieve(undertakingRef, None))(Future.successful(undertakingSubsidies1))
+          }
+          checkFormErrorIsDisplayed(
+            performAction()("TID1234"),
+            List(messageFromMessageKey("subsidy.remove.title"), messageFromMessageKey("subsidy.remove.yesno.legend"))
+              .mkString(" "),
+            messageFromMessageKey("subsidy.remove.error.required")
+          )
+        }
+      }
+
+      "redirect to next page" when {
+
+        "If user select yes" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
+            mockRetrieveSubsidy(SubsidyRetrieve(undertakingRef, None))(Future.successful(undertakingSubsidies1))
+            mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Right(undertakingRef))
+            mockSendAuditEvent[NonCustomsSubsidyRemoved](AuditEvent.NonCustomsSubsidyRemoved("1123", undertakingRef))
+          }
+          checkIsRedirect(
+            performAction("removeSubsidyClaim" -> "true")("TID1234"),
+            routes.SubsidyController.getReportPayment().url
+          )
+
+        }
+
+        "if user selects no" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+          }
+          checkIsRedirect(
+            performAction("removeSubsidyClaim" -> "false")("TID1234"),
+            routes.SubsidyController.getReportPayment().url
+          )
+
+        }
+
+      }
+    }
+
+    "handling post to check your answers" must {
+
+      def performAction(data: (String, String)*) = controller
+        .postCheckAnswers(
+          FakeRequest("POST", routes.SubsidyController.getCheckAnswers().url)
+            .withFormUrlEncodedBody(data: _*)
+        )
+
+      def update(subsidyJourneyOpt: Option[SubsidyJourney]) = subsidyJourneyOpt
+        .map(_.copy(cya = CyaFormPage(value = true.some)))
+
+      val updatedJourney = subsidyJourney.copy(cya = CyaFormPage(value = true.some))
+
+      "throw technical error" when {
+
+        "call to update subsidy journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("cya" -> "true")))
+        }
+
+        "call to fetch undertaking fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Right(updatedJourney))
+            mockRetreiveUndertaking(eori1)(Future.failed(exception))
+          }
+          assertThrows[Exception](await(performAction("cya" -> "true")))
+        }
+
+        "call to fetch undertaking come back with No reference" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Right(updatedJourney))
+            mockRetreiveUndertaking(eori1)(Future.successful(undertaking1.copy(reference = None).some))
+          }
+          assertThrows[Exception](await(performAction("cya" -> "true")))
+        }
+
+        "call to create subsidy fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Right(updatedJourney))
+            mockRetreiveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockTimeProviderToday(currentDate)
+            mockCreateSubsidy(
+              undertakingRef,
+              SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, currentDate)
+            )(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("cya" -> "true")))
+        }
+
+        "call to reset subsidy journey fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Right(updatedJourney))
+            mockRetreiveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockTimeProviderToday(currentDate)
+            mockCreateSubsidy(
+              undertakingRef,
+              SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, currentDate)
+            )(Right(undertakingRef))
+            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Left(Error(exception)))
+          }
+          assertThrows[Exception](await(performAction("cya" -> "true")))
+        }
+      }
+
+      "redirect to next page" when {
+
+        "cya page is reached via update journey" in {
+
+          val subsidyJourneyExisting = subsidyJourney.copy(existingTransactionId = SubsidyRef("TD123").some)
+          val updatedSJ = subsidyJourneyExisting.copy(cya = CyaFormPage(value = true.some))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](
+              _ => update(subsidyJourneyExisting.some),
+              eori1
+            )(Right(updatedSJ))
+            mockRetreiveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockTimeProviderToday(currentDate)
+            mockCreateSubsidy(
+              undertakingRef,
+              SubsidyController.toSubsidyUpdate(updatedSJ, undertakingRef, currentDate)
+            )(Right(undertakingRef))
+            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Right(SubsidyJourney()))
+            mockSendAuditEvent[AuditEvent.NonCustomsSubsidyUpdated](
+              AuditEvent.NonCustomsSubsidyUpdated(
+                ggDetails = "1123",
+                undertakingRef = undertakingRef,
+                subsidyJourney = updatedSJ,
+                currentDate
+              )
+            )
+          }
+
+          checkIsRedirect(
+            performAction("cya" -> "true"),
+            routes.SubsidyController.getReportPayment().url
+          )
+        }
+
+        "cya page is reached via add journey" in {
+
+          val updatedSJ = subsidyJourney.copy(cya = CyaFormPage(value = true.some))
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockUpdate[SubsidyJourney](
+              _ => update(subsidyJourney.some),
+              eori1
+            )(Right(updatedSJ))
+            mockRetreiveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockTimeProviderToday(currentDate)
+            mockCreateSubsidy(
+              undertakingRef,
+              SubsidyController.toSubsidyUpdate(updatedSJ, undertakingRef, currentDate)
+            )(Right(undertakingRef))
+            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Right(SubsidyJourney()))
+            mockSendAuditEvent[AuditEvent.NonCustomsSubsidyAdded](
+              AuditEvent.NonCustomsSubsidyAdded(
+                ggDetails = "1123",
+                leadEori = eori1,
+                undertakingRef = undertakingRef,
+                subsidyJourney = updatedSJ,
+                currentDate
+              )
+            )
+          }
+
+          checkIsRedirect(
+            performAction("cya" -> "true"),
+            routes.SubsidyController.getReportPayment().url
+          )
+        }
+      }
+
+    }
+
   }
 
 }

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -65,6 +65,8 @@ object CommonTestData {
     )
   )
 
+  val nonHmrcSubsidyList1 = nonHmrcSubsidyList.map(_.copy(subsidyUsageTransactionID = SubsidyRef("TID1234").some))
+
   val subsidyJourney = SubsidyJourney(
     publicAuthority = PublicAuthorityFormPage("Local Authority".some),
     traderRef = TraderRefFormPage(optionalTraderRef.some),
@@ -111,14 +113,16 @@ object CommonTestData {
   )
 
   val undertakingSubsidies = UndertakingSubsidies(
-    undertakingRef,
-    SubsidyAmount(1234.56),
-    SubsidyAmount(1234.56),
-    SubsidyAmount(1234.56),
-    SubsidyAmount(1234.56),
-    nonHmrcSubsidyList,
-    List.empty
+    undertakingIdentifier = undertakingRef,
+    nonHMRCSubsidyTotalEUR = SubsidyAmount(1234.56),
+    nonHMRCSubsidyTotalGBP = SubsidyAmount(1234.56),
+    hmrcSubsidyTotalEUR = SubsidyAmount(1234.56),
+    hmrcSubsidyTotalGBP = SubsidyAmount(1234.56),
+    nonHMRCSubsidyUsage = nonHmrcSubsidyList,
+    hmrcSubsidyUsage = List.empty
   )
+
+  val undertakingSubsidies1 = undertakingSubsidies.copy(nonHMRCSubsidyUsage = nonHmrcSubsidyList1)
 
   val eligibilityJourneyNotComplete = EligibilityJourney(
     customsWaivers = CustomsWaiversFormPage(true.some),

--- a/test/utils/CommonTestData.scala
+++ b/test/utils/CommonTestData.scala
@@ -219,4 +219,5 @@ object CommonTestData {
   )
 
   val businessEntityAddedEvent = AuditEvent.BusinessEntityAdded("1123", eori1, eori2)
+  val businessEntityUpdatedEvent = AuditEvent.BusinessEntityUpdated("1123", eori1, eori2)
 }


### PR DESCRIPTION
ticket details ->  audit events json as mentioned here [link](https://confluence.tools.tax.service.gov.uk/display/CIP/EU+Subsidy+Compliance+-+Transaction+Monitoring+Assessment)
It includes audit events for Non HMRC subsidy addition, remove, update and nil submission.
some code refactor and test cases included