### PR TITLE
Esc 392 393 no unverified email

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -39,7 +39,7 @@ class RetrieveEmailConnectorImpl @Inject() (http: HttpClient, servicesConfig: Se
 
   val cdsURL: String = servicesConfig.baseUrl("cds")
 
-  def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/${eori.toString}/verified-email"
+  def getUri(eori: EORI) = s"$cdsURL/customs-data-store/${eori.toString}/verified-email"
   override def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
     http
       .GET[HttpResponse](getUri(eori))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -39,7 +39,7 @@ class RetrieveEmailConnectorImpl @Inject() (http: HttpClient, servicesConfig: Se
 
   val cdsURL: String = servicesConfig.baseUrl("cds")
 
-  def getUri(eori: EORI) = s"$cdsURL/customs-data-store/${eori.toString}/verified-email"
+  def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/${eori.toString}/verified-email"
   override def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
     http
       .GET[HttpResponse](getUri(eori))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -58,7 +58,7 @@ class AccountController @Inject() (
         case EmailType.VerifiedEmail => getUndertakingAndHandleResponse
         case EmailType.UnVerifiedEmail =>
           Redirect(routes.UpdateEmailAddressController.updateUnverifiedEmailAddress()).toFuture
-        case EmailType.UndeliverableEmail =>
+        case EmailType.UnDeliverableEmail =>
           Redirect(routes.UpdateEmailAddressController.updateUndeliveredEmailAddress()).toFuture
       }
     }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 class UpdateEmailAddressController @Inject() (
   mcc: MessagesControllerComponents,
   updateUnverifiedEmailAddressPage: UpdateUnverifiedEmailPage,
-  updateUndeliverdEmailAddressPage: UpdateUndeliveredEmailAddressPage,
+  updateUndeliveredEmailAddressPage: UpdateUndeliveredEmailAddressPage,
   escActionBuilders: EscActionBuilders,
   servicesConfig: ServicesConfig
 )(implicit val appConfig: AppConfig)
@@ -48,7 +48,7 @@ class UpdateEmailAddressController @Inject() (
   }
 
   def updateUndeliveredEmailAddress: Action[AnyContent] = escAuthentication.async { implicit request =>
-    Future.successful(Ok(updateUndeliverdEmailAddressPage()))
+    Future.successful(Ok(updateUndeliveredEmailAddressPage()))
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
@@ -28,21 +28,27 @@ import scala.concurrent.Future
 @Singleton
 class UpdateEmailAddressController @Inject() (
   mcc: MessagesControllerComponents,
-  updateEmailAddressPage: UpdateEmailPage,
+  updateUnverifiedEmailAddressPage: UpdateUnverifiedEmailPage,
+  updateUndeliverdEmailAddressPage: UpdateUndeliveredEmailAddressPage,
   escActionBuilders: EscActionBuilders,
   servicesConfig: ServicesConfig
 )(implicit val appConfig: AppConfig)
     extends BaseController(mcc) {
   import escActionBuilders._
 
-  def updateEmailAddress: Action[AnyContent] = escAuthentication.async { implicit request =>
-    Future.successful(Ok(updateEmailAddressPage()))
+  val baseUrl: String = servicesConfig.baseUrl("update-email")
+  val updatedEmailUrl: String = s"$baseUrl/manage-email-cds/service/eu-subsidy-compliance-frontend"
+
+  def updateUnverifiedEmailAddress: Action[AnyContent] = escAuthentication.async { implicit request =>
+    Future.successful(Ok(updateUnverifiedEmailAddressPage()))
   }
 
   def postUpdateEmailAddress: Action[AnyContent] = escAuthentication.async { _ =>
-    val baseUrl: String = servicesConfig.baseUrl("update-email")
-    val updatedEmailUrl: String = s"$baseUrl/manage-email-cds/service/eu-subsidy-compliance-frontend"
     Future.successful(Redirect(updatedEmailUrl))
+  }
+
+  def updateUndeliveredEmailAddress: Action[AnyContent] = escAuthentication.async { implicit request =>
+    Future.successful(Ok(updateUndeliverdEmailAddressPage()))
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailType.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailType.scala
@@ -27,11 +27,9 @@ object EmailType {
 
   case object VerifiedEmail extends EmailType
 
-  case object UndeliverableEmail extends EmailType
+  case object UnDeliverableEmail extends EmailType
 
   case object UnVerifiedEmail extends EmailType
-
-  case object NoEmail extends EmailType
 
   implicit val eq: Eq[EmailType] = Eq.fromUniversalEquals
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailType.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailType.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
+
+import ai.x.play.json.Jsonx
+import ai.x.play.json.SingletonEncoder.simpleName
+import ai.x.play.json.implicits.formatSingleton
+import cats.Eq
+import play.api.libs.json.Format
+
+sealed trait EmailType extends Product with Serializable
+object EmailType {
+
+  case object VerifiedEmail extends EmailType
+
+  case object UndeliverableEmail extends EmailType
+
+  case object UnVerifiedEmail extends EmailType
+
+  case object NoEmail extends EmailType
+
+  implicit val eq: Eq[EmailType] = Eq.fromUniversalEquals
+
+  implicit val format: Format[EmailType] = Jsonx.formatSealed[EmailType]
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/RetrieveEmailResponse.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/RetrieveEmailResponse.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.EmailAddress
+
+case class RetrieveEmailResponse(emailType: EmailType, emailAddress: Option[EmailAddress])
+
+object RetrieveEmailResponse {
+  implicit val format: OFormat[RetrieveEmailResponse] = Json.format
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/UpdateUndeliveredEmailAddressPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/UpdateUndeliveredEmailAddressPage.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+@import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+
+@this(
+        layout: Layout,
+        formHelper: FormWithCSRF,
+        button: components.Button
+)
+
+@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@key = @{"updateUndeliveredEmail"}
+@layout(
+    pageTitle = Some(messages("createUndertaking.title")),
+    backLinkEnabled = false,
+    backLink = None
+) {
+    @formHelper(action = controllers.routes.UpdateEmailAddressController.postUpdateEmailAddress) {
+
+        <h1 class="govuk-heading-xl">@messages(s"$key.title")</h1>
+        <p class="govuk-body">@messages(s"$key.p1")</p>
+        <p class="govuk-body">@messages(s"$key.p2")</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>@{messages(s"$key.p3.list1")}</li>
+            <li>@{messages(s"$key.p3.list2")}</li>
+            <li>@{messages(s"$key.p3.list3")}</li>
+        </ul>
+
+        @button("common.verifyOrChangeEmail")
+    }
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/UpdateUnverifiedEmailPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/UpdateUnverifiedEmailPage.scala.html
@@ -27,17 +27,20 @@
 )
 
 @()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
-@key = @{"updateEmail"}
+@key = @{"updateUnverifiedEmail"}
+    @title = @{messages(s"$key.title")}
 @layout(
-    pageTitle = Some(messages("createUndertaking.title")),
+    pageTitle = Some(title),
     backLinkEnabled = false,
     backLink = None
 ) {
-    @formHelper(action = controllers.routes.UpdateEmailAddressController.postUpdateEmailAddress) {
+    @formHelper(action = controllers.routes.UpdateEmailAddressController.postUpdateEmailAddress()) {
 
         <h1 class="govuk-heading-xl">@messages(s"$key.title")</h1>
         <p class="govuk-body">@messages(s"$key.p1")</p>
         <p class="govuk-body">@messages(s"$key.p2")</p>
+        <p class="govuk-body">@messages(s"$key.p3")</p>
+        <p class="govuk-body">@messages(s"$key.p4")</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>@{messages(s"$key.p3.list1")}</li>
             <li>@{messages(s"$key.p3.list2")}</li>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -94,8 +94,10 @@ POST       /check-your-answers-subsidy              uk.gov.hmrc.eusubsidycomplia
 GET        /amend-undertaking                       uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getAmendUndertakingDetails
 POST       /amend-undertaking                       uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postAmendUndertaking
 
-GET        /update-email-address                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.updateEmailAddress
-POST       /update-email-address                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.postUpdateEmailAddress
+GET        /update-unverified-email-address         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.updateUnverifiedEmailAddress
+POST       /update-email-address         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.postUpdateEmailAddress
+GET        /update-undelivered-email-address        uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UpdateEmailAddressController.updateUndeliveredEmailAddress
+
 
 GET        /remove-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getRemoveSubsidyClaim(transactionId)
 POST       /remove-non-customs-subsidy/:transactionId           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postRemoveSubsidyClaim(transactionId)

--- a/conf/messages
+++ b/conf/messages
@@ -338,13 +338,26 @@ dashboard.sector.name.2 = Agriculture
 dashboard.sector.name.3 = Aquaculture
 dashboard.allowance.remaining.heading = Allowance remaining
 
-#update email address
-updateEmail.title = We cannot find a verified email address
-updateEmail.p1 = This is the email address your organisation has registered for the Customs Declaration Service(CDS). You need to verify this email address or change it. You can enter and verify the email instantly, provided you have access to the email account.
-updateEmail.p2 = This will be the only email address we use for:
-updateEmail.p3.list1 = updates on changes to the Customs Declaration Service
-updateEmail.p3.list2 = urgent updates about goods in customs
-updateEmail.p3.list3 = some financial notifications, including Direct Debit notices and VAT
+#update Unverified email address
+updateUnverifiedEmail.title = Your email has not been verified for the Customs Declaration Service (CDS)
+updateUnverifiedEmail.p1 = This email address has been registered for the Customs Declaration Service (CDS) by your organisation.
+updateUnverifiedEmail.p2 = You need to verify it, or change it.
+updateUnverifiedEmail.p3 = If you have access to the email account, you can verify the address.
+updateUnverifiedEmail.p4 = Once you have verified the email address, it will be the only one we use for:
+updateUnverifiedEmail.p3.list1 = updates on changes to the Customs Declaration Service
+updateUnverifiedEmail.p3.list2 = urgent updates about goods in customs
+updateUnverifiedEmail.p3.list3 = some financial notifications, including Direct Debit notices and VAT
+
+#update Undelivered email address
+updateUndeliveredEmail.title = There''s a problem with the CDS registered email address
+updateUndeliveredEmail.p1 = We tried to send you an email but it could not be delivered. This could be because the inbox is full, or due to a technical problem with your email provider.
+updateUndeliveredEmail.p2 =This is the email address your organisation has registered for the Customs Declaration Service (CDS). You need to verify this email address or change it. You can verify the email instantly provided you have access to the email account.
+updateUndeliveredEmail.p3 = This will be the only email address we use for:
+updateUndeliveredEmail.p3.list1 = updates on changes to the Customs Declaration Service
+updateUndeliveredEmail.p3.list2 = urgent updates about goods in customs
+updateUndeliveredEmail.p3.list3 = some financial notifications, including Direct Debit notices and VAT
+
+
 
 become-admin.title=Do you want to become the administrator for {0}
 become-admin.hint=As undertaking administrator, the business EORI number {0} will be responsible for reporting de minimis aid (less Customs Duty waivers) payments received by all businesses which are part of this single undertaking.

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -23,13 +23,12 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailType, RetrieveEmailResponse}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EligibilityJourney, EscService, RetrieveEmailService, Store, UndertakingJourney}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
-import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.NonLeadAccountPage
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData.{undertaking, _}
 
@@ -42,9 +41,9 @@ class AccountControllerSpec
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour {
 
-  val mockEscService           = mock[EscService]
-  val mockRetrieveEmailService = mock[RetrieveEmailService]
-  val mockTimeProvider         = mock[TimeProvider]
+  private val mockEscService = mock[EscService]
+  private val mockRetrieveEmailService = mock[RetrieveEmailService]
+  private val mockTimeProvider = mock[TimeProvider]
 
   override def overrideBindings = List(
     bind[AuthConnector].toInstance(mockAuthConnector),
@@ -55,20 +54,23 @@ class AccountControllerSpec
   )
 
   override def additionalConfig = super.additionalConfig.withFallback(
-    Configuration.from(Map(
-      // Disable CSP n=once hashes in rendered output
-      "play.filters.csp.nonce.enabled" -> false,
-    )))
+    Configuration.from(
+      Map(
+        // Disable CSP n=once hashes in rendered output
+        "play.filters.csp.nonce.enabled" -> false
+      )
+    )
+  )
 
   private val controller = instanceOf[AccountController]
 
-  private def mockRetreiveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
+  private def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
     (mockEscService
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
       .returning(result)
 
-  private def mockRetrieveEmail(eori: EORI)(result: Either[Error, Option[EmailAddress]]) =
+  private def mockRetrieveEmail(eori: EORI)(result: Either[Error, RetrieveEmailResponse]) =
     (mockRetrieveEmailService
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
@@ -97,11 +99,11 @@ class AccountControllerSpec
 
       "display the lead account home page" when {
 
-        def test(undertaking: Undertaking) = {
+        def test(undertaking: Undertaking): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
@@ -140,7 +142,7 @@ class AccountControllerSpec
                   routes.BusinessEntityController.getAddBusinessEntity().url
                 )
 
-              val isNonLeadEORIPresent = !undertaking.undertakingBusinessEntity.forall(_.leadEORI)
+              val isNonLeadEORIPresent = undertaking.undertakingBusinessEntity.filterNot(_.leadEORI).nonEmpty
 
               if (isNonLeadEORIPresent)
                 htmlBody should include regex messageFromMessageKey(
@@ -163,11 +165,11 @@ class AccountControllerSpec
           isTimeToReport: Boolean,
           dueDate: String,
           isOverdue: Boolean
-        ) = {
+        ): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
@@ -206,18 +208,18 @@ class AccountControllerSpec
           testTimeToReport(
             undertaking.copy(lastSubsidyUsageUpdt = LocalDate.of(2021, 12, 1).some),
             currentDate = LocalDate.of(2022, 2, 16),
-            true,
-            "1 March 2022",
-            false
+            isTimeToReport = true,
+            dueDate = "1 March 2022",
+            isOverdue = false
           )
         }
         "today's date is exactly 76 days from the last day of subsidy report " in {
           testTimeToReport(
             undertaking.copy(lastSubsidyUsageUpdt = LocalDate.of(2021, 12, 1).some),
             currentDate = LocalDate.of(2022, 2, 15),
-            true,
-            "1 March 2022",
-            false
+            isTimeToReport = true,
+            dueDate = "1 March 2022",
+            isOverdue = false
           )
         }
 
@@ -226,9 +228,9 @@ class AccountControllerSpec
           testTimeToReport(
             undertaking.copy(lastSubsidyUsageUpdt = lastUpdatedDate.some),
             currentDate = lastUpdatedDate.plusDays(91),
-            false,
-            "1 March 2022",
-            true
+            isTimeToReport = false,
+            dueDate = "1 March 2022",
+            isOverdue = true
           )
         }
 
@@ -239,8 +241,8 @@ class AccountControllerSpec
         "valid request for non-lead user is made" in {
           inSequence {
             mockAuthWithEnrolment(eori2)
-            mockRetrieveEmail(eori2)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori2)(Future.successful(undertaking.some))
+            mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori2)(Future.successful(undertaking.some))
             mockPut[Undertaking](undertaking, eori2)(Right(undertaking))
             mockGet[EligibilityJourney](eori2)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori2)(Right(UndertakingJourney().some))
@@ -276,8 +278,8 @@ class AccountControllerSpec
         "there is error in retrieving the undertaking" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(Future.failed(exception))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -286,8 +288,8 @@ class AccountControllerSpec
         "there is an error in fetching eligibility journey data" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(undertaking.some.toFuture)
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
           }
@@ -298,8 +300,8 @@ class AccountControllerSpec
         "there is an error in storing eligibility journey data" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(undertaking.some.toFuture)
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(None))
             mockPut[EligibilityJourney](EligibilityJourney(), eori1)(Left(Error(exception)))
@@ -311,8 +313,8 @@ class AccountControllerSpec
         "there is an error in retrieving  undertaking  journey data" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(undertaking.some.toFuture)
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete.some))
             mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
@@ -326,8 +328,8 @@ class AccountControllerSpec
           val undertakingData = UndertakingJourney.fromUndertaking(undertaking)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(undertaking.some.toFuture)
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(None))
@@ -341,8 +343,8 @@ class AccountControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(undertaking.some.toFuture)
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
@@ -357,8 +359,8 @@ class AccountControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(undertaking.some.toFuture)
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
@@ -372,8 +374,8 @@ class AccountControllerSpec
         "there is an error in storing Undertaking data" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-            mockRetreiveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockPut[Undertaking](undertaking, eori1)(Left(Error(exception)))
 
           }
@@ -384,12 +386,20 @@ class AccountControllerSpec
 
       "redirect to next page" when {
 
-        "No email is retrieved from cds api" in {
+        "Non verified email is retrieved from cds api" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Right(None))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.UnVerifiedEmail, validEmailAddress.some)))
           }
-          checkIsRedirect(performAction(), routes.UpdateEmailAddressController.updateEmailAddress())
+          checkIsRedirect(performAction(), routes.UpdateEmailAddressController.updateUnverifiedEmailAddress().url)
+        }
+
+        "Undeliverable email is retrieved from cds api" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.UnDeliverableEmail, validEmailAddress.some)))
+          }
+          checkIsRedirect(performAction(), routes.UpdateEmailAddressController.updateUndeliveredEmailAddress().url)
         }
 
         "email is retrieved from cds api" when {
@@ -399,8 +409,8 @@ class AccountControllerSpec
             "eligibility Journey is not complete and undertaking Journey is blank" in {
               inSequence {
                 mockAuthWithNecessaryEnrolment()
-                mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-                mockRetreiveUndertaking(eori1)(None.toFuture)
+                mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+                mockRetrieveUndertaking(eori1)(None.toFuture)
                 mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete.some))
                 mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
                 mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
@@ -411,8 +421,8 @@ class AccountControllerSpec
             "eligibility Journey  is complete and undertaking Journey is not complete" in {
               inSequence {
                 mockAuthWithNecessaryEnrolment()
-                mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-                mockRetreiveUndertaking(eori1)(Future.successful(None))
+                mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+                mockRetrieveUndertaking(eori1)(Future.successful(None))
                 mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
                 mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
                 mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
@@ -423,8 +433,8 @@ class AccountControllerSpec
             "eligibility Journey  and undertaking Journey are  complete" in {
               inSequence {
                 mockAuthWithNecessaryEnrolment()
-                mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
-                mockRetreiveUndertaking(eori1)(Future.successful(None))
+                mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+                mockRetrieveUndertaking(eori1)(Future.successful(None))
                 mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
                 mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete1.some))
                 mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, Error}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.RetrieveEmailResponse
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.RetrieveEmailService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -27,7 +28,7 @@ trait RetrieveEmailSupport { this: ControllerSpec =>
 
   val mockRetrieveEmailService = mock[RetrieveEmailService]
 
-  def mockRetrieveEmail(eori: EORI)(result: Either[Error, Option[EmailAddress]]) =
+  def mockRetrieveEmail(eori: EORI)(result: Either[Error, RetrieveEmailResponse]) =
     (mockRetrieveEmailService
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingControllerSpec.ModifyUndertakingRow
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.UndertakingUpdated
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Language, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
@@ -506,7 +506,7 @@ class UndertakingControllerSpec
               Right(updatedUndertakingJourney)
             )
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
-            mockRetrieveEmail(eori1)(Right(validEmailAddress.some))
+            mockRetrieveEmail(eori)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockSendEmail(validEmailAddress, emailParameter, templateId)(Right(EmailSendResult.EmailSent))
             mockTimeProviderNow(timeNow)
             mockSendAuditEvent(createUndertakingAuditEvent)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
@@ -70,6 +70,27 @@ class UpdateEmailAddressControllerSpec
       }
     }
 
+    "handling request to update Undelivered Email Address " must {
+
+      def performAction() = controller.updateUndeliveredEmailAddress(FakeRequest())
+
+      "display the page" in {
+        inSequence {
+          mockAuthWithNecessaryEnrolment()
+        }
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("updateUndeliveredEmail.title"),
+          { doc =>
+            val button = doc.select("form")
+            button.attr("action") shouldBe routes.UpdateEmailAddressController.postUpdateEmailAddress().url
+
+          }
+        )
+
+      }
+    }
+
     "handling request to post update email address" must {
       def performAction() = controller.postUpdateEmailAddress(FakeRequest())
       "redirect to next page" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
@@ -34,7 +34,7 @@ class UpdateEmailAddressControllerSpec
     bind[Store].toInstance(mockJourneyStore)
   )
 
-  override def additionalConfig = super.additionalConfig.withFallback(
+  override def additionalConfig: Configuration = super.additionalConfig.withFallback(
     Configuration(
       ConfigFactory.parseString(s"""
            | microservice.services.update-email {
@@ -46,20 +46,20 @@ class UpdateEmailAddressControllerSpec
     )
   )
 
-  val controller = instanceOf[UpdateEmailAddressController]
+  private val controller = instanceOf[UpdateEmailAddressController]
 
   "UpdateEmailAddressController" when {
 
-    "handling request to update Email Address " must {
+    "handling request to update Unverified Email Address " must {
 
-      def performAction() = controller.updateEmailAddress(FakeRequest())
+      def performAction() = controller.updateUnverifiedEmailAddress(FakeRequest())
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
         }
         checkPageIsDisplayed(
           performAction(),
-          messageFromMessageKey("updateEmail.title"),
+          messageFromMessageKey("updateUnverifiedEmail.title"),
           { doc =>
             val button = doc.select("form")
             button.attr("action") shouldBe routes.UpdateEmailAddressController.postUpdateEmailAddress().url


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-251
- When user logs in  and if the email address associated to EORI is not registered with CDS or unverified, then user is redirected to kickout page stating the email address is Unverified.
- if the email address is undeliverable, then user is redirected Undelivered kick out page  
- unit test cases for above scenario, some unit test cases formatting.