### PR TITLE
Esc 414 eori validate for add

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -29,7 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class EscConnector @Inject() (
   http: HttpClient,
-  servicesConfig: ServicesConfig,
+  servicesConfig: ServicesConfig
 )(implicit ec: ExecutionContext) {
 
   private lazy val escURL: String = servicesConfig.baseUrl("esc")

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -64,12 +64,14 @@ class AccountController @Inject() (
     }
   }
 
-  private def getUndertakingAndHandleResponse(implicit r: AuthenticatedEscRequest[AnyContent], e: EORI): Future[Result] = {
+  private def getUndertakingAndHandleResponse(implicit
+    r: AuthenticatedEscRequest[AnyContent],
+    e: EORI
+  ): Future[Result] =
     escService.retrieveUndertaking(r.eoriNumber) flatMap {
       case Some(u) => handleExistingUndertaking(u)
       case None => handleUndertakingNotCreated
     }
-  }
 
   private def handleUndertakingNotCreated(implicit e: EORI): Future[Result] = {
     val result = getOrCreateJourneys().map {
@@ -80,7 +82,9 @@ class AccountController @Inject() (
     result.getOrElse(handleMissingSessionData("Account Home - Undertaking not created -"))
   }
 
-  private def handleExistingUndertaking(u: Undertaking)(implicit r: AuthenticatedEscRequest[AnyContent], e: EORI): Future[Result] = {
+  private def handleExistingUndertaking(
+    u: Undertaking
+  )(implicit r: AuthenticatedEscRequest[AnyContent], e: EORI): Future[Result] = {
     val result = for {
       _ <- store.put(u).toContext
       _ <- getOrCreateJourneys(UndertakingJourney.fromUndertaking(u))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -136,23 +136,14 @@ class BusinessEntityController @Inject() (
 
     val businessEntityEori = "businessEntityEori"
 
-    def handleValidEori(form: FormValues, previous: Uri): Future[Result] =
-      escService.retrieveUndertakingWithResponseCommon(EORI(form.value)).flatMap {
-        case Right(Some(_)) =>
-          BadRequest(
-            eoriPage(
-              eoriForm.withError(businessEntityEori, "businessEntityEori.eoriInUse").fill(form),
-              previous
-            )
-          ).toFuture
+    def getErrorResponse(errorMessageKey: String, previous: String, form: FormValues) =
+      BadRequest(eoriPage(eoriForm.withError(businessEntityEori, errorMessageKey).fill(form), previous)).toFuture
 
-        case Left(_) =>
-          BadRequest(
-            eoriPage(
-              eoriForm.withError(businessEntityEori, s"error.$businessEntityEori.required").fill(form),
-              previous
-            )
-          ).toFuture
+    def handleValidEori(form: FormValues, previous: Uri): Future[Result] =
+      escService.retrieveUndertakingWithErrorResponse(EORI(form.value)).flatMap {
+
+        case Right(Some(_)) => getErrorResponse("businessEntityEori.eoriInUse", previous, form)
+        case Left(_) => getErrorResponse(s"error.$businessEntityEori.required", previous, form)
         case Right(None) =>
           store
             .update[BusinessEntityJourney] {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/ResponseCommon.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/ResponseCommon.scala
@@ -54,4 +54,16 @@ object ResponseCommon {
       (JsPath \ "returnParameters").writeNullable[List[Params]]
   )(unlift(ResponseCommon.unapply))
 
+  implicit val reads: Reads[ResponseCommon] = new Reads[ResponseCommon] {
+    override def reads(json: JsValue): JsResult[ResponseCommon] =
+      JsSuccess(
+        ResponseCommon(
+          (json \ "retrieveUndertakingResponse" \ "responseCommon" \ "status").as[EisStatus],
+          EisStatusString("status text"),
+          (json \ "retrieveUndertakingResponse" \ "responseCommon" \ "processingDate").as[LocalDateTime],
+          None
+        )
+      )
+  }
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/ResponseCommon.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/ResponseCommon.scala
@@ -54,16 +54,4 @@ object ResponseCommon {
       (JsPath \ "returnParameters").writeNullable[List[Params]]
   )(unlift(ResponseCommon.unapply))
 
-  implicit val reads: Reads[ResponseCommon] = new Reads[ResponseCommon] {
-    override def reads(json: JsValue): JsResult[ResponseCommon] =
-      JsSuccess(
-        ResponseCommon(
-          (json \ "retrieveUndertakingResponse" \ "responseCommon" \ "status").as[EisStatus],
-          EisStatusString("status text"),
-          (json \ "retrieveUndertakingResponse" \ "responseCommon" \ "processingDate").as[LocalDateTime],
-          None
-        )
-      )
-  }
-
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -43,12 +43,12 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
       .map(handleResponse[UndertakingRef](_, "update undertaking"))
 
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Option[Undertaking]] =
-    retrieveUndertakingWithResponseCommon(eori).map {
+    retrieveUndertakingWithErrorResponse(eori).map {
       case Left(_) => None
       case Right(undertakingOpt) => undertakingOpt
     }
 
-  def retrieveUndertakingWithResponseCommon(
+  def retrieveUndertakingWithErrorResponse(
     eori: EORI
   )(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Option[Undertaking]]] =
     escConnector.retrieveUndertaking(eori).map {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -59,7 +59,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
           case NOT_ACCEPTABLE =>
             value
               .parseJSON[UpstreamErrorResponse]
-              .fold(_ => sys.error("Error in parsing Response common"), Left(_))
+              .fold(_ => sys.error("Error in parsing Upstream Error Response"), Left(_))
           case OK =>
             value
               .parseJSON[Undertaking]

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -411,7 +411,7 @@ class BusinessEntityControllerSpec
         )(retrieveResponse: Either[UpstreamErrorResponse, Option[Undertaking]], errorMessageKey: String): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertakingWithErrorResponse(eori4)(retrieveResponse)
           }
@@ -472,7 +472,7 @@ class BusinessEntityControllerSpec
             businessEntityJourney.copy(eori = businessEntityJourney.eori.copy(value = Some(eori4)))
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(Future.successful(undertaking.some))
+            mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertakingWithErrorResponse(eori4)(Right(None))
             mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney.some), eori1)(


### PR DESCRIPTION
This PR is to fix a bug when a EORi is entered on add member page. As of now , the backend only handles the exception when the error code is 107 but do not handle if the error code is 055. In case of error 055, the FE should display a form error and says `Enter a valid EORI`. This message is still not confirmed so as of now it' decided to use this message as this EORI is not valid to be used . 
- Change in STUB-> added a scenario where a EORI ending with 777 will give 055 error code.
- Change in BE-> handled the code as 406 cause 404 means not found and not found scenario is handled differently in FE.
- change in FE-  Created a new function  retrieveUndertakingWithErrorResponse which check the response status , if 406, then , parse the response for UpstreamErrorResponse and if it's parsed then throw a display form error. 