### PR TITLE
Esc 515

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -66,9 +66,8 @@ class EscConnector @Inject() (
     http
       .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
       .map(Right(_))
-      .recover {
-        case _: NotFoundException => Right(HttpResponse(NOT_FOUND, ""))
-        case ex => Left(ConnectorError(ex))
+      .recover { case ex =>
+        Left(ConnectorError(ex))
       }
 
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{Inject, Singleton}
-import play.api.http.Status.NOT_FOUND
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidyAmendment}
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, NotFoundException}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -16,9 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
-import cats.implicits.catsSyntaxOptionId
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json.{JsObject, JsResult, JsSuccess, JsValue, Json, OFormat}
+import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
@@ -58,29 +56,4 @@ case class Undertaking(
 
 object Undertaking {
   implicit val undertakingFormat: OFormat[Undertaking] = Json.format[Undertaking]
-  implicit val undertakingOptFormat: OFormat[Option[Undertaking]] = new OFormat[Option[Undertaking]] {
-    override def reads(json: JsValue): JsResult[Option[Undertaking]] =
-      (json \ "name")
-        .validateOpt[UndertakingName]
-        .flatMap {
-          case Some(_) =>
-            JsSuccess(
-              Undertaking(
-                (json \ "reference").asOpt[UndertakingRef],
-                (json \ "name").as[UndertakingName],
-                (json \ "industrySector").as[Sector],
-                (json \ "industrySectorLimit").asOpt[IndustrySectorLimit],
-                (json \ "lastSubsidyUsageUpdt").asOpt[LocalDate],
-                (json \ "undertakingBusinessEntity").as[List[BusinessEntity]]
-              ).some
-            )
-
-          case None => JsSuccess(None)
-        }
-
-    override def writes(o: Option[Undertaking]): JsObject = o match {
-      case Some(u) => Json.writes[Undertaking].writes(u)
-      case None => JsObject.empty
-    }
-  }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
-import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
+import cats.implicits.{catsSyntaxEq}
 import com.google.inject.{Inject, Singleton}
-import play.api.http.Status.{NOT_ACCEPTABLE, NOT_FOUND, OK}
+import play.api.http.Status.{NOT_ACCEPTABLE, OK}
 import play.api.libs.json.{JsResult, JsSuccess, JsValue, Reads}
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
@@ -66,6 +66,8 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
                 _ => sys.error(" Error in parsing undertaking"),
                 undertaking => Right(undertaking)
               )
+
+          case _ => Right(None)
         }
     }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -55,17 +55,16 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
       case Left(_) => Right(None)
       case Right(value) =>
         value.status match {
-          case NOT_FOUND => Right(None)
           case NOT_ACCEPTABLE =>
             value
               .parseJSON[UpstreamErrorResponse]
               .fold(_ => sys.error("Error in parsing Upstream Error Response"), Left(_))
           case OK =>
             value
-              .parseJSON[Undertaking]
+              .parseJSON[Option[Undertaking]]
               .fold(
                 _ => sys.error(" Error in parsing undertaking"),
-                undertaking => Right(undertaking.some)
+                undertaking => Right(undertaking)
               )
         }
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -198,22 +198,8 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
 
       "return an error" when {
 
-        "the http response doesn't come back with status 200(created)" in {
-          mockRetrieveUndertaking(eori1)(Right(HttpResponse(ACCEPTED, undertakingJson, emptyHeaders)))
-          val result = service.retrieveUndertaking(eori1)
-          assertThrows[RuntimeException](await(result))
-        }
-
         "there is no json in the response, with status OK" in {
           mockRetrieveUndertaking(eori1)(Right(HttpResponse(OK, "hi")))
-          val result = service.retrieveUndertaking(eori1)
-          assertThrows[RuntimeException](await(result))
-        }
-
-        "the json in the response can't be parsed, with status 200(OK)" in {
-          val json = Json.parse("""{ "a" : 1 }""")
-
-          mockRetrieveUndertaking(eori1)(Right(HttpResponse(OK, json, emptyHeaders)))
           val result = service.retrieveUndertaking(eori1)
           assertThrows[RuntimeException](await(result))
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -204,14 +204,6 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
           assertThrows[RuntimeException](await(result))
         }
 
-        "status is NOt acceptable, but can't be parsed as UpstreamErrorResponse" in {
-          val json = Json.parse("""{ "a" : 1 }""")
-
-          mockRetrieveUndertaking(eori1)(Right(HttpResponse(NOT_ACCEPTABLE, json, emptyHeaders)))
-          val result = service.retrieveUndertaking(eori1)
-          assertThrows[RuntimeException](await(result))
-        }
-
       }
 
       "return successfully" when {


### PR DESCRIPTION
Since the BE retrieve undertaking now return Option, the Http Response json has to be parsed for Option[Undertaking], 
aded OFormat for Option[Undertaking]. I tried this change with Either [ConnectorError, Undertaking] as well. It is also working fine , We need to include the oFormat for Either[A,B]. Kept this Option to make it simple can do Either one as well if majority decides :)