### PR TITLE
Esc 385 cya page

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -49,7 +49,7 @@ case class UndertakingJourney(
 
   override def previous(implicit r: Request[_]): Uri =
     if (isAmend) routes.UndertakingController.getAmendUndertakingDetails().url
-    else if (requiredDetailsProvided) routes.UndertakingController.getCheckAnswers().url
+    else if (requiredDetailsProvided && !isCurrentPageCYA) routes.UndertakingController.getCheckAnswers().url
     else previousMap.get(r.uri).getOrElse(super.previous)
 
   override def next(implicit request: Request[_]): Future[Result] =
@@ -58,6 +58,8 @@ case class UndertakingJourney(
     else super.next
 
   def isEmpty: Boolean = steps.flatMap(_.value).isEmpty
+
+  def isCurrentPageCYA(implicit request: Request[_]) = request.uri == routes.UndertakingController.getCheckAnswers().url
 
   private def requiredDetailsProvided =
     Seq(name, sector).map(_.value.isDefined) == Seq(true, true)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -612,6 +612,7 @@ class UndertakingControllerSpec
           performAction(),
           messageFromMessageKey("undertaking.cya.title"),
           { doc =>
+            doc.select(".govuk-back-link").attr("href") shouldBe routes.UndertakingController.getSector().url
             val rows =
               doc.select(".govuk-summary-list__row").iterator().asScala.toList.map { element =>
                 val question = element.select(".govuk-summary-list__key").text()


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-385

the back link on CYA page was not working because in the previous logic it was going to second else which says 
`else if (requiredDetailsProvided) routes.UndertakingController.getCheckAnswers().url`
but it should not go there if the current page is CYA page , so added the check there `&& !isCurrentPageCYA`