### PR TITLE
ESC-430 is lead eori check now caches Undertaking plus some refactors

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 import com.google.inject.{Inject, Singleton}
 import play.api.http.Status.NOT_FOUND
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidyAmendment}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidyAmendment}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, NotFoundException}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -44,81 +44,81 @@ class EscConnector @Inject() (
 
   def createUndertaking(
     undertaking: Undertaking
-  )(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
+  )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[Undertaking, HttpResponse](s"$escURL/$createUndertakingPath", undertaking)
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
   def updateUndertaking(
     undertaking: Undertaking
-  )(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
+  )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[Undertaking, HttpResponse](s"$escURL/$updateUndertakingPath", undertaking)
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
-  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
+  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
       .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
       .map(Right(_))
       .recover {
         case _: NotFoundException => Right(HttpResponse(NOT_FOUND, ""))
-        case ex => Left(Error(ex))
+        case ex => Left(ConnectorError(ex))
       }
 
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]] =
+  ): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[BusinessEntity, HttpResponse](s"$escURL/$addMemberPath/$undertakingRef", businessEntity)
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
   def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]] =
+  ): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[BusinessEntity, HttpResponse](s"$escURL/$removeMemberPath/$undertakingRef", businessEntity)
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
   def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
     hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]] =
+  ): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[SubsidyUpdate, HttpResponse](s"$escURL/$updateSubsidyPath", subsidyUpdate)
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
   def removeSubsidy(undertakingRef: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(implicit
     hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]] =
+  ): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[SubsidyUpdate, HttpResponse](s"$escURL/$updateSubsidyPath", toSubsidyDelete(nonHmrcSubsidy, undertakingRef))
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
   def retrieveSubsidy(
     subsidyRetrieve: SubsidyRetrieve
-  )(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
+  )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[SubsidyRetrieve, HttpResponse](s"$escURL/$retrieveSubsidyPath", subsidyRetrieve)
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 
   private def toSubsidyDelete(nonHmrcSubsidy: NonHmrcSubsidy, undertakingRef: UndertakingRef) =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -16,45 +16,21 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
-import com.google.inject.{ImplementedBy, Inject, Singleton}
+import com.google.inject.{Inject, Singleton}
 import play.api.http.Status.NOT_FOUND
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidyAmendment}
-import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, NotFoundException}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
 
-@ImplementedBy(classOf[EscConnectorImpl])
-trait EscConnector {
-  def createUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
-  def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
-  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
-  def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
-    hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]]
-  def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
-    hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]]
-  def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
-    hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]]
-  def retrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
-  def removeSubsidy(undertakingRef: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(implicit
-    hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]]
-
-}
-
 @Singleton
-class EscConnectorImpl @Inject() (
+class EscConnector @Inject() (
   http: HttpClient,
   servicesConfig: ServicesConfig,
-  timeProvider: TimeProvider
-)(implicit ec: ExecutionContext)
-    extends EscConnector {
+)(implicit ec: ExecutionContext) {
 
   private val escURL: String = servicesConfig.baseUrl("esc")
 
@@ -66,7 +42,7 @@ class EscConnectorImpl @Inject() (
   private val updateSubsidyPath = "eu-subsidy-compliance/subsidy/update"
   private val retrieveSubsidyPath = "eu-subsidy-compliance/subsidy/retrieve"
 
-  override def createUndertaking(
+  def createUndertaking(
     undertaking: Undertaking
   )(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
     http
@@ -76,7 +52,7 @@ class EscConnectorImpl @Inject() (
         Left(Error(e))
       }
 
-  override def updateUndertaking(
+  def updateUndertaking(
     undertaking: Undertaking
   )(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
     http
@@ -86,7 +62,7 @@ class EscConnectorImpl @Inject() (
         Left(Error(e))
       }
 
-  override def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
+  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
     http
       .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
       .map(Right(_))
@@ -95,7 +71,7 @@ class EscConnectorImpl @Inject() (
         case ex => Left(Error(ex))
       }
 
-  override def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
+  def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier
   ): Future[Either[Error, HttpResponse]] =
     http
@@ -105,7 +81,7 @@ class EscConnectorImpl @Inject() (
         Left(Error(e))
       }
 
-  override def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
+  def removeMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier
   ): Future[Either[Error, HttpResponse]] =
     http
@@ -115,7 +91,7 @@ class EscConnectorImpl @Inject() (
         Left(Error(e))
       }
 
-  override def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
+  def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
     hc: HeaderCarrier
   ): Future[Either[Error, HttpResponse]] =
     http
@@ -125,7 +101,7 @@ class EscConnectorImpl @Inject() (
         Left(Error(e))
       }
 
-  override def removeSubsidy(undertakingRef: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(implicit
+  def removeSubsidy(undertakingRef: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(implicit
     hc: HeaderCarrier
   ): Future[Either[Error, HttpResponse]] =
     http
@@ -135,7 +111,7 @@ class EscConnectorImpl @Inject() (
         Left(Error(e))
       }
 
-  override def retrieveSubsidy(
+  def retrieveSubsidy(
     subsidyRetrieve: SubsidyRetrieve
   )(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
     http

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -32,7 +32,7 @@ class EscConnector @Inject() (
   servicesConfig: ServicesConfig,
 )(implicit ec: ExecutionContext) {
 
-  private val escURL: String = servicesConfig.baseUrl("esc")
+  private lazy val escURL: String = servicesConfig.baseUrl("esc")
 
   private val createUndertakingPath = "eu-subsidy-compliance/undertaking"
   private val updateUndertakingPath = "eu-subsidy-compliance/undertaking/update"

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{ImplementedBy, Inject, Singleton}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @ImplementedBy(classOf[RetrieveEmailConnectorImpl])
 trait RetrieveEmailConnector {
 
-  def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
+  def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]]
 
 }
 
@@ -40,11 +40,11 @@ class RetrieveEmailConnectorImpl @Inject() (http: HttpClient, servicesConfig: Se
   val cdsURL: String = servicesConfig.baseUrl("cds")
 
   def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/${eori.toString}/verified-email"
-  override def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]] =
+  override def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
       .GET[HttpResponse](getUri(eori))
       .map(Right(_))
       .recover { case e =>
-        Left(Error(e))
+        Left(ConnectorError(e))
       }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/SendEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/SendEmailConnector.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{ImplementedBy, Inject, Singleton}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendRequest
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -27,7 +27,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[SendEmailConnectorImpl])
 trait SendEmailConnector {
-  def sendEmail(emailSendRequest: EmailSendRequest)(implicit hc: HeaderCarrier): Future[Either[Error, HttpResponse]]
+  def sendEmail(emailSendRequest: EmailSendRequest)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]]
 }
 
 @Singleton
@@ -40,10 +40,10 @@ class SendEmailConnectorImpl @Inject() (http: HttpClient, servicesConfig: Servic
 
   override def sendEmail(emailSendRequest: EmailSendRequest)(implicit
     hc: HeaderCarrier
-  ): Future[Either[Error, HttpResponse]] =
+  ): Future[Either[ConnectorError, HttpResponse]] =
     http
       .POST[EmailSendRequest, HttpResponse](sendEmailUrl, emailSendRequest)
       .map(Right(_))
-      .recover { case e => Left(Error(e)) }
+      .recover { case e => Left(ConnectorError(e)) }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -40,8 +40,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class BusinessEntityController @Inject() (
   mcc: MessagesControllerComponents,
   escActionBuilders: EscActionBuilders,
-  store: Store,
-  val escService: EscService,
+  override val store: Store,
+  override val escService: EscService,
   journeyTraverseService: JourneyTraverseService,
   timeProvider: TimeProvider,
   sendEmailHelperService: SendEmailHelperService,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupport.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupport.scala
@@ -19,8 +19,10 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import play.api.mvc.Result
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEscRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
-import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax._
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,14 +30,18 @@ import scala.concurrent.{ExecutionContext, Future}
 trait LeadOnlyUndertakingSupport { this: FrontendController =>
 
   protected val escService: EscService
+  protected val store: Store
   protected implicit val executionContext: ExecutionContext
 
   // Only execute the block where the undertaking exists and the logged in user is the lead for that undertaking.
   // If there is no undertaking, or the user is not the lead we redirect to the account home page.
-  def withLeadUndertaking[A](f: Undertaking => Future[Result])(implicit r: AuthenticatedEscRequest[A]): Future[Result] =
-    escService.retrieveUndertaking(r.eoriNumber) flatMap {
-      case Some(undertaking) if undertaking.isLeadEORI(r.eoriNumber) => f(undertaking)
-      case _ => Redirect(routes.AccountController.getAccountPage()).toFuture
-    }
+  def withLeadUndertaking[A](f: Undertaking => Future[Result])(implicit r: AuthenticatedEscRequest[A]): Future[Result] = {
+    implicit val eori: EORI = r.eoriNumber
+
+    store.get[Undertaking].toContext
+      .orElse(escService.retrieveUndertaking(eori).toContext)
+      .filter(_.isLeadEORI(r.eoriNumber))
+      .foldF(Redirect(routes.AccountController.getAccountPage()).toFuture)(f)
+  }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
@@ -32,8 +32,8 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 class NoBusinessPresentController @Inject() (
   mcc: MessagesControllerComponents,
   escActionBuilders: EscActionBuilders,
-  store: Store,
-  val escService: EscService,
+  override val store: Store,
+  override val escService: EscService,
   noBusinessPresentPage: NoBusinessPresentPage
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc) with LeadOnlyUndertakingSupport {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.NonCustomsSubsidyNilReturn
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, NilSubmissionDate, SubsidyUpdate}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, EscService}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax.{FutureToOptionTOps, OptionToOptionTOps}
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
@@ -36,7 +36,8 @@ import scala.concurrent.ExecutionContext
 class NoClaimNotificationController @Inject() (
   mcc: MessagesControllerComponents,
   escActionBuilders: EscActionBuilders,
-  val escService: EscService,
+  override val store: Store,
+  override val escService: EscService,
   auditService: AuditService,
   timeProvider: TimeProvider,
   noClaimNotificationPage: NoClaimNotificationPage,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -36,8 +36,8 @@ import scala.concurrent.ExecutionContext
 class SelectNewLeadController @Inject() (
   mcc: MessagesControllerComponents,
   escActionBuilders: EscActionBuilders,
-  val escService: EscService,
-  store: Store,
+  override val escService: EscService,
+  override val store: Store,
   sendEmailHelperService: SendEmailHelperService,
   auditService: AuditService,
   selectNewLeadPage: SelectNewLeadPage,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -46,8 +46,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class SubsidyController @Inject() (
   mcc: MessagesControllerComponents,
   escActionBuilders: EscActionBuilders,
-  store: Store,
-  val escService: EscService,
+  override val store: Store,
+  override val escService: EscService,
   journeyTraverseService: JourneyTraverseService,
   auditService: AuditService,
   reportPaymentPage: ReportPaymentPage,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
@@ -19,10 +19,9 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -33,8 +32,8 @@ class UpdateEmailAddressController @Inject() (
   updateUnverifiedEmailAddressPage: UpdateUnverifiedEmailPage,
   updateUndeliveredEmailAddressPage: UpdateUndeliveredEmailAddressPage,
   escActionBuilders: EscActionBuilders,
-  servicesConfig: ServicesConfig,
-  val escService: EscService
+  override val escService: EscService,
+  override val store: Store,
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc) with LeadOnlyUndertakingSupport {
   import escActionBuilders._

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressController.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 
@@ -32,22 +31,20 @@ class UpdateEmailAddressController @Inject() (
   updateUnverifiedEmailAddressPage: UpdateUnverifiedEmailPage,
   updateUndeliveredEmailAddressPage: UpdateUndeliveredEmailAddressPage,
   escActionBuilders: EscActionBuilders,
-  override val escService: EscService,
-  override val store: Store,
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
-    extends BaseController(mcc) with LeadOnlyUndertakingSupport {
+    extends BaseController(mcc) {
   import escActionBuilders._
 
   def updateUnverifiedEmailAddress: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
-    withLeadUndertaking { _ => Ok(updateUnverifiedEmailAddressPage()).toFuture }
+    Ok(updateUnverifiedEmailAddressPage()).toFuture
   }
 
-  def postUpdateEmailAddress: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
-    withLeadUndertaking { _ => Redirect(appConfig.emailFrontendUrl).toFuture }
+  def postUpdateEmailAddress: Action[AnyContent] = withAuthenticatedUser.async {
+    Redirect(appConfig.emailFrontendUrl).toFuture
   }
 
   def updateUndeliveredEmailAddress: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
-    withLeadUndertaking { _ => Ok(updateUndeliveredEmailAddressPage()).toFuture }
+    Ok(updateUndeliveredEmailAddressPage()).toFuture
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ConnectorError.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ConnectorError.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
-final case class Error(message: String, cause: Throwable) extends RuntimeException(message, cause)
+final case class ConnectorError(message: String, cause: Throwable) extends RuntimeException(message, cause)
 
-object Error {
-  def apply(cause: Throwable): Error = Error(cause.getMessage, cause)
-  def apply(message: String): Error = Error(message, null)
+object ConnectorError {
+  def apply(cause: Throwable): ConnectorError = ConnectorError(cause.getMessage, cause)
+  def apply(message: String): ConnectorError = ConnectorError(message, null)
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Error.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Error.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
-final case class Error(value: Throwable)
+final case class Error(message: String, cause: Throwable) extends RuntimeException(message, cause)
 
 object Error {
-  def apply(message: String): Error = Error(new RuntimeException("message"))
+  def apply(cause: Throwable): Error = Error(cause.getMessage, cause)
+  def apply(message: String): Error = Error(message, null)
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Error.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Error.scala
@@ -16,12 +16,8 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
-final case class Error(value: Either[String, Throwable]) extends AnyVal
+final case class Error(value: Throwable)
 
 object Error {
-
-  def apply(message: String): Error = Error(Left(message))
-
-  def apply(error: Throwable): Error = Error(Right(error))
-
+  def apply(message: String): Error = Error(new RuntimeException("message"))
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -41,7 +41,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
 
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Option[Undertaking]] =
     escConnector.retrieveUndertaking(eori).map {
-      case Left(Error(_)) => None
+      case Left(_) => None
       case Right(value) =>
         value.status match {
           case NOT_FOUND => None

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -81,7 +81,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
     escConnector.removeSubsidy(undertakingRef, nonHmrcSubsidy)
       .map(handleResponse[UndertakingRef](_, "remove subsidy"))
 
-  private def handleResponse[A](r: Either[Error, HttpResponse], action: String)(implicit reads: Reads[A]) =
+  private def handleResponse[A](r: Either[ConnectorError, HttpResponse], action: String)(implicit reads: Reads[A]) =
     r.fold(_ => sys.error(s"Error executing $action"), { response =>
       if (response.status =!= OK) sys.error(s"Error executing $action - Got response status: ${response.status}")
        else response.parseJSON[A].fold(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailService.scala
@@ -34,7 +34,7 @@ class SendEmailService @Inject() (emailSendConnector: SendEmailConnector)(implic
     hc: HeaderCarrier
   ): Future[EmailSendResult] =
     emailSendConnector.sendEmail(EmailSendRequest(List(emailAddress), templateId, emailParameters)).map {
-      case Left(Error(_)) => sys.error(s"Error in Sending Email ${emailParameters.description}")
+      case Left(error) => throw Error(s"Error in Sending Email ${emailParameters.description}", error)
       case Right(value) =>
         value.status match {
           case ACCEPTED => EmailSendResult.EmailSent

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailService.scala
@@ -21,7 +21,7 @@ import play.api.Logging
 import play.api.http.Status.ACCEPTED
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.SendEmailConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendRequest, EmailSendResult}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, Error}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, ConnectorError}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,7 +34,7 @@ class SendEmailService @Inject() (emailSendConnector: SendEmailConnector)(implic
     hc: HeaderCarrier
   ): Future[EmailSendResult] =
     emailSendConnector.sendEmail(EmailSendRequest(List(emailAddress), templateId, emailParameters)).map {
-      case Left(error) => throw Error(s"Error in Sending Email ${emailParameters.description}", error)
+      case Left(error) => throw ConnectorError(s"Error in Sending Email ${emailParameters.description}", error)
       case Right(value) =>
         value.status match {
           case ACCEPTED => EmailSendResult.EmailSent

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.wordspec._
 import play.api.libs.json.JsString
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HttpResponse
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -32,7 +32,7 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
   def connectorBehaviour(
     mockResponse: Option[HttpResponse] => Unit,
-    performCall: () => Future[Either[Error, HttpResponse]]
+    performCall: () => Future[Either[ConnectorError, HttpResponse]]
   ) = {
     "do a get http call and return the result" in {
       List(
@@ -61,7 +61,7 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
   def connectorBehaviourWithMockTime(
     mockResponse: Option[HttpResponse] => Unit,
-    performCall: () => Future[Either[Error, HttpResponse]],
+    performCall: () => Future[Either[ConnectorError, HttpResponse]],
     mockTimeResponse: LocalDate => Unit
   ) = {
     "do a get http call and return the result" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -21,9 +21,8 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
-import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnectorImpl
+import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
-import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import utils.CommonTestData._
@@ -32,9 +31,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with HttpSupport with ConnectorSpec {
 
-  val (protocol, host, port) = ("http", "host", "123")
+  private val (protocol, host, port) = ("http", "host", "123")
 
-  val config = Configuration(
+  private val config = Configuration(
     ConfigFactory.parseString(s"""
                                  | microservice.services.esc {
                                  |    protocol = "$protocol"
@@ -44,12 +43,9 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
                                  |""".stripMargin)
   )
 
-  val mockTimeProvider = mock[TimeProvider]
+  private val connector = new EscConnector(mockHttp, new ServicesConfig(config))
 
-  val connector = new EscConnectorImpl(mockHttp, new ServicesConfig(config), mockTimeProvider)
-
-  implicit val hc: HeaderCarrier = HeaderCarrier()
-  val responseHeaders = Map.empty[String, Seq[String]]
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
 
   "EscConnectorSpec" when {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -77,7 +77,7 @@ class AccountControllerSpec
       .returning {
         result
           .fold(
-            e => Future.failed(e.value),
+            e => Future.failed(e),
             Future.successful
           )
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -77,11 +77,7 @@ class AccountControllerSpec
       .returning {
         result
           .fold(
-            e =>
-              Future.failed(
-                e.value
-                  .fold(s => new Exception(s), identity)
-              ),
+            e => Future.failed(e.value),
             Future.successful
           )
       }
@@ -142,7 +138,7 @@ class AccountControllerSpec
                   routes.BusinessEntityController.getAddBusinessEntity().url
                 )
 
-              val isNonLeadEORIPresent = undertaking.undertakingBusinessEntity.filterNot(_.leadEORI).nonEmpty
+              val isNonLeadEORIPresent = !undertaking.undertakingBusinessEntity.forall(_.leadEORI)
 
               if (isNonLeadEORIPresent)
                 htmlBody should include regex messageFromMessageKey(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -24,7 +24,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailType, RetrieveEmailResponse}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EligibilityJourney, EscService, RetrieveEmailService, Store, UndertakingJourney}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
@@ -70,7 +70,7 @@ class AccountControllerSpec
       .expects(eori, *)
       .returning(result)
 
-  private def mockRetrieveEmail(eori: EORI)(result: Either[Error, RetrieveEmailResponse]) =
+  private def mockRetrieveEmail(eori: EORI)(result: Either[ConnectorError, RetrieveEmailResponse]) =
     (mockRetrieveEmailService
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
@@ -273,7 +273,7 @@ class AccountControllerSpec
         "there is error in retrieving the email" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -295,7 +295,7 @@ class AccountControllerSpec
             mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
-            mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -308,7 +308,7 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(None))
-            mockPut[EligibilityJourney](EligibilityJourney(), eori1)(Left(Error(exception)))
+            mockPut[EligibilityJourney](EligibilityJourney(), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -321,7 +321,7 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete.some))
-            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -337,7 +337,7 @@ class AccountControllerSpec
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(None))
-            mockPut[UndertakingJourney](undertakingData, eori1)(Left(Error(exception)))
+            mockPut[UndertakingJourney](undertakingData, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -352,7 +352,7 @@ class AccountControllerSpec
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
-            mockGet[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -369,7 +369,7 @@ class AccountControllerSpec
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete.some))
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
             mockGet[BusinessEntityJourney](eori1)(Right(None))
-            mockPut[BusinessEntityJourney](businessEntityData, eori1)(Left(Error(exception)))
+            mockPut[BusinessEntityJourney](businessEntityData, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -380,7 +380,7 @@ class AccountControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockPut[Undertaking](undertaking, eori1)(Left(Error(exception)))
+            mockPut[Undertaking](undertaking, eori1)(Left(ConnectorError(exception)))
 
           }
           assertThrows[Exception](await(performAction()))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessE
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormPages.{BecomeLeadEoriFormPage, TermsAndConditionsFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.http.HeaderCarrier
@@ -82,7 +82,7 @@ class BecomeLeadControllerSpec
       .returning(result)
 
   private def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
-    result: Either[Error, UndertakingRef]
+    result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
@@ -101,7 +101,7 @@ class BecomeLeadControllerSpec
         "call to fetch new lead journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[BecomeLeadJourney](eori1)(Left(Error(exception)))
+            mockGet[BecomeLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -172,7 +172,7 @@ class BecomeLeadControllerSpec
             newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Left(Error(exception)))
+            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("becomeAdmin" -> "true")))
         }
@@ -192,7 +192,7 @@ class BecomeLeadControllerSpec
         "call to fetch new lead journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[BecomeLeadJourney](eori1)(Left(Error(exception)))
+            mockGet[BecomeLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -237,7 +237,7 @@ class BecomeLeadControllerSpec
         "call to fetch become lead journey fails" in {
           inSequence {
             mockAuthWithEnrolment(eori4)
-            mockGet[BecomeLeadJourney](eori4)(Left(Error(exception)))
+            mockGet[BecomeLeadJourney](eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()(English.code)))
         }
@@ -296,7 +296,7 @@ class BecomeLeadControllerSpec
             mockAuthWithEnrolment(eori4)
             mockGet[BecomeLeadJourney](eori4)(Right(newBecomeLeadJourney.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
-            mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Left(Error(exception)))
+            mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()(English.code)))
         }
@@ -307,7 +307,7 @@ class BecomeLeadControllerSpec
             mockGet[BecomeLeadJourney](eori4)(Right(newBecomeLeadJourney.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Right(undertakingRef))
-            mockAddMember(undertakingRef, businessEntity1.copy(leadEORI = false))(Left(Error(exception)))
+            mockAddMember(undertakingRef, businessEntity1.copy(leadEORI = false))(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()(English.code)))
         }
@@ -319,7 +319,7 @@ class BecomeLeadControllerSpec
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Right(undertakingRef))
             mockAddMember(undertakingRef, businessEntity1.copy(leadEORI = false))(Right(undertakingRef))
-            mockRetrieveEmail(eori4)(Left(Error(exception)))
+            mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()(English.code)))
         }
@@ -338,7 +338,7 @@ class BecomeLeadControllerSpec
             mockSendEmail(validEmailAddress, newLeadParams, "template_promoted_themself_as_lead_email_to_lead_EN")(
               Right(EmailSendResult.EmailSent)
             )
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()(English.code)))
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -87,7 +87,7 @@ class BecomeLeadControllerSpec
     (mockEscService
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
       .expects(undertakingRef, businessEntity, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   "BecomeLeadControllerSpec" when {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -87,7 +87,7 @@ class BecomeLeadControllerSpec
     (mockEscService
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
       .expects(undertakingRef, businessEntity, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   "BecomeLeadControllerSpec" when {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -20,7 +20,7 @@ import cats.implicits.catsSyntaxOptionId
 import com.typesafe.config.ConfigFactory
 import play.api.Configuration
 import play.api.inject.bind
-import play.api.mvc.{Cookie, Result}
+import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -49,7 +49,8 @@ class BusinessEntityControllerSpec
     with JourneySupport
     with RetrieveEmailSupport
     with SendEmailSupport
-    with AuditServiceSupport {
+    with AuditServiceSupport
+    with LeadOnlyRedirectSupport {
 
   private val mockEscService = mock[EscService]
   private val mockTimeProvider = mock[TimeProvider]
@@ -1304,18 +1305,6 @@ class BusinessEntityControllerSpec
 
   private def mockTimeToday(now: LocalDate) =
     (mockTimeProvider.today _).expects().returning(now)
-
-  private def testLeadOnlyRedirect(f: () => Future[Result]) = {
-    inSequence {
-      mockAuthWithEnrolment(eori3)
-      mockGet[Undertaking](eori3)(Right(undertaking.some))
-    }
-
-    val result = f()
-
-    status(result) shouldBe SEE_OTHER
-    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
-  }
 
 }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -1302,7 +1302,7 @@ class BusinessEntityControllerSpec
     (mockEscService
       .removeMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
       .expects(undertakingRef, businessEntity, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
     result: Either[Error, UndertakingRef]
@@ -1310,7 +1310,7 @@ class BusinessEntityControllerSpec
     (mockEscService
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
       .expects(undertakingRef, businessEntity, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockTimeToday(now: LocalDate) =
     (mockTimeProvider.today _).expects().returning(now)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -1302,7 +1302,7 @@ class BusinessEntityControllerSpec
     (mockEscService
       .removeMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
       .expects(undertakingRef, businessEntity, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
     result: Either[Error, UndertakingRef]
@@ -1310,7 +1310,7 @@ class BusinessEntityControllerSpec
     (mockEscService
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
       .expects(undertakingRef, businessEntity, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockTimeToday(now: LocalDate) =
     (mockTimeProvider.today _).expects().returning(now)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -105,7 +105,7 @@ class BusinessEntityControllerSpec
         "call to get business entity journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -114,7 +114,7 @@ class BusinessEntityControllerSpec
         "call to store undertaking fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockPut[Undertaking](undertaking, eori1)(Left(ConnectorError(exception)))
           }
@@ -127,7 +127,7 @@ class BusinessEntityControllerSpec
         def test(input: Option[String], businessEntityJourney: BusinessEntityJourney): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockPut[Undertaking](undertaking, eori1)(Right(undertaking))
           }
@@ -181,7 +181,7 @@ class BusinessEntityControllerSpec
             beOpt.map(x => x.copy(addBusiness = x.addBusiness.copy(value = Some(true))))
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockUpdate[BusinessEntityJourney](_ => updateFunc(businessEntityJourney.some), eori)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("addBusiness" -> "true")))
@@ -195,7 +195,7 @@ class BusinessEntityControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
           }
 
           checkFormErrorIsDisplayed(
@@ -216,7 +216,7 @@ class BusinessEntityControllerSpec
         "user selected No" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
           }
           checkIsRedirect(performAction("addBusiness" -> "false"), routes.AccountController.getAccountPage().url)
         }
@@ -226,7 +226,7 @@ class BusinessEntityControllerSpec
             beOpt.map(x => x.copy(addBusiness = x.addBusiness.copy(value = Some(true))))
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockUpdate[BusinessEntityJourney](_ => updateFunc(BusinessEntityJourney().some), eori)(
               Right(BusinessEntityJourney(addBusiness = AddBusinessFormPage(true.some)))
             )
@@ -253,7 +253,7 @@ class BusinessEntityControllerSpec
         "call to get previous uri fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -263,7 +263,7 @@ class BusinessEntityControllerSpec
         "call to get business entity journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("/add-member"))
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -274,7 +274,7 @@ class BusinessEntityControllerSpec
         "call to get business entity journey came back empty" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("/add-member"))
             mockGet[BusinessEntityJourney](eori1)(Right(None))
           }
@@ -290,7 +290,7 @@ class BusinessEntityControllerSpec
           val previousUrl = "add-member"
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right(previousUrl))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
           }
@@ -352,7 +352,7 @@ class BusinessEntityControllerSpec
         "call to get previous uri fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -373,7 +373,7 @@ class BusinessEntityControllerSpec
             .some
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertaking(eori4)(Future.successful(None))
             mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Left(ConnectorError(exception)))
@@ -390,7 +390,7 @@ class BusinessEntityControllerSpec
         def test(data: (String, String)*)(errorMessageKey: String): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
           }
           checkFormErrorIsDisplayed(
@@ -433,7 +433,7 @@ class BusinessEntityControllerSpec
         "Call to fetch Business Entity journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -443,7 +443,7 @@ class BusinessEntityControllerSpec
         "call to fetch Business Entity journey returns Nothing" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(None))
           }
           assertThrows[Exception](await(performAction()))
@@ -452,7 +452,7 @@ class BusinessEntityControllerSpec
         "call to fetch Business Entity journey returns journey without eori" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.copy(eori = AddEoriFormPage()).some))
           }
           assertThrows[Exception](await(performAction()))
@@ -463,7 +463,7 @@ class BusinessEntityControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
         }
 
@@ -503,18 +503,10 @@ class BusinessEntityControllerSpec
         val exception = new Exception("oh no")
         val emailParametersBE = SingleEORIEmailParameter(eori2, undertaking.name, undertakingRef, "addMemberEmailToBE")
 
-        "call to get undertaking fails" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.failed(exception))
-          }
-          assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
-        }
-
         "call to get undertaking return undertaking without undertaking ref" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.copy(reference = None).some))
+            mockGet[Undertaking](eori1)(Right(undertaking.copy(reference = None).some))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
         }
@@ -522,7 +514,7 @@ class BusinessEntityControllerSpec
         "call to get business entity fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
@@ -531,7 +523,7 @@ class BusinessEntityControllerSpec
         "call to get business entity returns nothing" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(None))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
@@ -540,7 +532,7 @@ class BusinessEntityControllerSpec
         "call to get business entity  return  without EORI" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.copy(eori = AddEoriFormPage(None)).some))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
@@ -551,7 +543,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Left(ConnectorError(exception)))
           }
@@ -563,7 +555,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Left(ConnectorError(exception)))
@@ -577,7 +569,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.UnVerifiedEmail, None)))
@@ -590,7 +582,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -605,7 +597,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -619,7 +611,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
           }
@@ -642,7 +634,7 @@ class BusinessEntityControllerSpec
             DoubleEORIEmailParameter(eori1, eori2, undertaking.name, undertakingRef, "addMemberEmailToLead")
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -667,7 +659,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -722,7 +714,7 @@ class BusinessEntityControllerSpec
             DoubleEORIEmailParameter(eori1, eori2, undertaking.name, undertakingRef, "addMemberEmailToLead")
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockRemoveMember(
               undertakingRef,
@@ -770,7 +762,7 @@ class BusinessEntityControllerSpec
           val businessEntityJourney = BusinessEntityJourney.businessEntityJourneyForEori(undertaking1.some, eori1)
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockPut[BusinessEntityJourney](businessEntityJourney, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction(eori1)))
@@ -787,9 +779,7 @@ class BusinessEntityControllerSpec
         )
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(
-            Future.successful(undertaking1.copy(undertakingBusinessEntity = List(be)).some)
-          )
+          mockGet[Undertaking](eori1)(Right(undertaking1.copy(undertakingBusinessEntity = List(be)).some))
           mockPut[BusinessEntityJourney](businessEntityJourney, eori1)(Right(businessEntityJourney))
         }
         checkPageIsDisplayed(
@@ -1041,7 +1031,7 @@ class BusinessEntityControllerSpec
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -1052,7 +1042,7 @@ class BusinessEntityControllerSpec
         def test(undertaking: Undertaking, inputDate: Option[String]): Unit = {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking.some))
           }
           checkPageIsDisplayed(
@@ -1103,7 +1093,7 @@ class BusinessEntityControllerSpec
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
           }
           assertThrows[Exception](await(performAction()(eori4)))
         }
@@ -1111,7 +1101,7 @@ class BusinessEntityControllerSpec
         "call to remove BE fails" in {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Left(ConnectorError(exception)))
@@ -1122,7 +1112,7 @@ class BusinessEntityControllerSpec
         "call to fetch business entity email address fails" in {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
@@ -1142,7 +1132,7 @@ class BusinessEntityControllerSpec
 
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
@@ -1162,7 +1152,7 @@ class BusinessEntityControllerSpec
         "nothing is selected" in {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking1.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
           }
           checkFormErrorIsDisplayed(
@@ -1186,7 +1176,7 @@ class BusinessEntityControllerSpec
         ): Unit = {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
@@ -1263,7 +1253,7 @@ class BusinessEntityControllerSpec
         "user selects No as input" in {
           inSequence {
             mockAuthWithEnrolment(eori1)
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
           }
           checkIsRedirect(
@@ -1318,7 +1308,7 @@ class BusinessEntityControllerSpec
   private def testLeadOnlyRedirect(f: () => Future[Result]) = {
     inSequence {
       mockAuthWithEnrolment(eori3)
-      mockRetrieveUndertaking(eori3)(Future.successful(undertaking.some))
+      mockGet[Undertaking](eori3)(Right(undertaking.some))
     }
 
     val result = f()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, DoubleEORIEmailParameter, SingleEORIAndDateEmailParameter, SingleEORIEmailParameter}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, Language, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, Language, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.FormPages.{AddBusinessFormPage, AddEoriFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
@@ -106,7 +106,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockGet[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -116,7 +116,7 @@ class BusinessEntityControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
-            mockPut[Undertaking](undertaking, eori1)(Left(Error(exception)))
+            mockPut[Undertaking](undertaking, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -182,7 +182,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockUpdate[BusinessEntityJourney](_ => updateFunc(businessEntityJourney.some), eori)(Left(Error(exception)))
+            mockUpdate[BusinessEntityJourney](_ => updateFunc(businessEntityJourney.some), eori)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("addBusiness" -> "true")))
         }
@@ -254,7 +254,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockGetPrevious[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGetPrevious[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -265,7 +265,7 @@ class BusinessEntityControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("/add-member"))
-            mockGet[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -353,7 +353,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockGetPrevious[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGetPrevious[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -376,7 +376,7 @@ class BusinessEntityControllerSpec
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertaking(eori4)(Future.successful(None))
-            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Left(Error(exception)))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Left(ConnectorError(exception)))
           }
 
           assertThrows[Exception](await(performAction("businessEntityEori" -> "123456789010")))
@@ -434,7 +434,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockGet[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -523,7 +523,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
-            mockGet[BusinessEntityJourney](eori1)(Left(Error(exception)))
+            mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
         }
@@ -553,7 +553,7 @@ class BusinessEntityControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
-            mockAddMember(undertakingRef, businessEntity)(Left(Error(exception)))
+            mockAddMember(undertakingRef, businessEntity)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
         }
@@ -566,7 +566,7 @@ class BusinessEntityControllerSpec
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
-            mockRetrieveEmail(eori2)(Left(Error(exception)))
+            mockRetrieveEmail(eori2)(Left(ConnectorError(exception)))
           }
 
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
@@ -595,7 +595,7 @@ class BusinessEntityControllerSpec
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
             mockRetrieveEmail(eori2)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockSendEmail(validEmailAddress, emailParametersBE, "template_add_be_EN")(Right(EmailSendResult.EmailSent))
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
         }
@@ -771,7 +771,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockPut[BusinessEntityJourney](businessEntityJourney, eori1)(Left(Error(exception)))
+            mockPut[BusinessEntityJourney](businessEntityJourney, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction(eori1)))
         }
@@ -896,7 +896,7 @@ class BusinessEntityControllerSpec
             mockAuthWithEnrolment(eori4)
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(currentDate)
-            mockRemoveMember(undertakingRef, businessEntity4)(Left(Error(exception)))
+            mockRemoveMember(undertakingRef, businessEntity4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeYourselfBusinessEntity" -> "true")(English.code)))
         }
@@ -907,7 +907,7 @@ class BusinessEntityControllerSpec
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(currentDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
-            mockRetrieveEmail(eori4)(Left(Error(exception)))
+            mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeYourselfBusinessEntity" -> "true")(English.code)))
         }
@@ -922,7 +922,7 @@ class BusinessEntityControllerSpec
             mockSendEmail(validEmailAddress, emailParamBE, "template_remove_yourself_be_EN")(
               Right(EmailSendResult.EmailSent)
             )
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeYourselfBusinessEntity" -> "true")(English.code)))
         }
@@ -1114,7 +1114,7 @@ class BusinessEntityControllerSpec
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
-            mockRemoveMember(undertakingRef, businessEntity4)(Left(Error(exception)))
+            mockRemoveMember(undertakingRef, businessEntity4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeBusiness" -> "true")(eori4)))
         }
@@ -1126,7 +1126,7 @@ class BusinessEntityControllerSpec
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(effectiveDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))
-            mockRetrieveEmail(eori4)(Left(Error(exception)))
+            mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeBusiness" -> "true")(eori4)))
         }
@@ -1150,7 +1150,7 @@ class BusinessEntityControllerSpec
             mockSendEmail(validEmailAddress, emailParameterBE, "template_remove_be_EN")(
               Right(EmailSendResult.EmailSent)
             )
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeBusiness" -> "true")(eori4)))
         }
@@ -1297,7 +1297,7 @@ class BusinessEntityControllerSpec
       .returning(result)
 
   private def mockRemoveMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
-    result: Either[Error, UndertakingRef]
+    result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
       .removeMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
@@ -1305,7 +1305,7 @@ class BusinessEntityControllerSpec
       .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
-    result: Either[Error, UndertakingRef]
+    result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -21,7 +21,7 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.TermsAndConditionsAccepted
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
@@ -60,7 +60,7 @@ class EligibilityControllerSpec
         "call to get eligibility journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -106,7 +106,7 @@ class EligibilityControllerSpec
         "call to get eligibility journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -179,7 +179,7 @@ class EligibilityControllerSpec
         "call to update eligibility journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(Error(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("customswaivers" -> "true")))
         }
@@ -228,7 +228,7 @@ class EligibilityControllerSpec
         "call to get eligibility fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -307,7 +307,7 @@ class EligibilityControllerSpec
         "call to get previous fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGetPrevious[EligibilityJourney](eori)(Left(Error(exception)))
+            mockGetPrevious[EligibilityJourney](eori)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -317,7 +317,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(Error(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("willyouclaim" -> "true")))
         }
@@ -364,7 +364,7 @@ class EligibilityControllerSpec
         "call to get eligibility fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -451,7 +451,7 @@ class EligibilityControllerSpec
         "call to get previous fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGetPrevious[EligibilityJourney](eori)(Left(Error(exception)))
+            mockGetPrevious[EligibilityJourney](eori)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -461,7 +461,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(Error(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("mainbusinesscheck" -> "true")))
         }
@@ -507,7 +507,7 @@ class EligibilityControllerSpec
         "call to get previous fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGetPrevious[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGetPrevious[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -558,7 +558,7 @@ class EligibilityControllerSpec
         "call to update eligibility journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(Error(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("terms" -> "true")))
         }
@@ -589,7 +589,7 @@ class EligibilityControllerSpec
         "call to get eligibility fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[EligibilityJourney](eori1)(Left(Error(exception)))
+            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
@@ -33,18 +33,18 @@ trait JourneyStoreSupport { this: MockFactory =>
     (mockJourneyStore
       .get(_: ClassTag[Any], _: EORI, _: Reads[Any]))
       .expects(*, eori, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   def mockPut[A](input: A, eori: EORI)(result: Either[Error, A]) =
     (mockJourneyStore
       .put(_: A)(_: EORI, _: Writes[A]))
       .expects(input, eori, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   def mockUpdate[A](f: Option[A] => Option[A], eori: EORI)(result: Either[Error, A]) =
     (mockJourneyStore
       .update(_: Option[A] => Option[A])(_: ClassTag[A], _: EORI, _: Format[A]))
       .expects(*, *, eori, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
@@ -33,18 +33,18 @@ trait JourneyStoreSupport { this: MockFactory =>
     (mockJourneyStore
       .get(_: ClassTag[Any], _: EORI, _: Reads[Any]))
       .expects(*, eori, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   def mockPut[A](input: A, eori: EORI)(result: Either[Error, A]) =
     (mockJourneyStore
       .put(_: A)(_: EORI, _: Writes[A]))
       .expects(input, eori, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   def mockUpdate[A](f: Option[A] => Option[A], eori: EORI)(result: Either[Error, A]) =
     (mockJourneyStore
       .update(_: Option[A] => Option[A])(_: ClassTag[A], _: EORI, _: Format[A]))
       .expects(*, *, eori, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.{Format, Reads, Writes}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Store
 
@@ -29,19 +29,19 @@ trait JourneyStoreSupport { this: MockFactory =>
 
   val mockJourneyStore: Store = mock[Store]
 
-  def mockGet[A](eori: EORI)(result: Either[Error, Option[A]]) =
+  def mockGet[A](eori: EORI)(result: Either[ConnectorError, Option[A]]) =
     (mockJourneyStore
       .get(_: ClassTag[Any], _: EORI, _: Reads[Any]))
       .expects(*, eori, *)
       .returning(result.fold(e => Future.failed(e), Future.successful))
 
-  def mockPut[A](input: A, eori: EORI)(result: Either[Error, A]) =
+  def mockPut[A](input: A, eori: EORI)(result: Either[ConnectorError, A]) =
     (mockJourneyStore
       .put(_: A)(_: EORI, _: Writes[A]))
       .expects(input, eori, *)
       .returning(result.fold(e => Future.failed(e), Future.successful))
 
-  def mockUpdate[A](f: Option[A] => Option[A], eori: EORI)(result: Either[Error, A]) =
+  def mockUpdate[A](f: Option[A] => Option[A], eori: EORI)(result: Either[ConnectorError, A]) =
     (mockJourneyStore
       .update(_: Option[A] => Option[A])(_: ClassTag[A], _: EORI, _: Format[A]))
       .expects(*, *, eori, *)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneySupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneySupport.scala
@@ -34,6 +34,6 @@ trait JourneySupport { this: ControllerSpec =>
     (mockJourneyTraverseService
       .getPrevious(_: ClassTag[A], _: EORI, _: Request[_], _: Reads[A]))
       .expects(*, eori, *, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful(_)))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneySupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneySupport.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import play.api.libs.json.Reads
 import play.api.mvc.Request
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{Journey, JourneyTraverseService}
@@ -30,7 +30,7 @@ trait JourneySupport { this: ControllerSpec =>
 
   val mockJourneyTraverseService = mock[JourneyTraverseService]
 
-  def mockGetPrevious[A <: Journey : ClassTag](eori: EORI)(result: Either[Error, Uri]) =
+  def mockGetPrevious[A <: Journey : ClassTag](eori: EORI)(result: Either[ConnectorError, Uri]) =
     (mockJourneyTraverseService
       .getPrevious(_: ClassTag[A], _: EORI, _: Request[_], _: Reads[A]))
       .expects(*, eori, *, *)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneySupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneySupport.scala
@@ -34,6 +34,6 @@ trait JourneySupport { this: ControllerSpec =>
     (mockJourneyTraverseService
       .getPrevious(_: ClassTag[A], _: EORI, _: Request[_], _: Reads[A]))
       .expects(*, eori, *, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyRedirectSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyRedirectSupport.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+
+import cats.implicits.catsSyntaxOptionId
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should.Matchers
+import play.api.http.Status.SEE_OTHER
+import play.api.mvc.Result
+import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, status}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
+import utils.CommonTestData.{eori3, undertaking}
+
+import scala.concurrent.Future
+
+trait LeadOnlyRedirectSupport extends MockFactory with Matchers {
+  this: AuthAndSessionDataBehaviour with JourneyStoreSupport =>
+
+  protected def testLeadOnlyRedirect(f: () => Future[Result]) = {
+    inSequence {
+      mockAuthWithEnrolment(eori3)
+      mockGet[Undertaking](eori3)(Right(undertaking.some))
+    }
+
+    val result = f()
+
+    status(result) shouldBe SEE_OTHER
+    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
+  }
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupportSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupportSpec.scala
@@ -29,7 +29,7 @@ import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, status}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEscRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.Fixtures.eori
 import uk.gov.hmrc.http.HeaderCarrier
@@ -41,9 +41,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory with ScalaFutures with Matchers {
 
   private val mockEscService = mock[EscService]
+  private val mockStore = mock[Store]
 
   private val underTest = new FrontendController(mock[MessagesControllerComponents]) with LeadOnlyUndertakingSupport {
     override protected val escService: EscService = mockEscService
+    override protected val store: Store = mockStore
     override protected implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.global
   }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupportSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupportSpec.scala
@@ -27,7 +27,7 @@ import play.api.mvc.Results.Ok
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, status}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEscRequest
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
@@ -141,7 +141,7 @@ class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory wi
 
       "an error occurred retrieving the undertaking from the cache" in {
         inSequence {
-          mockGet[Undertaking](eori)(Left(Error("Error")))
+          mockGet[Undertaking](eori)(Left(ConnectorError("Error")))
         }
 
         runTest()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupportSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyUndertakingSupportSpec.scala
@@ -54,12 +54,7 @@ class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory wi
     "invoke the function" when {
 
       def runTest() = {
-        val fakeRequest = AuthenticatedEscRequest(
-          "Foo",
-          "Bar",
-          FakeRequest(),
-          eori
-        )
+        val fakeRequest = authorisedRequestForEori(eori)
         val result = underTest.withLeadUndertaking(_ => Ok("Foo").toFuture)(fakeRequest)
         status(result) shouldBe OK
       }
@@ -91,12 +86,7 @@ class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory wi
           mockGet[Undertaking](eori3)(Right(undertaking.some))
         }
 
-        val fakeRequest = AuthenticatedEscRequest(
-          "Foo",
-          "Bar",
-          FakeRequest(),
-          eori3
-        )
+        val fakeRequest = authorisedRequestForEori(eori3)
 
         val result = underTest.withLeadUndertaking(_ => Ok("Foo").toFuture)(fakeRequest)
 
@@ -110,12 +100,7 @@ class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory wi
           mockRetrieveUndertaking(eori)(Option.empty.toFuture)
         }
 
-        val fakeRequest = AuthenticatedEscRequest(
-          "Foo",
-          "Bar",
-          FakeRequest(),
-          eori
-        )
+        val fakeRequest = authorisedRequestForEori(eori)
 
         val result = underTest.withLeadUndertaking(_ => Ok("Foo").toFuture)(fakeRequest)
 
@@ -127,12 +112,7 @@ class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory wi
     "throw an error" when {
 
       def runTest() = {
-        val fakeRequest = AuthenticatedEscRequest(
-          "Foo",
-          "Bar",
-          FakeRequest(),
-          eori
-        )
+        val fakeRequest = authorisedRequestForEori(eori)
 
         val result = underTest.withLeadUndertaking(_ => Ok("Foo").toFuture)(fakeRequest)
 
@@ -164,5 +144,12 @@ class LeadOnlyUndertakingSupportSpec extends AnyWordSpecLike with MockFactory wi
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
       .returning(result)
+
+  private def authorisedRequestForEori(e: EORI) = AuthenticatedEscRequest(
+    "Foo",
+    "Bar",
+    FakeRequest(),
+    e
+  )
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
 import play.api.inject.bind
-import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -26,13 +25,12 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Undertaki
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EscService, Store}
 import utils.CommonTestData._
 
-import scala.concurrent.Future
-
 class NoBusinessPresentControllerSpec
     extends ControllerSpec
     with AuthSupport
     with JourneyStoreSupport
-    with AuthAndSessionDataBehaviour {
+    with AuthAndSessionDataBehaviour
+    with LeadOnlyRedirectSupport {
 
   private val mockEscService = mock[EscService]
 
@@ -114,18 +112,6 @@ class NoBusinessPresentControllerSpec
       }
     }
 
-  }
-
-  private def testLeadOnlyRedirect(f: () => Future[Result]) = {
-    inSequence {
-      mockAuthWithEnrolment(eori3)
-      mockGet[Undertaking](eori3)(Right(undertaking.some))
-    }
-
-    val result = f()
-
-    status(result) shouldBe SEE_OTHER
-    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
   }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, EscService, Store}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData.{businessEntityJourney1, eori1, eori3, undertaking, undertaking1}
@@ -100,7 +100,7 @@ class NoBusinessPresentControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1.some), eori1)(Left(Error(exception)))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, NilSubmissionDate, SubsidyUpdate, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, NilSubmissionDate, SubsidyUpdate, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
@@ -108,7 +108,7 @@ class NoClaimNotificationControllerSpec
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
             mockTimeProviderToday(currentDay)
             mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
-              Left(Error(exception))
+              Left(ConnectorError(exception))
             )
           }
           assertThrows[Exception](await(performAction("noClaimNotification" -> "true")))
@@ -200,7 +200,7 @@ class NoClaimNotificationControllerSpec
       .returning(result)
 
   private def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
-    result: Either[Error, UndertakingRef]
+    result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -23,8 +23,8 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, NilSubmissionDate, SubsidyUpdate, Undertaking}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
@@ -63,7 +63,7 @@ class NoClaimNotificationControllerSpec
 
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori)(Right(undertaking.some))
         }
         checkPageIsDisplayed(
           performAction(),
@@ -105,7 +105,7 @@ class NoClaimNotificationControllerSpec
         "call to create Subsidy fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockTimeProviderToday(currentDay)
             mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
               Left(ConnectorError(exception))
@@ -121,7 +121,7 @@ class NoClaimNotificationControllerSpec
         "check box is not checked" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
           }
 
           checkFormErrorIsDisplayed(
@@ -136,7 +136,7 @@ class NoClaimNotificationControllerSpec
 
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockTimeProviderToday(currentDay)
           mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
             Right(undertakingRef)
@@ -166,7 +166,7 @@ class NoClaimNotificationControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkPageIsDisplayed(
           performAction(),
@@ -193,12 +193,6 @@ class NoClaimNotificationControllerSpec
 
   }
 
-  private def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
-    (mockEscService
-      .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
-      .expects(eori, *)
-      .returning(result)
-
   private def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
     result: Either[ConnectorError, UndertakingRef]
   ) =
@@ -213,7 +207,7 @@ class NoClaimNotificationControllerSpec
   private def testLeadOnlyRedirect(f: () => Future[Result]) = {
     inSequence {
       mockAuthWithEnrolment(eori3)
-      mockRetrieveUndertaking(eori3)(Future.successful(undertaking.some))
+      mockGet[Undertaking](eori3)(Right(undertaking.some))
     }
 
     val result = f()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -205,7 +205,7 @@ class NoClaimNotificationControllerSpec
     (mockEscService
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
       .expects(reference, subsidyUpdate, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockTimeProviderToday(today: LocalDate) =
     (mockTimeProvider.today _).expects().returning(today)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
 import play.api.inject.bind
-import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -28,7 +27,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, NilSubmis
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.CommonTestData.{eori1, eori3, undertaking, undertakingRef}
+import utils.CommonTestData.{eori1, undertaking, undertakingRef}
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -38,7 +37,8 @@ class NoClaimNotificationControllerSpec
     with AuthSupport
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour
-    with AuditServiceSupport {
+    with AuditServiceSupport
+    with LeadOnlyRedirectSupport {
 
   private val mockEscService = mock[EscService]
   private val mockTimeProvider = mock[TimeProvider]
@@ -203,17 +203,5 @@ class NoClaimNotificationControllerSpec
 
   private def mockTimeProviderToday(today: LocalDate) =
     (mockTimeProvider.today _).expects().returning(today)
-
-  private def testLeadOnlyRedirect(f: () => Future[Result]) = {
-    inSequence {
-      mockAuthWithEnrolment(eori3)
-      mockGet[Undertaking](eori3)(Right(undertaking.some))
-    }
-
-    val result = f()
-
-    status(result) shouldBe SEE_OTHER
-    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
-  }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -205,7 +205,7 @@ class NoClaimNotificationControllerSpec
     (mockEscService
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
       .expects(reference, subsidyUpdate, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockTimeProviderToday(today: LocalDate) =
     (mockTimeProvider.today _).expects().returning(today)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
@@ -32,5 +32,5 @@ trait RetrieveEmailSupport { this: ControllerSpec =>
     (mockRetrieveEmailService
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
@@ -26,11 +26,11 @@ import scala.concurrent.Future
 
 trait RetrieveEmailSupport { this: ControllerSpec =>
 
-  val mockRetrieveEmailService = mock[RetrieveEmailService]
+  val mockRetrieveEmailService: RetrieveEmailService = mock[RetrieveEmailService]
 
   def mockRetrieveEmail(eori: EORI)(result: Either[Error, RetrieveEmailResponse]) =
     (mockRetrieveEmailService
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful(_)))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/RetrieveEmailSupport.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.RetrieveEmailResponse
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.RetrieveEmailService
 import uk.gov.hmrc.http.HeaderCarrier
@@ -28,7 +28,7 @@ trait RetrieveEmailSupport { this: ControllerSpec =>
 
   val mockRetrieveEmailService: RetrieveEmailService = mock[RetrieveEmailService]
 
-  def mockRetrieveEmail(eori: EORI)(result: Either[Error, RetrieveEmailResponse]) =
+  def mockRetrieveEmail(eori: EORI)(result: Either[ConnectorError, RetrieveEmailResponse]) =
     (mockRetrieveEmailService
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIEmailParameter, SingleEORIEmailParameter}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.FormPages.AddEoriFormPage
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.SelectNewLeadFormPage
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
@@ -88,7 +88,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockGet[NewLeadJourney](eori1)(Left(Error(exception)))
+            mockGet[NewLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -99,7 +99,7 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
             mockGet[NewLeadJourney](eori1)(Right(None))
-            mockPut[NewLeadJourney](NewLeadJourney(), eori1)(Left(Error(exception)))
+            mockPut[NewLeadJourney](NewLeadJourney(), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -182,7 +182,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(Left(Error(exception)))
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
@@ -195,7 +195,7 @@ class SelectNewLeadControllerSpec
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
-            mockRetrieveEmail(eori4)(Left(Error(exception)))
+            mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4.toString)(English.code)))
         }
@@ -210,7 +210,7 @@ class SelectNewLeadControllerSpec
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockSendEmail(validEmailAddress, emailParamsBE, "template_BE_as_lead_EN")(Right(EmailSendResult.EmailSent))
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
@@ -305,7 +305,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockGet[NewLeadJourney](eori1)(Left(Error(exception)))
+            mockGet[NewLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -339,7 +339,7 @@ class SelectNewLeadControllerSpec
             mockUpdate[BusinessEntityJourney](
               _ => update(businessEntityJourneyLead.copy(eori = AddEoriFormPage(eori4.some)).some),
               eori1
-            )(Left(Error(exception)))
+            )(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -360,7 +360,7 @@ class SelectNewLeadControllerSpec
               eori1
             )(Right(businessEntityJourneyLead))
 
-            mockPut[NewLeadJourney](NewLeadJourney(), eori)(Left(Error(exception)))
+            mockPut[NewLeadJourney](NewLeadJourney(), eori)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -20,7 +20,7 @@ import cats.implicits.catsSyntaxOptionId
 import com.typesafe.config.ConfigFactory
 import play.api.Configuration
 import play.api.inject.bind
-import play.api.mvc.{Cookie, Result}
+import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
@@ -34,8 +34,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.Sel
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import utils.CommonTestData._
 
-import scala.concurrent.Future
-
 class SelectNewLeadControllerSpec
     extends ControllerSpec
     with AuthSupport
@@ -43,7 +41,8 @@ class SelectNewLeadControllerSpec
     with AuthAndSessionDataBehaviour
     with RetrieveEmailSupport
     with SendEmailSupport
-    with AuditServiceSupport {
+    with AuditServiceSupport
+    with LeadOnlyRedirectSupport {
 
   private val mockEscService = mock[EscService]
 
@@ -411,18 +410,6 @@ class SelectNewLeadControllerSpec
 
     }
 
-  }
-
-  private def testLeadOnlyRedirect(f: () => Future[Result]) = {
-    inSequence {
-      mockAuthWithEnrolment(eori3)
-      mockGet[Undertaking](eori3)(Right(undertaking.some))
-    }
-
-    val result = f()
-
-    status(result) shouldBe SEE_OTHER
-    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
   }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SendEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SendEmailSupport.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendResult}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, Error}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, ConnectorError}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SendEmailService
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -26,7 +26,7 @@ trait SendEmailSupport { this: ControllerSpec =>
 
   val mockSendEmailService = mock[SendEmailService]
 
-  def mockSendEmail(emailAddress: EmailAddress, emailParameters: EmailParameters, templateId: String)(result: Either[Error, EmailSendResult]) =
+  def mockSendEmail(emailAddress: EmailAddress, emailParameters: EmailParameters, templateId: String)(result: Either[ConnectorError, EmailSendResult]) =
     (mockSendEmailService
       .sendEmail(_: EmailAddress, _: EmailParameters, _: String)(_: HeaderCarrier))
       .expects(emailAddress, emailParameters, templateId, *)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SendEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SendEmailSupport.scala
@@ -22,17 +22,15 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-trait SendEmailSupport {
-  this: ControllerSpec =>
+trait SendEmailSupport { this: ControllerSpec =>
 
   val mockSendEmailService = mock[SendEmailService]
-
 
   def mockSendEmail(emailAddress: EmailAddress, emailParameters: EmailParameters, templateId: String)(result: Either[Error, EmailSendResult]) =
     (mockSendEmailService
       .sendEmail(_: EmailAddress, _: EmailParameters, _: String)(_: HeaderCarrier))
       .expects(emailAddress, emailParameters, templateId, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 }
 
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SendEmailSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SendEmailSupport.scala
@@ -30,7 +30,7 @@ trait SendEmailSupport { this: ControllerSpec =>
     (mockSendEmailService
       .sendEmail(_: EmailAddress, _: EmailParameters, _: String)(_: HeaderCarrier))
       .expects(emailAddress, emailParameters, templateId, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 }
 
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1278,7 +1278,7 @@ class SubsidyControllerSpec
     (mockEscService
       .removeSubsidy(_: UndertakingRef, _: NonHmrcSubsidy)(_: HeaderCarrier))
       .expects(reference, nonHmrcSubsidy, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
     result: Either[Error, UndertakingRef]
@@ -1286,7 +1286,7 @@ class SubsidyControllerSpec
     (mockEscService
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
       .expects(reference, subsidyUpdate, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockTimeProviderToday(today: LocalDate) =
     (mockTimeProvider.today _).expects().returning(today)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -18,15 +18,14 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
 import play.api.inject.bind
-import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyControllerSpec.RemoveSubsidyRow
+import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.NonCustomsSubsidyRemoved
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{SubsidyRef, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
@@ -46,7 +45,8 @@ class SubsidyControllerSpec
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour
     with JourneySupport
-    with AuditServiceSupport {
+    with AuditServiceSupport
+    with LeadOnlyRedirectSupport {
 
   private val mockEscService = mock[EscService]
   private val mockTimeProvider = mock[TimeProvider]
@@ -1280,18 +1280,6 @@ class SubsidyControllerSpec
 
   private def mockTimeProviderToday(today: LocalDate) =
     (mockTimeProvider.today _).expects().returning(today)
-
-  private def testLeadOnlyRedirect(f: () => Future[Result]) = {
-    inSequence {
-      mockAuthWithEnrolment(eori3)
-      mockGet[Undertaking](eori3)(Right(undertaking.some))
-    }
-
-    val result = f()
-
-    status(result) shouldBe SEE_OTHER
-    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
-  }
 
 }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -81,7 +81,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -196,7 +196,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -304,7 +304,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -398,7 +398,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -443,7 +443,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourneyOpt))
-            mockUpdate[SubsidyJourney](_ => update(subsidyJourneyOpt), eori1)(Left(Error(exception)))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourneyOpt), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("claim-amount" -> "123.45")))
         }
@@ -538,7 +538,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -624,7 +624,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGetPrevious[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGetPrevious[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -641,7 +641,7 @@ class SubsidyControllerSpec
             mockUpdate[SubsidyJourney](
               _ => update(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(None)).some),
               eori1
-            )(Left(Error(exception)))
+            )(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("should-claim-eori" -> "false")))
         }
@@ -796,7 +796,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -887,7 +887,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGetPrevious[SubsidyJourney](eori1)(Left(Error(exception)))
+            mockGetPrevious[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -1057,7 +1057,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockRetrieveSubsidy(SubsidyRetrieve(undertakingRef, None))(Future.successful(undertakingSubsidies1))
-            mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Left(Error(exception)))
+            mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
         }
@@ -1138,7 +1138,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(Future.successful(undertaking1.some))
-            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Left(Error(exception)))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
@@ -1161,7 +1161,7 @@ class SubsidyControllerSpec
             mockCreateSubsidy(
               undertakingRef,
               SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, currentDate)
-            )(Left(Error(exception)))
+            )(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
@@ -1176,7 +1176,7 @@ class SubsidyControllerSpec
               undertakingRef,
               SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, currentDate)
             )(Right(undertakingRef))
-            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Left(Error(exception)))
+            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
@@ -1273,7 +1273,7 @@ class SubsidyControllerSpec
       .returning(result)
 
   private def mockRemoveSubsidy(reference: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(
-    result: Either[Error, UndertakingRef]
+    result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
       .removeSubsidy(_: UndertakingRef, _: NonHmrcSubsidy)(_: HeaderCarrier))
@@ -1281,7 +1281,7 @@ class SubsidyControllerSpec
       .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
-    result: Either[Error, UndertakingRef]
+    result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1278,7 +1278,7 @@ class SubsidyControllerSpec
     (mockEscService
       .removeSubsidy(_: UndertakingRef, _: NonHmrcSubsidy)(_: HeaderCarrier))
       .expects(reference, nonHmrcSubsidy, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
     result: Either[Error, UndertakingRef]
@@ -1286,7 +1286,7 @@ class SubsidyControllerSpec
     (mockEscService
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
       .expects(reference, subsidyUpdate, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockTimeProviderToday(today: LocalDate) =
     (mockTimeProvider.today _).expects().returning(today)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -76,7 +76,7 @@ class UndertakingControllerSpec
     (mockEscService
       .createUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
     (mockEscService
@@ -88,7 +88,7 @@ class UndertakingControllerSpec
     (mockEscService
       .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
-      .returning(result.fold(e => Future.failed(e.value), Future.successful))
+      .returning(result.fold(e => Future.failed(e), Future.successful))
 
   private def mockTimeProviderNow(now: LocalDateTime) =
     (mockTimeProvider.now _).expects().returning(now)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -76,7 +76,7 @@ class UndertakingControllerSpec
     (mockEscService
       .createUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
     (mockEscService
@@ -88,7 +88,7 @@ class UndertakingControllerSpec
     (mockEscService
       .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
-      .returning(result.fold(e => Future.failed(e.value.fold(s => new Exception(s), identity)), Future.successful))
+      .returning(result.fold(e => Future.failed(e.value), Future.successful))
 
   private def mockTimeProviderNow(now: LocalDateTime) =
     (mockTimeProvider.now _).expects().returning(now)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.UndertakingUpdated
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{Error, Language, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Language, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
@@ -72,7 +72,7 @@ class UndertakingControllerSpec
     )
   )
 
-  private def mockCreateUndertaking(undertaking: Undertaking)(result: Either[Error, UndertakingRef]) =
+  private def mockCreateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
       .createUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
@@ -84,7 +84,7 @@ class UndertakingControllerSpec
       .expects(eori, *)
       .returning(result)
 
-  private def mockUpdateUndertaking(undertaking: Undertaking)(result: Either[Error, UndertakingRef]) =
+  private def mockUpdateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
       .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
@@ -108,7 +108,7 @@ class UndertakingControllerSpec
         "call to fetch undertaking journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -117,7 +117,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[UndertakingJourney](eori1)(Right(None))
-            mockPut[UndertakingJourney](UndertakingJourney(), eori1)(Left(Error(exception)))
+            mockPut[UndertakingJourney](UndertakingJourney(), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -208,7 +208,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingName" -> "TestUndertaking123")))
         }
@@ -230,7 +230,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(Error(exception)))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingName" -> "TestUndertaking123")))
         }
@@ -293,7 +293,7 @@ class UndertakingControllerSpec
         "call to fetch undertaking journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -394,7 +394,7 @@ class UndertakingControllerSpec
         "call to get previous url fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGetPrevious[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGetPrevious[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingSector" -> "2")))
         }
@@ -404,7 +404,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
-            mockUpdate[UndertakingJourney](_ => update(currentUndertaking.some), eori1)(Left(Error(exception)))
+            mockUpdate[UndertakingJourney](_ => update(currentUndertaking.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingSector" -> "2")))
         }
@@ -497,7 +497,7 @@ class UndertakingControllerSpec
             mockUpdate[UndertakingJourney](
               _ => updateFunc(undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some)).some),
               eori1
-            )(Left(Error(exception)))
+            )(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
         }
@@ -514,7 +514,7 @@ class UndertakingControllerSpec
             mockUpdate[UndertakingJourney](_ => updateFunc(updatedUndertakingJourney.some), eori1)(
               Right(updatedUndertakingJourney)
             )
-            mockCreateUndertaking(undertakingCreated)(Left(Error(exception)))
+            mockCreateUndertaking(undertakingCreated)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
 
@@ -534,7 +534,7 @@ class UndertakingControllerSpec
               Right(updatedUndertakingJourney)
             )
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
-            mockRetrieveEmail(eori1)(Left(Error(exception)))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
 
@@ -632,7 +632,7 @@ class UndertakingControllerSpec
         "call to get undertaking journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -674,7 +674,7 @@ class UndertakingControllerSpec
         "call to get undertaking journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockGet[UndertakingJourney](eori1)(Left(Error(exception)))
+            mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -692,7 +692,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(Error(exception)))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -745,7 +745,7 @@ class UndertakingControllerSpec
         "call to update undertaking journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(Error(exception)))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete.some), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
 
@@ -815,7 +815,7 @@ class UndertakingControllerSpec
               Right(undertakingJourneyComplete.copy(isAmend = true))
             )
             mockRetrieveUndertaking(eori)(Future.successful(undertaking1.some))
-            mockUpdateUndertaking(updatedUndertaking)(Left(Error(exception)))
+            mockUpdateUndertaking(updatedUndertaking)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
@@ -16,24 +16,20 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
-import cats.implicits.catsSyntaxOptionId
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import play.api.Configuration
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
-import utils.CommonTestData.{eori1, undertaking}
 
 class UpdateEmailAddressControllerSpec
     extends ControllerSpec
     with AuthSupport
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour
-    with ScalaFutures
-    with LeadOnlyRedirectSupport {
+    with ScalaFutures {
 
   private val mockEscService = mock[EscService]
 
@@ -43,7 +39,7 @@ class UpdateEmailAddressControllerSpec
     bind[EscService].toInstance(mockEscService),
   )
 
-  val redirectUrl = "manage-email-cds/service/eu-subsidy-compliance-frontend"
+  private val redirectUrl = "manage-email-cds/service/eu-subsidy-compliance-frontend"
 
   override def additionalConfig: Configuration = super.additionalConfig.withFallback(
     Configuration(
@@ -66,7 +62,6 @@ class UpdateEmailAddressControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkPageIsDisplayed(
           performAction(),
@@ -79,12 +74,6 @@ class UpdateEmailAddressControllerSpec
         )
 
       }
-
-      "redirect to the account home page" when {
-        "user is not an undertaking lead" in {
-          testLeadOnlyRedirect(performAction)
-        }
-      }
     }
 
     "handling request to update Undelivered Email Address " must {
@@ -94,7 +83,6 @@ class UpdateEmailAddressControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkPageIsDisplayed(
           performAction(),
@@ -107,12 +95,6 @@ class UpdateEmailAddressControllerSpec
         )
       }
 
-      "redirect to the account home page" when {
-        "user is not an undertaking lead" in {
-          testLeadOnlyRedirect(performAction)
-        }
-      }
-
     }
 
     "handling request to post update email address" must {
@@ -122,15 +104,8 @@ class UpdateEmailAddressControllerSpec
       "redirect to next page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkIsRedirect(performAction(), redirectUrl)
-      }
-
-      "redirect to the account home page" when {
-        "user is not an undertaking lead" in {
-          testLeadOnlyRedirect(performAction)
-        }
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
@@ -27,9 +27,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, status}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
-import uk.gov.hmrc.http.HeaderCarrier
 import utils.CommonTestData.{eori1, eori3, undertaking}
 
 import scala.concurrent.Future
@@ -72,7 +70,7 @@ class UpdateEmailAddressControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkPageIsDisplayed(
           performAction(),
@@ -100,7 +98,7 @@ class UpdateEmailAddressControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkPageIsDisplayed(
           performAction(),
@@ -128,7 +126,7 @@ class UpdateEmailAddressControllerSpec
       "redirect to next page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+          mockGet[Undertaking](eori1)(Right(undertaking.some))
         }
         checkIsRedirect(performAction(), redirectUrl)
       }
@@ -142,16 +140,10 @@ class UpdateEmailAddressControllerSpec
     }
   }
 
-  private def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =
-    (mockEscService
-      .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
-      .expects(eori, *)
-      .returning(result)
-
   private def testLeadOnlyRedirect(f: () => Future[Result]) = {
     inSequence {
       mockAuthWithEnrolment(eori3)
-      mockRetrieveUndertaking(eori3)(Future.successful(undertaking.some))
+      mockGet[Undertaking](eori3)(Right(undertaking.some))
     }
 
     val result = f()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UpdateEmailAddressControllerSpec.scala
@@ -20,24 +20,20 @@ import cats.implicits.catsSyntaxOptionId
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import play.api.Configuration
-import play.api.http.Status.SEE_OTHER
 import play.api.inject.bind
-import play.api.mvc.Result
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{defaultAwaitTimeout, redirectLocation, status}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
-import utils.CommonTestData.{eori1, eori3, undertaking}
-
-import scala.concurrent.Future
+import utils.CommonTestData.{eori1, undertaking}
 
 class UpdateEmailAddressControllerSpec
     extends ControllerSpec
     with AuthSupport
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour
-    with ScalaFutures {
+    with ScalaFutures
+    with LeadOnlyRedirectSupport {
 
   private val mockEscService = mock[EscService]
 
@@ -138,18 +134,6 @@ class UpdateEmailAddressControllerSpec
       }
 
     }
-  }
-
-  private def testLeadOnlyRedirect(f: () => Future[Result]) = {
-    inSequence {
-      mockAuthWithEnrolment(eori3)
-      mockGet[Undertaking](eori3)(Right(undertaking.some))
-    }
-
-    val result = f()
-
-    status(result) shouldBe SEE_OTHER
-    redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
   }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Error, SubsidyRetrieve, SubsidyUpdate, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, SubsidyRetrieve, SubsidyUpdate, Undertaking}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.CommonTestData._
 
@@ -39,7 +39,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
   private val service: EscService = new EscService(mockEscConnector)
 
   private def mockCreateUndertaking(undertaking: Undertaking)(
-    result: Either[Error, HttpResponse]
+    result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
       .createUndertaking(_: Undertaking)(_: HeaderCarrier))
@@ -47,21 +47,21 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .returning(Future.successful(result))
 
   private def mockUpdateUndertaking(undertaking: Undertaking)(
-    result: Either[Error, HttpResponse]
+    result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
       .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
       .returning(Future.successful(result))
 
-  private def mockRetrieveUndertaking(eori: EORI)(result: Either[Error, HttpResponse]) =
+  private def mockRetrieveUndertaking(eori: EORI)(result: Either[ConnectorError, HttpResponse]) =
     (mockEscConnector
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
       .returning(Future.successful(result))
 
   private def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
-    result: Either[Error, HttpResponse]
+    result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
       .addMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
@@ -69,7 +69,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .returning(Future.successful(result))
 
   private def mockRemoveMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(
-    result: Either[Error, HttpResponse]
+    result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
       .removeMember(_: UndertakingRef, _: BusinessEntity)(_: HeaderCarrier))
@@ -77,7 +77,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .returning(Future.successful(result))
 
   private def mockCreateSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
-    result: Either[Error, HttpResponse]
+    result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
       .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
@@ -85,7 +85,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .returning(Future.successful(result))
 
   private def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(
-    result: Either[Error, HttpResponse]
+    result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
       .retrieveSubsidy(_: SubsidyRetrieve)(_: HeaderCarrier))
@@ -107,7 +107,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       "return an error" when {
 
         "the http call fails" in {
-          mockCreateUndertaking(undertaking)(Left(Error("")))
+          mockCreateUndertaking(undertaking)(Left(ConnectorError("")))
           val result = service.createUndertaking(undertaking)
           assertThrows[RuntimeException](await(result))
         }
@@ -149,7 +149,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       "return an error" when {
 
         "the http call fails" in {
-          mockUpdateUndertaking(undertaking)(Left(Error("")))
+          mockUpdateUndertaking(undertaking)(Left(ConnectorError("")))
           val result = service.updateUndertaking(undertaking)
           assertThrows[RuntimeException](await(result))
         }
@@ -237,7 +237,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       "return an error" when {
 
         "the http call fails" in {
-          mockAddMember(undertakingRef, businessEntity3)(Left(Error("")))
+          mockAddMember(undertakingRef, businessEntity3)(Left(ConnectorError("")))
           val result = service.addMember(undertakingRef, businessEntity3)
           assertThrows[RuntimeException](await(result))
         }
@@ -286,7 +286,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
         }
 
         "the http call fails" in {
-          mockRemoveMember(undertakingRef, businessEntity3)(Left(Error("")))
+          mockRemoveMember(undertakingRef, businessEntity3)(Left(ConnectorError("")))
           isError()
         }
 
@@ -332,7 +332,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
         }
 
         "the http call fails" in {
-          mockCreateSubsidy(undertakingRef, subsidyUpdate)(Left(Error("")))
+          mockCreateSubsidy(undertakingRef, subsidyUpdate)(Left(ConnectorError("")))
           isError()
         }
 
@@ -376,7 +376,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
         }
 
         "the http call fails" in {
-          mockRetrieveSubsidy(subsidyRetrieve)(Left(Error("")))
+          mockRetrieveSubsidy(subsidyRetrieve)(Left(ConnectorError("")))
           isError()
         }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailServiceSpec.scala
@@ -45,7 +45,7 @@ class RetrieveEmailServiceSpec extends AnyWordSpec with Matchers with MockFactor
 
   private val emptyHeaders = Map.empty[String, Seq[String]]
 
-  private val service = new RetrieveEmailServiceImpl(mockRetrieveEmailConnector)
+  private val service = new RetrieveEmailService(mockRetrieveEmailConnector)
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailServiceSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.RetrieveEmailConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailType.VerifiedEmail
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
@@ -37,7 +37,7 @@ class RetrieveEmailServiceSpec extends AnyWordSpec with Matchers with MockFactor
 
   private val mockRetrieveEmailConnector = mock[RetrieveEmailConnector]
 
-  private def mockRetrieveEmail(eori: EORI)(result: Either[Error, HttpResponse]) =
+  private def mockRetrieveEmail(eori: EORI)(result: Either[ConnectorError, HttpResponse]) =
     (mockRetrieveEmailConnector
       .retrieveEmailByEORI(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
@@ -60,7 +60,7 @@ class RetrieveEmailServiceSpec extends AnyWordSpec with Matchers with MockFactor
       "return an error" when {
 
         "the http call fails" in {
-          mockRetrieveEmail(eori1)(Left(Error("")))
+          mockRetrieveEmail(eori1)(Left(ConnectorError("")))
           val result = service.retrieveEmailByEORI(eori1)
           assertThrows[RuntimeException](await(result))
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SendEmailServiceSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.SendEmailConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Error
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendRequest, EmailSendResult}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import utils.CommonTestData._
@@ -33,7 +33,7 @@ class SendEmailServiceSpec extends AnyWordSpec with Matchers with MockFactory {
 
   private val mockSendEmailConnector: SendEmailConnector = mock[SendEmailConnector]
 
-  private def mockSendEmail(emailSendRequest: EmailSendRequest)(result: Either[Error, HttpResponse]) =
+  private def mockSendEmail(emailSendRequest: EmailSendRequest)(result: Either[ConnectorError, HttpResponse]) =
     (mockSendEmailConnector
       .sendEmail(_: EmailSendRequest)(_: HeaderCarrier))
       .expects(emailSendRequest, *)
@@ -52,7 +52,7 @@ class SendEmailServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       "return an error" when {
 
         "the http call fails" in {
-          mockSendEmail(emailSendRequest)(Left(Error("")))
+          mockSendEmail(emailSendRequest)(Left(ConnectorError("")))
           val result = service.sendEmail(validEmailAddress, emailParameter, templatedId)
           assertThrows[RuntimeException](await(result))
         }


### PR DESCRIPTION
Summary of changes
* lead only eori check now fetches from cache first and only hits backend service if the undertaking isn't cached
* factored out the test code into a support trait
* simplified and renamed the Error class to ConnectorError and it now extends RuntimeException
* removed some unnecessary traits
* other minor tidy ups