### PR TITLE
ESC-397 BE remove itself audit event and test case

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -360,6 +360,8 @@ class BusinessEntityController @Inject() (
                       undertakingRef,
                       removalEffectiveDateString.some
                     )
+                    _ = auditService
+                      .sendEvent(AuditEvent.BusinessEntityRemovedSelf(request.authorityId, leadEORI, loggedInEORI))
                   } yield Redirect(routes.SignOutController.signOut())
                 case _ => Future(Redirect(routes.AccountController.getAccountPage()))
               }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -108,6 +108,18 @@ object AuditEvent {
     implicit val writes: Writes[BusinessEntityRemoved] = Json.writes
   }
 
+  final case class BusinessEntityRemovedSelf(
+    ggDetails: String,
+    leadEori: EORI,
+    removedEori: EORI
+  ) extends AuditEvent {
+    override val auditType: String = "BusinessEntityRemovedSelf"
+    override val transactionName: String = "BusinessEntityRemovedSelf"
+  }
+  object BusinessEntityRemovedSelf {
+    implicit val writes: Writes[BusinessEntityRemovedSelf] = Json.writes
+  }
+
   final case class BusinessEntityUpdated(
     ggDetails: String,
     leadEori: EORI,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -1066,6 +1066,7 @@ class BusinessEntityControllerSpec
               mockSendEmail(validEmailAddress, emailParamBE, templateIdBe)(Right(EmailSendResult.EmailSent))
               mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
               mockSendEmail(validEmailAddress, emailParamLead, templateIdLead)(Right(EmailSendResult.EmailSent))
+              mockSendAuditEvent(AuditEvent.BusinessEntityRemovedSelf("1123", eori1, eori4))
             }
             checkIsRedirect(
               performAction("removeYourselfBusinessEntity" -> "true")(lang),


### PR DESCRIPTION
ticket details -> [here](https://jira.tools.tax.service.gov.uk/browse/ESC-397)
- add audit event for the process when a business entity delete itself