### PR TITLE
ESC-421 simplify store update function types plus other tidy ups

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -120,7 +120,7 @@ class AccountController @Inject() (
           .orElse(store.put[NilReturnJourney](NilReturnJourney()).toContext)
         updatedJourney <-
           if (isUpdateNeededForNilJourneyCounter(nilReturnJourney))
-            store.update2[NilReturnJourney](updateNilReturnCounter).toContext
+            store.update[NilReturnJourney](updateNilReturnCounter).toContext
           else nilReturnJourney.some.toContext
         result <- Ok(
           leadAccountPage(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -120,7 +120,7 @@ class AccountController @Inject() (
           .orElse(store.put[NilReturnJourney](NilReturnJourney()).toContext)
         updatedJourney <-
           if (isUpdateNeededForNilJourneyCounter(nilReturnJourney))
-            store.update[NilReturnJourney](updateNilReturnCounter).toContext
+            store.update2[NilReturnJourney](updateNilReturnCounter).toContext
           else nilReturnJourney.some.toContext
         result <- Ok(
           leadAccountPage(
@@ -140,12 +140,8 @@ class AccountController @Inject() (
     } else Ok(nonLeadAccountPage(undertaking)).toFuture
   }
 
-  private def updateNilReturnJourney(nrj: Option[NilReturnJourney])(f: NilReturnJourney => NilReturnJourney) =
-    nrj.map(f)
-
-  private def updateNilReturnCounter(nrj: Option[NilReturnJourney]) = updateNilReturnJourney(nrj) { nj =>
-    nj.copy(nilReturnCounter = nj.nilReturnCounter + 1)
-  }
+  // TODO - this could be a method on the journey class itself
+  private def updateNilReturnCounter(nrj: NilReturnJourney) = nrj.copy(nilReturnCounter = nrj.nilReturnCounter + 1)
 
   //nilReturnCounter is used to track when user has moved to home account page after nil return claim
   //This counter also helps in identifying when to display the success message which should be displayed only once

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -51,7 +51,7 @@ class AccountController @Inject() (
 
   import escActionBuilders._
 
-  val dueDays = 90
+  private val dueDays = 90
 
   def getAccountPage: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
@@ -119,8 +119,8 @@ class AccountController @Inject() (
           .toContext
           .orElse(store.put[NilReturnJourney](NilReturnJourney()).toContext)
         updatedJourney <-
-          if (isUpdateNeededForNilJourneyCounter(nilReturnJourney))
-            store.update[NilReturnJourney](updateNilReturnCounter).toContext
+          if (nilReturnJourney.canIncrementNilReturnCounter)
+            store.update[NilReturnJourney](_.incrementNilReturnCounter).toContext
           else nilReturnJourney.some.toContext
         result <- Ok(
           leadAccountPage(
@@ -139,20 +139,5 @@ class AccountController @Inject() (
 
     } else Ok(nonLeadAccountPage(undertaking)).toFuture
   }
-
-  // TODO - this could be a method on the journey class itself
-  private def updateNilReturnCounter(nrj: NilReturnJourney) = nrj.copy(nilReturnCounter = nrj.nilReturnCounter + 1)
-
-  //nilReturnCounter is used to track when user has moved to home account page after nil return claim
-  //This counter also helps in identifying when to display the success message which should be displayed only once
-  //By default,  NilReturnJourney has counter set to 0. When user submit on No claim page, the count is set to 1, indicating user has started the nil return journey.
-  // Home account has logic to update the counter only if hasNilJourneyStarted or isNilJourneyDoneRecently.
-  // Since the journey has started ,when the user is redirected to home account, counter get updated to 2.
-  // Home page has logic to display the message only if the isNilJourneyDoneRecently . At this point the message will be displayed.
-  //If user refreshes or return to home page via another journey, counter is updated and success message is no longer displayed
-  //Since neither the nil journey has just started nor finished recently, counter will no longer be updated because of this func logic
-  // and will be reset to 1 if user goes on to nil return journey again.
-  private def isUpdateNeededForNilJourneyCounter(nilReturnJourney: NilReturnJourney) =
-    nilReturnJourney.hasNilJourneyStarted || nilReturnJourney.isNilJourneyDoneRecently
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -175,7 +175,7 @@ class BecomeLeadController @Inject() (
     )
   }
 
-  lazy val becomeAdminForm: Form[FormValues] = Form(
+  private val becomeAdminForm: Form[FormValues] = Form(
     mapping("becomeAdmin" -> mandatory("becomeAdmin"))(FormValues.apply)(FormValues.unapply)
   )
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -94,7 +94,7 @@ class BecomeLeadController @Inject() (
           },
         form =>
           store
-            .update2[BecomeLeadJourney](j => j.copy(becomeLeadEori = j.becomeLeadEori.copy(value = Some(form.value == "true"))))
+            .update[BecomeLeadJourney](j => j.copy(becomeLeadEori = j.becomeLeadEori.copy(value = Some(form.value == "true"))))
             .flatMap { _ =>
               if (form.value == "true") Future(Redirect(routes.BecomeLeadController.getAcceptPromotionTerms()))
               else Future(Redirect(routes.AccountController.getAccountPage()))
@@ -118,7 +118,7 @@ class BecomeLeadController @Inject() (
   def postAcceptPromotionTerms: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
     store
-      .update2[BecomeLeadJourney](j => j.copy(acceptTerms = j.acceptTerms.copy(value = Some(true))))
+      .update[BecomeLeadJourney](j => j.copy(acceptTerms = j.acceptTerms.copy(value = Some(true))))
       .flatMap(_ => Future(Redirect(routes.BecomeLeadController.getPromotionConfirmation())))
   }
 
@@ -170,7 +170,7 @@ class BecomeLeadController @Inject() (
   def getPromotionCleanup: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
     store
-      .update2[BecomeLeadJourney](_ => BecomeLeadJourney())
+      .update[BecomeLeadJourney](_ => BecomeLeadJourney())
       .flatMap(_ => Future(Redirect(routes.AccountController.getAccountPage()))
     )
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -94,12 +94,7 @@ class BecomeLeadController @Inject() (
           },
         form =>
           store
-            .update[BecomeLeadJourney] {
-              _.map { becomeLeadJourney =>
-                becomeLeadJourney
-                  .copy(becomeLeadEori = becomeLeadJourney.becomeLeadEori.copy(value = Some(form.value == "true")))
-              }
-            }
+            .update2[BecomeLeadJourney](j => j.copy(becomeLeadEori = j.becomeLeadEori.copy(value = Some(form.value == "true"))))
             .flatMap { _ =>
               if (form.value == "true") Future(Redirect(routes.BecomeLeadController.getAcceptPromotionTerms()))
               else Future(Redirect(routes.AccountController.getAccountPage()))
@@ -123,14 +118,8 @@ class BecomeLeadController @Inject() (
   def postAcceptPromotionTerms: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
     store
-      .update[BecomeLeadJourney] {
-        _.map { becomeLeadJourney =>
-          becomeLeadJourney.copy(acceptTerms = becomeLeadJourney.acceptTerms.copy(value = Some(true)))
-        }
-      }
-      .flatMap { _ =>
-        Future(Redirect(routes.BecomeLeadController.getPromotionConfirmation()))
-      }
+      .update2[BecomeLeadJourney](j => j.copy(acceptTerms = j.acceptTerms.copy(value = Some(true))))
+      .flatMap(_ => Future(Redirect(routes.BecomeLeadController.getPromotionConfirmation())))
   }
 
   def getPromotionConfirmation: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
@@ -181,12 +170,9 @@ class BecomeLeadController @Inject() (
   def getPromotionCleanup: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
     store
-      .update[BecomeLeadJourney] {
-        _.map(_ => BecomeLeadJourney())
-      }
-      .flatMap { _ =>
-        Future(Redirect(routes.AccountController.getAccountPage()))
-      }
+      .update2[BecomeLeadJourney](_ => BecomeLeadJourney())
+      .flatMap(_ => Future(Redirect(routes.AccountController.getAccountPage()))
+    )
   }
 
   lazy val becomeAdminForm: Form[FormValues] = Form(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -358,21 +358,21 @@ class BusinessEntityController @Inject() (
           .map(_ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()))
     }
 
-  lazy val addBusinessForm: Form[FormValues] = Form(
+  private val addBusinessForm: Form[FormValues] = Form(
     mapping("addBusiness" -> mandatory("addBusiness"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val removeBusinessForm: Form[FormValues] = Form(
+  private val removeBusinessForm: Form[FormValues] = Form(
     mapping("removeBusiness" -> mandatory("removeBusiness"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val removeYourselfBusinessForm: Form[FormValues] = Form(
+  private val removeYourselfBusinessForm: Form[FormValues] = Form(
     mapping("removeYourselfBusinessEntity" -> mandatory("removeYourselfBusinessEntity"))(FormValues.apply)(
       FormValues.unapply
     )
   )
 
-  lazy val eoriForm: Form[FormValues] = Form(
+  private val eoriForm: Form[FormValues] = Form(
     mapping("businessEntityEori" -> mandatory("businessEntityEori"))(eoriEntered =>
       FormValues(s"$eoriPrefix$eoriEntered")
     )(eori => eori.value.drop(2).some)
@@ -383,6 +383,6 @@ class BusinessEntityController @Inject() (
       .verifying("businessEntityEori.regex.error", eori => eori.value.matches(EORI.regex))
   )
 
-  lazy val cyaForm: Form[FormValues] = Form(mapping("cya" -> mandatory("cya"))(FormValues.apply)(FormValues.unapply))
+  private val cyaForm: Form[FormValues] = Form(mapping("cya" -> mandatory("cya"))(FormValues.apply)(FormValues.unapply))
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -96,7 +96,7 @@ class BusinessEntityController @Inject() (
     implicit val eori: EORI = request.eoriNumber
 
     def handleValidAnswer(form: FormValues) = {
-      if (form.value === "true") store.update[BusinessEntityJourney](updateAddBusiness(form)).flatMap(_.next)
+      if (form.value === "true") store.update[BusinessEntityJourney](_.setAddBusiness(form.value.toBoolean)).flatMap(_.next)
       else Redirect(routes.AccountController.getAccountPage()).toFuture
     }
 
@@ -138,7 +138,7 @@ class BusinessEntityController @Inject() (
 
         case Right(Some(_)) => getErrorResponse("businessEntityEori.eoriInUse", previous, form)
         case Left(_) => getErrorResponse(s"error.$businessEntityEori.required", previous, form)
-        case Right(None) => store.update[BusinessEntityJourney](updateEori(form)).flatMap(_.next)
+        case Right(None) => store.update[BusinessEntityJourney](_.setEori(EORI(form.value))).flatMap(_.next)
       }
 
     withLeadUndertaking { _ =>
@@ -357,16 +357,6 @@ class BusinessEntityController @Inject() (
           .put[BusinessEntityJourney](BusinessEntityJourney())
           .map(_ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()))
     }
-
-  // TODO - consider moving these methods onto the journey itself
-  def updateEori(f: FormValues)(journey: BusinessEntityJourney) =
-    journey.copy(eori = journey.eori.copy(
-      value = EORI(f.value).some),
-      oldEORI = journey.eori.value
-    )
-
-  def updateAddBusiness(f: FormValues)(journey: BusinessEntityJourney) =
-    journey.copy(addBusiness = journey.addBusiness.copy(value = f.value.toBoolean.some))
 
   lazy val addBusinessForm: Form[FormValues] = Form(
     mapping("addBusiness" -> mandatory("addBusiness"))(FormValues.apply)(FormValues.unapply)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -96,7 +96,7 @@ class BusinessEntityController @Inject() (
     implicit val eori: EORI = request.eoriNumber
 
     def handleValidAnswer(form: FormValues) = {
-      if (form.value === "true") store.update2[BusinessEntityJourney](updateAddBusiness(form)).flatMap(_.next)
+      if (form.value === "true") store.update[BusinessEntityJourney](updateAddBusiness(form)).flatMap(_.next)
       else Redirect(routes.AccountController.getAccountPage()).toFuture
     }
 
@@ -138,7 +138,7 @@ class BusinessEntityController @Inject() (
 
         case Right(Some(_)) => getErrorResponse("businessEntityEori.eoriInUse", previous, form)
         case Left(_) => getErrorResponse(s"error.$businessEntityEori.required", previous, form)
-        case Right(None) => store.update2[BusinessEntityJourney](updateEori(form)).flatMap(_.next)
+        case Right(None) => store.update[BusinessEntityJourney](updateEori(form)).flatMap(_.next)
       }
 
     withLeadUndertaking { _ =>

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
@@ -54,27 +54,27 @@ class EligibilityController @Inject() (
 
   import escActionBuilders._
 
-  lazy val customsWaiversForm: Form[FormValues] = Form(
+  private val customsWaiversForm: Form[FormValues] = Form(
     mapping("customswaivers" -> mandatory("customswaivers"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val mainBusinessCheckForm: Form[FormValues] = Form(
+  private val mainBusinessCheckForm: Form[FormValues] = Form(
     mapping("mainbusinesscheck" -> mandatory("mainbusinesscheck"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val willYouClaimForm: Form[FormValues] = Form(
+  private val willYouClaimForm: Form[FormValues] = Form(
     mapping("willyouclaim" -> mandatory("willyouclaim"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val termsForm: Form[FormValues] = Form(
+  private val termsForm: Form[FormValues] = Form(
     mapping("terms" -> mandatory("terms"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val eoriCheckForm: Form[FormValues] = Form(
+  private val eoriCheckForm: Form[FormValues] = Form(
     mapping("eoricheck" -> mandatory("eoricheck"))(FormValues.apply)(FormValues.unapply)
   )
 
-  lazy val createUndertakingForm: Form[FormValues] = Form(
+  private val createUndertakingForm: Form[FormValues] = Form(
     mapping("createUndertaking" -> mandatory("createUndertaking"))(FormValues.apply)(FormValues.unapply)
   )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
@@ -82,7 +82,7 @@ class EligibilityController @Inject() (
       .bindFromRequest()
       .fold(
         errors => Future.successful(BadRequest(checkEoriPage(errors, eori))),
-        form => store.update2[EligibilityJourney](updateEoriCheck(form.value.toBoolean)).flatMap(_.next)
+        form => store.update[EligibilityJourney](updateEoriCheck(form.value.toBoolean)).flatMap(_.next)
       )
 
   }
@@ -107,7 +107,7 @@ class EligibilityController @Inject() (
         .bindFromRequest()
         .fold(
           errors => Future.successful(BadRequest(customsWaiversPage(errors, previous))),
-          form => store.update2[EligibilityJourney](updateCustomWaiver(form.value.toBoolean)).flatMap(_.next)
+          form => store.update[EligibilityJourney](updateCustomWaiver(form.value.toBoolean)).flatMap(_.next)
         )
     }
   }
@@ -132,7 +132,7 @@ class EligibilityController @Inject() (
         .bindFromRequest()
         .fold(
           errors => Future.successful(BadRequest(willYouClaimPage(errors, previous))),
-          form => store.update2[EligibilityJourney](updateWillYouClaim(form.value.toBoolean)).flatMap(_.next)
+          form => store.update[EligibilityJourney](updateWillYouClaim(form.value.toBoolean)).flatMap(_.next)
         )
     }
   }
@@ -163,7 +163,7 @@ class EligibilityController @Inject() (
           .bindFromRequest()
           .fold(
             errors => Future.successful(BadRequest(mainBusinessCheckPage(errors, eori, previous))),
-            form => store.update2[EligibilityJourney](updateMainBusinessCheck(form.value.toBoolean)).flatMap(_.next)
+            form => store.update[EligibilityJourney](updateMainBusinessCheck(form.value.toBoolean)).flatMap(_.next)
           )
       }
   }
@@ -186,7 +186,7 @@ class EligibilityController @Inject() (
       .fold(
         _ => throw new IllegalStateException("value hard-coded, form hacking?"),
         form =>
-          store.update2[EligibilityJourney](updateAcceptTerms(form.value.toBoolean)).flatMap { eligibilityJourney =>
+          store.update[EligibilityJourney](updateAcceptTerms(form.value.toBoolean)).flatMap { eligibilityJourney =>
             auditService.sendEvent(TermsAndConditionsAccepted(eori))
             eligibilityJourney.next
           }
@@ -212,7 +212,7 @@ class EligibilityController @Inject() (
       .fold(
         _ => throw new IllegalStateException("value hard-coded, form hacking?"),
         form =>
-          store.update2[EligibilityJourney](updateCreateUndertaking(form.value.toBoolean)).map { _ =>
+          store.update[EligibilityJourney](updateCreateUndertaking(form.value.toBoolean)).map { _ =>
             Redirect(routes.UndertakingController.getUndertakingName())
           }
       )

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
@@ -131,7 +131,7 @@ class EligibilityController @Inject() (
         .bindFromRequest()
         .fold(
           errors => Future.successful(BadRequest(customsWaiversPage(errors, previous))),
-          form => store.update[EligibilityJourney](_.setCustomWaiver(form.value.toBoolean)).flatMap(_.next)
+          form => store.update[EligibilityJourney](_.setCustomsWaiver(form.value.toBoolean)).flatMap(_.next)
         )
     }
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
@@ -54,6 +54,30 @@ class EligibilityController @Inject() (
 
   import escActionBuilders._
 
+  lazy val customsWaiversForm: Form[FormValues] = Form(
+    mapping("customswaivers" -> mandatory("customswaivers"))(FormValues.apply)(FormValues.unapply)
+  )
+
+  lazy val mainBusinessCheckForm: Form[FormValues] = Form(
+    mapping("mainbusinesscheck" -> mandatory("mainbusinesscheck"))(FormValues.apply)(FormValues.unapply)
+  )
+
+  lazy val willYouClaimForm: Form[FormValues] = Form(
+    mapping("willyouclaim" -> mandatory("willyouclaim"))(FormValues.apply)(FormValues.unapply)
+  )
+
+  lazy val termsForm: Form[FormValues] = Form(
+    mapping("terms" -> mandatory("terms"))(FormValues.apply)(FormValues.unapply)
+  )
+
+  lazy val eoriCheckForm: Form[FormValues] = Form(
+    mapping("eoricheck" -> mandatory("eoricheck"))(FormValues.apply)(FormValues.unapply)
+  )
+
+  lazy val createUndertakingForm: Form[FormValues] = Form(
+    mapping("createUndertaking" -> mandatory("createUndertaking"))(FormValues.apply)(FormValues.unapply)
+  )
+
   def firstEmptyPage: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
     store
@@ -82,7 +106,7 @@ class EligibilityController @Inject() (
       .bindFromRequest()
       .fold(
         errors => Future.successful(BadRequest(checkEoriPage(errors, eori))),
-        form => store.update[EligibilityJourney](updateEoriCheck(form.value.toBoolean)).flatMap(_.next)
+        form => store.update[EligibilityJourney](_.setEoriCheck(form.value.toBoolean)).flatMap(_.next)
       )
 
   }
@@ -107,7 +131,7 @@ class EligibilityController @Inject() (
         .bindFromRequest()
         .fold(
           errors => Future.successful(BadRequest(customsWaiversPage(errors, previous))),
-          form => store.update[EligibilityJourney](updateCustomWaiver(form.value.toBoolean)).flatMap(_.next)
+          form => store.update[EligibilityJourney](_.setCustomWaiver(form.value.toBoolean)).flatMap(_.next)
         )
     }
   }
@@ -132,7 +156,7 @@ class EligibilityController @Inject() (
         .bindFromRequest()
         .fold(
           errors => Future.successful(BadRequest(willYouClaimPage(errors, previous))),
-          form => store.update[EligibilityJourney](updateWillYouClaim(form.value.toBoolean)).flatMap(_.next)
+          form => store.update[EligibilityJourney](_.setWillYouClaim(form.value.toBoolean)).flatMap(_.next)
         )
     }
   }
@@ -163,7 +187,7 @@ class EligibilityController @Inject() (
           .bindFromRequest()
           .fold(
             errors => Future.successful(BadRequest(mainBusinessCheckPage(errors, eori, previous))),
-            form => store.update[EligibilityJourney](updateMainBusinessCheck(form.value.toBoolean)).flatMap(_.next)
+            form => store.update[EligibilityJourney](_.setMainBusinessCheck(form.value.toBoolean)).flatMap(_.next)
           )
       }
   }
@@ -186,7 +210,7 @@ class EligibilityController @Inject() (
       .fold(
         _ => throw new IllegalStateException("value hard-coded, form hacking?"),
         form =>
-          store.update[EligibilityJourney](updateAcceptTerms(form.value.toBoolean)).flatMap { eligibilityJourney =>
+          store.update[EligibilityJourney](_.setAcceptTerms(form.value.toBoolean)).flatMap { eligibilityJourney =>
             auditService.sendEvent(TermsAndConditionsAccepted(eori))
             eligibilityJourney.next
           }
@@ -212,53 +236,10 @@ class EligibilityController @Inject() (
       .fold(
         _ => throw new IllegalStateException("value hard-coded, form hacking?"),
         form =>
-          store.update[EligibilityJourney](updateCreateUndertaking(form.value.toBoolean)).map { _ =>
+          store.update[EligibilityJourney](_.setCreateUndertaking(form.value.toBoolean)).map { _ =>
             Redirect(routes.UndertakingController.getUndertakingName())
           }
       )
   }
-
-  // TODO - move these update methods into the Journey itself. They don't really belong here.
-  def updateWillYouClaim(newWillYouClaim: Boolean)(ej: EligibilityJourney) =
-      ej.copy(willYouClaim = ej.willYouClaim.copy(value = Some(newWillYouClaim)))
-
-  def updateCustomWaiver(newCustomWaiver: Boolean)(ej: EligibilityJourney) =
-      ej.copy(customsWaivers = ej.customsWaivers.copy(value = Some(newCustomWaiver)))
-
-  def updateMainBusinessCheck(newMainBusinessCheck: Boolean)(ej: EligibilityJourney) =
-    ej.copy(mainBusinessCheck = ej.mainBusinessCheck.copy(value = Some(newMainBusinessCheck)))
-
-  def updateAcceptTerms(newAcceptTerms: Boolean)(ej: EligibilityJourney) =
-      ej.copy(acceptTerms = ej.acceptTerms.copy(value = Some(newAcceptTerms)))
-
-  def updateEoriCheck(newEoriCheck: Boolean)(ej: EligibilityJourney) =
-    ej.copy(eoriCheck = ej.eoriCheck.copy(value = Some(newEoriCheck)))
-
-  def updateCreateUndertaking(newCreateUndertaking: Boolean)(ej: EligibilityJourney) =
-    ej.copy(createUndertaking = ej.createUndertaking.copy(value = Some(newCreateUndertaking)))
-
-  lazy val customsWaiversForm: Form[FormValues] = Form(
-    mapping("customswaivers" -> mandatory("customswaivers"))(FormValues.apply)(FormValues.unapply)
-  )
-
-  lazy val mainBusinessCheckForm: Form[FormValues] = Form(
-    mapping("mainbusinesscheck" -> mandatory("mainbusinesscheck"))(FormValues.apply)(FormValues.unapply)
-  )
-
-  lazy val willYouClaimForm: Form[FormValues] = Form(
-    mapping("willyouclaim" -> mandatory("willyouclaim"))(FormValues.apply)(FormValues.unapply)
-  )
-
-  lazy val termsForm: Form[FormValues] = Form(
-    mapping("terms" -> mandatory("terms"))(FormValues.apply)(FormValues.unapply)
-  )
-
-  lazy val eoriCheckForm: Form[FormValues] = Form(
-    mapping("eoricheck" -> mandatory("eoricheck"))(FormValues.apply)(FormValues.unapply)
-  )
-
-  lazy val createUndertakingForm: Form[FormValues] = Form(
-    mapping("createUndertaking" -> mandatory("createUndertaking"))(FormValues.apply)(FormValues.unapply)
-  )
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
@@ -51,9 +51,7 @@ class NoBusinessPresentController @Inject() (
     withLeadUndertaking { _ =>
       implicit val eori: EORI = request.eoriNumber
       for {
-        _ <- store.update[BusinessEntityJourney] { businessEntityJourneyOpt =>
-          businessEntityJourneyOpt.map(_.copy(isLeadSelectJourney = true.some))
-        }
+        _ <- store.update2[BusinessEntityJourney](_.copy(isLeadSelectJourney = true.some))
       } yield Redirect(routes.BusinessEntityController.getAddBusinessEntity())
     }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
@@ -51,7 +51,7 @@ class NoBusinessPresentController @Inject() (
     withLeadUndertaking { _ =>
       implicit val eori: EORI = request.eoriNumber
       for {
-        _ <- store.update2[BusinessEntityJourney](_.copy(isLeadSelectJourney = true.some))
+        _ <- store.update[BusinessEntityJourney](_.copy(isLeadSelectJourney = true.some))
       } yield Redirect(routes.BusinessEntityController.getAddBusinessEntity())
     }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -66,7 +66,7 @@ class NoClaimNotificationController @Inject() (
             val nilSubmissionDate = timeProvider.today
             val result = for {
               reference <- undertaking.reference.toContext
-              _ <- store.update[NilReturnJourney](updateNilReturnValues(form)).toContext
+              _ <- store.update2[NilReturnJourney](updateNilReturnValues(form)).toContext
               _ <- escService
                 .createSubsidy(reference, SubsidyUpdate(reference, NilSubmissionDate(nilSubmissionDate)))
                 .toContext
@@ -82,12 +82,9 @@ class NoClaimNotificationController @Inject() (
     }
   }
 
-  def updateNilReturnJourney(nrj: Option[NilReturnJourney])(f: NilReturnJourney => NilReturnJourney) =
-    nrj.map(f)
-
-  def updateNilReturnValues(f: FormValues)(nrj: Option[NilReturnJourney]) = updateNilReturnJourney(nrj) { nj =>
-    nj.copy(nilReturn = nj.nilReturn.copy(value = Some(f.value.toBoolean)), nilReturnCounter = 1)
-  }
+  // TODO - consider adding methods to the journey class
+  def updateNilReturnValues(f: FormValues)(j: NilReturnJourney) =
+    j.copy(nilReturn = j.nilReturn.copy(value = Some(f.value.toBoolean)), nilReturnCounter = 1)
 
   lazy val noClaimForm: Form[FormValues] = Form(
     mapping("noClaimNotification" -> mandatory("noClaimNotification"))(FormValues.apply)(FormValues.unapply)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -66,7 +66,7 @@ class NoClaimNotificationController @Inject() (
             val nilSubmissionDate = timeProvider.today
             val result = for {
               reference <- undertaking.reference.toContext
-              _ <- store.update2[NilReturnJourney](updateNilReturnValues(form)).toContext
+              _ <- store.update[NilReturnJourney](updateNilReturnValues(form)).toContext
               _ <- escService
                 .createSubsidy(reference, SubsidyUpdate(reference, NilSubmissionDate(nilSubmissionDate)))
                 .toContext

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -82,7 +82,7 @@ class NoClaimNotificationController @Inject() (
     }
   }
 
-  lazy val noClaimForm: Form[FormValues] = Form(
+  private val noClaimForm: Form[FormValues] = Form(
     mapping("noClaimNotification" -> mandatory("noClaimNotification"))(FormValues.apply)(FormValues.unapply)
   )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -66,7 +66,7 @@ class NoClaimNotificationController @Inject() (
             val nilSubmissionDate = timeProvider.today
             val result = for {
               reference <- undertaking.reference.toContext
-              _ <- store.update[NilReturnJourney](updateNilReturnValues(form)).toContext
+              _ <- store.update[NilReturnJourney](_.setNilReturnValues(form.value.toBoolean)).toContext
               _ <- escService
                 .createSubsidy(reference, SubsidyUpdate(reference, NilSubmissionDate(nilSubmissionDate)))
                 .toContext
@@ -81,10 +81,6 @@ class NoClaimNotificationController @Inject() (
         )
     }
   }
-
-  // TODO - consider adding methods to the journey class
-  def updateNilReturnValues(f: FormValues)(j: NilReturnJourney) =
-    j.copy(nilReturn = j.nilReturn.copy(value = Some(f.value.toBoolean)), nilReturnCounter = 1)
 
   lazy val noClaimForm: Form[FormValues] = Form(
     mapping("noClaimNotification" -> mandatory("noClaimNotification"))(FormValues.apply)(FormValues.unapply)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -51,7 +51,7 @@ class SelectNewLeadController @Inject() (
   private val promoteOtherAsLeadEmailToBusinessEntity = "promoteAsLeadEmailToBE"
   private val promoteOtherAsLeadEmailToLead = "promoteAsLeadEmailToLead"
 
-  private lazy val selectNewLeadForm: Form[FormValues] = Form(
+  private val selectNewLeadForm: Form[FormValues] = Form(
     mapping("selectNewLead" -> mandatory("selectNewLead"))(FormValues.apply)(FormValues.unapply)
   )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -87,7 +87,7 @@ class SelectNewLeadController @Inject() (
         val eoriBE = EORI(form.value)
         val undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("Undertaking Ref"))
         for {
-          _ <- store.update2[NewLeadJourney] { newLeadJourney =>
+          _ <- store.update[NewLeadJourney] { newLeadJourney =>
             val updatedLead = newLeadJourney.selectNewLead.copy(value = eoriBE.some)
             newLeadJourney.copy(selectNewLead = updatedLead)
           }
@@ -127,7 +127,7 @@ class SelectNewLeadController @Inject() (
       store.get[NewLeadJourney].flatMap {
         case Some(newLeadJourney) =>
           for {
-            _ <- store.update2[BusinessEntityJourney](b => b.copy(isLeadSelectJourney = None))
+            _ <- store.update[BusinessEntityJourney](b => b.copy(isLeadSelectJourney = None))
             _ <- store.put[NewLeadJourney](NewLeadJourney())
             selectedEORI = newLeadJourney.selectNewLead.value.getOrElse(handleMissingSessionData("selected EORI"))
           } yield Ok(leadEORIChangedPage(selectedEORI, undertaking.name))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -143,7 +143,7 @@ class SubsidyController @Inject() (
           formWithErrors => handleReportPaymentFormError(previous, undertaking, formWithErrors),
           form =>
             for {
-              journey <- store.update2[SubsidyJourney](_.setReportPayment(form.value.toBoolean))
+              journey <- store.update[SubsidyJourney](_.setReportPayment(form.value.toBoolean))
               redirect <-
                 if (form.value === "true") journey.next
                 else Redirect(routes.AccountController.getAccountPage()).toFuture
@@ -178,7 +178,7 @@ class SubsidyController @Inject() (
             BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture,
           form =>
             for {
-              journey <- store.update2[SubsidyJourney](_.setClaimAmount(form))
+              journey <- store.update[SubsidyJourney](_.setClaimAmount(form))
               redirect <- journey.next
             } yield redirect
         )
@@ -218,7 +218,7 @@ class SubsidyController @Inject() (
             formWithErrors => BadRequest(addClaimDatePage(formWithErrors, previous)).toFuture,
             form =>
               for {
-                journey <- store.update2[SubsidyJourney](_.setClaimDate(form))
+                journey <- store.update[SubsidyJourney](_.setClaimDate(form))
                 redirect <- journey.next
               } yield redirect
           )
@@ -254,7 +254,7 @@ class SubsidyController @Inject() (
             formWithErrors => BadRequest(addClaimEoriPage(formWithErrors, previous)).toFuture,
             (form: OptionalEORI) =>
               for {
-                journey <- store.update2[SubsidyJourney](_.setClaimEori(form))
+                journey <- store.update[SubsidyJourney](_.setClaimEori(form))
                 redirect <- journey.next
               } yield redirect
           )
@@ -286,7 +286,7 @@ class SubsidyController @Inject() (
             errors => BadRequest(addPublicAuthorityPage(errors, previous)).toFuture,
             form =>
               for {
-                journey <- store.update2[SubsidyJourney](_.setPublicAuthority(form))
+                journey <- store.update[SubsidyJourney](_.setPublicAuthority(form))
                 redirect <- journey.next
               } yield redirect
           )
@@ -318,7 +318,7 @@ class SubsidyController @Inject() (
             errors => BadRequest(addTraderReferencePage(errors, previous)).toFuture,
             form =>
               for {
-                updatedSubsidyJourney <- store.update2[SubsidyJourney](_.setTraderRef(form))
+                updatedSubsidyJourney <- store.update[SubsidyJourney](_.setTraderRef(form))
                 redirect <- updatedSubsidyJourney.next
               } yield redirect
           )
@@ -358,7 +358,7 @@ class SubsidyController @Inject() (
           form =>
             {
               for {
-                journey <- store.update2[SubsidyJourney](_.setCya(form.value.toBoolean)).toContext
+                journey <- store.update[SubsidyJourney](_.setCya(form.value.toBoolean)).toContext
                 _ <- validateSubsidyJourneyFieldsPopulated(journey).toContext
                 ref <- undertaking.reference.toContext
                 currentDate = timeProvider.today

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -143,7 +143,7 @@ class SubsidyController @Inject() (
           formWithErrors => handleReportPaymentFormError(previous, undertaking, formWithErrors),
           form =>
             for {
-              journey <- store.update[SubsidyJourney](_.map(_.setReportPayment(form.value.toBoolean)))
+              journey <- store.update2[SubsidyJourney](_.setReportPayment(form.value.toBoolean))
               redirect <-
                 if (form.value === "true") journey.next
                 else Redirect(routes.AccountController.getAccountPage()).toFuture
@@ -178,7 +178,7 @@ class SubsidyController @Inject() (
             BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture,
           form =>
             for {
-              journey <- store.update[SubsidyJourney](_.map(_.setClaimAmount(form)))
+              journey <- store.update2[SubsidyJourney](_.setClaimAmount(form))
               redirect <- journey.next
             } yield redirect
         )
@@ -218,7 +218,7 @@ class SubsidyController @Inject() (
             formWithErrors => BadRequest(addClaimDatePage(formWithErrors, previous)).toFuture,
             form =>
               for {
-                journey <- store.update[SubsidyJourney](_.map(_.setClaimDate(form)))
+                journey <- store.update2[SubsidyJourney](_.setClaimDate(form))
                 redirect <- journey.next
               } yield redirect
           )
@@ -254,7 +254,7 @@ class SubsidyController @Inject() (
             formWithErrors => BadRequest(addClaimEoriPage(formWithErrors, previous)).toFuture,
             (form: OptionalEORI) =>
               for {
-                journey <- store.update[SubsidyJourney](_.map(_.setClaimEori(form)))
+                journey <- store.update2[SubsidyJourney](_.setClaimEori(form))
                 redirect <- journey.next
               } yield redirect
           )
@@ -286,7 +286,7 @@ class SubsidyController @Inject() (
             errors => BadRequest(addPublicAuthorityPage(errors, previous)).toFuture,
             form =>
               for {
-                journey <- store.update[SubsidyJourney](_.map(_.setPublicAuthority(form)))
+                journey <- store.update2[SubsidyJourney](_.setPublicAuthority(form))
                 redirect <- journey.next
               } yield redirect
           )
@@ -318,7 +318,7 @@ class SubsidyController @Inject() (
             errors => BadRequest(addTraderReferencePage(errors, previous)).toFuture,
             form =>
               for {
-                updatedSubsidyJourney <- store.update[SubsidyJourney](_.map(_.setTraderRef(form)))
+                updatedSubsidyJourney <- store.update2[SubsidyJourney](_.setTraderRef(form))
                 redirect <- updatedSubsidyJourney.next
               } yield redirect
           )
@@ -358,7 +358,7 @@ class SubsidyController @Inject() (
           form =>
             {
               for {
-                journey <- store.update[SubsidyJourney](_.map(_.setCya(form.value.toBoolean))).toContext
+                journey <- store.update2[SubsidyJourney](_.setCya(form.value.toBoolean)).toContext
                 _ <- validateSubsidyJourneyFieldsPopulated(journey).toContext
                 ref <- undertaking.reference.toContext
                 currentDate = timeProvider.today

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -94,7 +94,7 @@ class UndertakingController @Inject() (
             errors => BadRequest(undertakingNamePage(errors, journey.previous)).toFuture,
             success = form => {
               for {
-                updatedUndertakingJourney <- store.update2[UndertakingJourney](updateUndertakingName(form))
+                updatedUndertakingJourney <- store.update[UndertakingJourney](updateUndertakingName(form))
                 redirect <- updatedUndertakingJourney.next
               } yield redirect
             }
@@ -137,7 +137,7 @@ class UndertakingController @Inject() (
           },
           form =>
             for {
-              updatedUndertakingJourney <- store.update2[UndertakingJourney](updateUndertakingSector(form))
+              updatedUndertakingJourney <- store.update[UndertakingJourney](updateUndertakingSector(form))
               redirect <- updatedUndertakingJourney.next
             } yield redirect
         )
@@ -165,7 +165,7 @@ class UndertakingController @Inject() (
         _ => throw new IllegalStateException("value hard-coded, form hacking?"),
         form => {
           val result = for {
-            updatedJourney <- store.update2[UndertakingJourney](updateUndertakingCYA(form)).toContext
+            updatedJourney <- store.update[UndertakingJourney](updateUndertakingCYA(form)).toContext
             undertakingName <- updatedJourney.name.value.toContext
             undertakingSector <- updatedJourney.sector.value.toContext
             undertaking = Undertaking(
@@ -220,7 +220,7 @@ class UndertakingController @Inject() (
         _ => throw new IllegalStateException("value hard-coded, form hacking?"),
         form =>
           store
-            .update2[UndertakingJourney](updateUndertakingConfirmation(form))
+            .update[UndertakingJourney](updateUndertakingConfirmation(form))
             .map { _ =>
               Redirect(routes.BusinessEntityController.getAddBusinessEntity())
             }
@@ -249,7 +249,7 @@ class UndertakingController @Inject() (
   }
 
   private def updateIsAmendState(value: Boolean)(implicit e: EORI): Future[UndertakingJourney] =
-    store.update2[UndertakingJourney](_.copy(isAmend = value))
+    store.update[UndertakingJourney](_.copy(isAmend = value))
 
   def postAmendUndertaking: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     withLeadUndertaking { _ =>

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -293,6 +293,7 @@ class UndertakingController @Inject() (
       case None => handleMissingSessionData("Undertaking journey")
     }
 
+  // TODO - move these onto hte undertaking journey - they don't really belong here
   private def updateUndertakingName(formValues: FormValues)(journey: UndertakingJourney) =
       journey.copy(name = journey.name.copy(value = Some(formValues.value)))
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
@@ -40,6 +40,17 @@ case class BusinessEntityJourney(
     )
 
   def isAmend: Boolean = oldEORI.nonEmpty
+
+  def setEori(e: EORI): BusinessEntityJourney =
+    this.copy(
+      eori = eori.copy(value = e.some),
+      oldEORI = eori.value
+    )
+
+  def setAddBusiness(b: Boolean): BusinessEntityJourney =
+    this.copy(
+      addBusiness = addBusiness.copy(value = b.some))
+
 }
 
 object BusinessEntityJourney {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.FormPages.{AddBusinessCyaFormPage, AddBusinessFormPage, AddEoriFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
@@ -56,14 +55,6 @@ case class BusinessEntityJourney(
 object BusinessEntityJourney {
 
   implicit val format: Format[BusinessEntityJourney] = Json.format[BusinessEntityJourney]
-
-  def businessEntityJourneyForEori(undertakingOpt: Option[Undertaking], eori: EORI): BusinessEntityJourney =
-    undertakingOpt.fold(BusinessEntityJourney()) { _ =>
-      BusinessEntityJourney(
-        addBusiness = AddBusinessFormPage(true.some),
-        eori = AddEoriFormPage(eori.some)
-      )
-    }
 
   object FormPages {
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -56,6 +56,23 @@ case class EligibilityJourney(
         case _ => false
       }.toArray
 
+  def setWillYouClaim(newWillYouClaim: Boolean): EligibilityJourney =
+    this.copy(willYouClaim = willYouClaim.copy(value = Some(newWillYouClaim)))
+
+  def setCustomWaiver(newCustomWaiver: Boolean): EligibilityJourney =
+    this.copy(customsWaivers = customsWaivers.copy(value = Some(newCustomWaiver)))
+
+  def setMainBusinessCheck(newMainBusinessCheck: Boolean): EligibilityJourney =
+    this.copy(mainBusinessCheck = mainBusinessCheck.copy(value = Some(newMainBusinessCheck)))
+
+  def setAcceptTerms(newAcceptTerms: Boolean): EligibilityJourney =
+    this.copy(acceptTerms = acceptTerms.copy(value = Some(newAcceptTerms)))
+
+  def setEoriCheck(newEoriCheck: Boolean): EligibilityJourney =
+    this.copy(eoriCheck = eoriCheck.copy(value = Some(newEoriCheck)))
+
+  def setCreateUndertaking(newCreateUndertaking: Boolean): EligibilityJourney =
+    this.copy(createUndertaking = createUndertaking.copy(value = Some(newCreateUndertaking)))
 }
 
 object EligibilityJourney {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourney.scala
@@ -59,7 +59,7 @@ case class EligibilityJourney(
   def setWillYouClaim(newWillYouClaim: Boolean): EligibilityJourney =
     this.copy(willYouClaim = willYouClaim.copy(value = Some(newWillYouClaim)))
 
-  def setCustomWaiver(newCustomWaiver: Boolean): EligibilityJourney =
+  def setCustomsWaiver(newCustomWaiver: Boolean): EligibilityJourney =
     this.copy(customsWaivers = customsWaivers.copy(value = Some(newCustomWaiver)))
 
   def setMainBusinessCheck(newMainBusinessCheck: Boolean): EligibilityJourney =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyStore.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyStore.scala
@@ -20,6 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import play.api.libs.json.{Format, Reads, Writes}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax.FutureOptionToOptionTOps
 import uk.gov.hmrc.mongo.cache.{CacheIdType, DataKey, MongoCacheRepository}
 import uk.gov.hmrc.mongo.{CurrentTimestampSupport, MongoComponent}
 
@@ -66,5 +67,9 @@ class JourneyStore @Inject() (
 
   private def dataKeyForType[A](implicit ct: ClassTag[A]) = DataKey[A](ct.runtimeClass.getSimpleName)
 
+  override def update2[A: ClassTag](f: A => A)(implicit eori: EORI, format: Format[A]): Future[A] =
+    get.toContext
+      .map(f)
+      .foldF(throw new IllegalStateException("trying to update non-existent model"))(e => put(e))
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NilReturnJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NilReturnJourney.scala
@@ -25,11 +25,35 @@ case class NilReturnJourney(nilReturn: NilReturnFormPage = NilReturnFormPage(), 
     extends Journey {
   override def steps: Array[FormPage[_]] = Array(nilReturn)
 
-  def hasNilJourneyStarted = nilReturnCounter == 1 //means user has clicked on the check box to do nil return submission
-  def isNilJourneyDoneRecently =
-    nilReturnCounter == 2 //means the page previous to current page was to submit the nil return
+  // Has user clicked on the check box to do nil return submission
+  def hasNilJourneyStarted: Boolean = nilReturnCounter == 1
 
-  def setNilReturnValues(b: Boolean) = this.copy(nilReturn = nilReturn.copy(value = Some(b)), nilReturnCounter = 1)
+  // Means the page previous to current page was to submit the nil return
+  def isNilJourneyDoneRecently: Boolean = nilReturnCounter == 2
+
+  def setNilReturnValues(b: Boolean): NilReturnJourney =
+    this.copy(nilReturn = nilReturn.copy(value = Some(b)), nilReturnCounter = 1)
+
+  def incrementNilReturnCounter: NilReturnJourney = this.copy(nilReturnCounter = nilReturnCounter + 1)
+
+  /**
+   * nilReturnCounter is used to track when user has moved to home account page after nil return claim
+   *
+   * This counter also helps in identifying when to display the success message which should be displayed only once
+   *
+   * By default,  NilReturnJourney has counter set to 0. When user submit on No claim page, the count is set to 1,
+   * indicating user has started the nil return journey.
+   *
+   * Home account has logic to update the counter only if hasNilJourneyStarted or isNilJourneyDoneRecently.
+   *
+   * Since the journey has started, when the user is redirected to home account, counter get updated to 2.
+   *
+   * Home page has logic to display the message only if the isNilJourneyDoneRecently . At this point the message will be
+   * displayed. If user refreshes or return to home page via another journey, counter is updated and success message is
+   * no longer displayed. Since neither the nil journey has just started nor finished recently, counter will no longer
+   * be updated because of this func logic and will be reset to 1 if user goes on to nil return journey again.
+   */
+  def canIncrementNilReturnCounter: Boolean = hasNilJourneyStarted || isNilJourneyDoneRecently
 }
 
 object NilReturnJourney {
@@ -46,7 +70,6 @@ object NilReturnJourney {
     object NilReturnFormPage {
       implicit val nilReturnFormPageFormat: OFormat[NilReturnFormPage] = Json.format
     }
-
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NilReturnJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/NilReturnJourney.scala
@@ -28,6 +28,8 @@ case class NilReturnJourney(nilReturn: NilReturnFormPage = NilReturnFormPage(), 
   def hasNilJourneyStarted = nilReturnCounter == 1 //means user has clicked on the check box to do nil return submission
   def isNilJourneyDoneRecently =
     nilReturnCounter == 2 //means the page previous to current page was to submit the nil return
+
+  def setNilReturnValues(b: Boolean) = this.copy(nilReturn = nilReturn.copy(value = Some(b)), nilReturnCounter = 1)
 }
 
 object NilReturnJourney {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Store.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Store.scala
@@ -30,7 +30,10 @@ trait Store {
 
   def put[A](in: A)(implicit eori: EORI, writes: Writes[A]): Future[A]
 
+  @deprecated("Use update2 and rename when all usages of this method have been removed", "")
   def update[A : ClassTag](f: Option[A] => Option[A])(implicit eori: EORI, format: Format[A]): Future[A]
+
+  def update2[A : ClassTag](f: A => A)(implicit eori: EORI, format: Format[A]): Future[A]
 
   def delete[A : ClassTag](implicit eori: EORI): Future[Unit]
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Store.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Store.scala
@@ -30,10 +30,7 @@ trait Store {
 
   def put[A](in: A)(implicit eori: EORI, writes: Writes[A]): Future[A]
 
-  @deprecated("Use update2 and rename when all usages of this method have been removed", "")
-  def update[A : ClassTag](f: Option[A] => Option[A])(implicit eori: EORI, format: Format[A]): Future[A]
-
-  def update2[A : ClassTag](f: A => A)(implicit eori: EORI, format: Format[A]): Future[A]
+  def update[A : ClassTag](f: A => A)(implicit eori: EORI, format: Format[A]): Future[A]
 
   def delete[A : ClassTag](implicit eori: EORI): Future[Unit]
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -22,6 +22,7 @@ import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.{Form, Uri}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
@@ -59,10 +60,19 @@ case class UndertakingJourney(
 
   def isEmpty: Boolean = steps.flatMap(_.value).isEmpty
 
-  def isCurrentPageCYA(implicit request: Request[_]) = request.uri == routes.UndertakingController.getCheckAnswers().url
+  def isCurrentPageCYA(implicit request: Request[_]): Boolean =
+    request.uri == routes.UndertakingController.getCheckAnswers().url
 
-  private def requiredDetailsProvided =
-    Seq(name, sector).map(_.value.isDefined) == Seq(true, true)
+  private def requiredDetailsProvided = Seq(name, sector).map(_.value.isDefined) == Seq(true, true)
+
+  def setUndertakingName(n: String): UndertakingJourney = this.copy(name = name.copy(value = Some(n)))
+
+  def setUndertakingSector(s: Int): UndertakingJourney = this.copy(sector = sector.copy(value = Some(Sector(s))))
+
+  def setUndertakingCYA(b: Boolean): UndertakingJourney = this.copy(cya = cya.copy(value = Some(b)))
+
+  def setUndertakingConfirmation(b: Boolean): UndertakingJourney =
+    this.copy(confirmation = confirmation.copy(value = Some(b)))
 
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val microservice = Project(appName, file("."))
     ),
     ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*filters.*;.*handlers.*;.*components.*;.*repositories.*;" +
       ".*BuildInfo.*;.*javascript.*;.*Routes.*;.*GuiceInjector;" +
-      ".*ControllerConfiguration;.*testonly.*;.*syntax.*;.*models.*;.*views.*;.*config.*",
+      ".*ControllerConfiguration;.*testonly.*;.*models.*;.*views.*;.*config.*",
     ScoverageKeys.coverageMinimumStmtTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -31,7 +31,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.{BusinessEntityJourney, 
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{undertaking, _}
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -203,9 +203,7 @@ class AccountControllerSpec
           currentDate: LocalDate
         ): Unit = {
 
-          def update(njOpt: Option[NilReturnJourney]) = njOpt.map { nj =>
-            nj.copy(nilReturnCounter = nj.nilReturnCounter + 1)
-          }
+          def update(nj: NilReturnJourney) = nj.copy(nilReturnCounter = nj.nilReturnCounter + 1)
           val updatedNJ = nilReturnJourney.copy(nilReturnCounter = nilReturnJourney.nilReturnCounter + 1)
 
           inSequence {
@@ -218,7 +216,7 @@ class AccountControllerSpec
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockTimeProviderToday(currentDate)
             mockGet[NilReturnJourney](eori1)(Right(nilReturnJourney.some))
-            mockUpdate[NilReturnJourney](_ => update(nilReturnJourney.some), eori1)(Right(updatedNJ))
+            mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNJ))
           }
           checkPageIsDisplayed(
             performAction(),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -216,7 +216,7 @@ class AccountControllerSpec
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockTimeProviderToday(currentDate)
             mockGet[NilReturnJourney](eori1)(Right(nilReturnJourney.some))
-            mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNJ))
+            mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNJ))
           }
           checkPageIsDisplayed(
             performAction(),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -182,7 +182,7 @@ class BecomeLeadControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("becomeAdmin" -> "true")))
         }
@@ -216,7 +216,7 @@ class BecomeLeadControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction("becomeAdmin" -> "true")) shouldBe Some(routes.BecomeLeadController.getAcceptPromotionTerms().url)
         }
@@ -227,7 +227,7 @@ class BecomeLeadControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction("becomeAdmin" -> "false")) shouldBe Some(routes.AccountController.getAccountPage().url)
         }
@@ -527,7 +527,7 @@ class BecomeLeadControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction()) shouldBe routes.BecomeLeadController.getPromotionConfirmation().url.some
         }
@@ -546,7 +546,7 @@ class BecomeLeadControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction()) shouldBe routes.AccountController.getAccountPage().url.some
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -178,12 +178,11 @@ class BecomeLeadControllerSpec
 
         "call to update new lead journey fails" in {
 
-          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) =
-            newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
+          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("becomeAdmin" -> "true")))
         }
@@ -213,24 +212,22 @@ class BecomeLeadControllerSpec
       "Successful" when {
         "redirect to accept when user submits true" in {
 
-          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) =
-            newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
+          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction("becomeAdmin" -> "true")) shouldBe Some(routes.BecomeLeadController.getAcceptPromotionTerms().url)
         }
 
         "redirect to account homepage when user submits false" in {
 
-          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) =
-            newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
+          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction("becomeAdmin" -> "false")) shouldBe Some(routes.AccountController.getAccountPage().url)
         }
@@ -526,11 +523,11 @@ class BecomeLeadControllerSpec
       "redirect" when {
 
         "redirect to promotion confirmation on success" in {
-          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) =
-            newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
+          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
+
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction()) shouldBe routes.BecomeLeadController.getPromotionConfirmation().url.some
         }
@@ -545,11 +542,11 @@ class BecomeLeadControllerSpec
       "redirect" when {
 
         "redirect to promotion confirmation on success" in {
-          def update(newLeadJourneyOpt: Option[BecomeLeadJourney]) =
-            newLeadJourneyOpt.map(_.copy(becomeLeadEori = BecomeLeadEoriFormPage()))
+          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
+
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney().some), eori1)(Right(newBecomeLeadJourney))
+            mockUpdate2[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori1)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction()) shouldBe routes.AccountController.getAccountPage().url.some
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -194,7 +194,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney), eori)(Left(ConnectorError(exception)))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori)(Left(ConnectorError(exception)))
           }
 
           assertThrows[Exception](await(performAction("addBusiness" -> "true")))
@@ -240,7 +240,7 @@ class BusinessEntityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[BusinessEntityJourney](_ => update(BusinessEntityJourney()), eori)(
+            mockUpdate[BusinessEntityJourney](_ => update(BusinessEntityJourney()), eori)(
               Right(BusinessEntityJourney(addBusiness = AddBusinessFormPage(true.some)))
             )
           }
@@ -394,7 +394,7 @@ class BusinessEntityControllerSpec
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertakingWithErrorResponse(eori4)(Right(None))
-            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Left(ConnectorError(exception)))
           }
 
           assertThrows[Exception](await(performAction("businessEntityEori" -> "123456789010")))
@@ -485,7 +485,7 @@ class BusinessEntityControllerSpec
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertakingWithErrorResponse(eori4)(Right(None))
-            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Right(updatedBusinessJourney))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Right(updatedBusinessJourney))
           }
           checkIsRedirect(
             performAction("businessEntityEori" -> "123456789010"),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -30,13 +30,13 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, DoubleEORIEmailParameter, SingleEORIAndDateEmailParameter, SingleEORIEmailParameter}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, FormValues, Language, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, Language, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.FormPages.{AddBusinessFormPage, AddEoriFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 
 import java.time.LocalDate
 import scala.collection.JavaConverters._
@@ -253,13 +253,6 @@ class BusinessEntityControllerSpec
         "user is not an undertaking lead" in {
           testLeadOnlyRedirect(() => performAction())
         }
-      }
-
-      "Test to update add business" in {
-        val initialBE = BusinessEntityJourney()
-        val updatedBE = initialBE.copy(addBusiness = AddBusinessFormPage(true.some))
-        val result = controller.updateAddBusiness(FormValues("true"))(initialBE)
-        result shouldBe updatedBE
       }
 
     }
@@ -492,16 +485,6 @@ class BusinessEntityControllerSpec
             routes.BusinessEntityController.getCheckYourAnswers().url
           )
         }
-      }
-
-      "test to update the EORI" in {
-        val initialBE = BusinessEntityJourney(eori = AddEoriFormPage(value = EORI("GB123456789010").some))
-        val updatedBE = initialBE.copy(
-          eori = AddEoriFormPage(value = EORI("GB123456789012").some),
-          oldEORI = EORI("GB123456789010").some
-        )
-        val result = controller.updateEori(FormValues("GB123456789012"))(initialBE)
-        result shouldBe updatedBE
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -189,15 +189,14 @@ class BusinessEntityControllerSpec
 
         "call to update BusinessEntityJourney fails" in {
 
-          def updateFunc(beOpt: Option[BusinessEntityJourney]) =
-            beOpt.map(x => x.copy(addBusiness = x.addBusiness.copy(value = Some(true))))
+          def update(j: BusinessEntityJourney) = j.copy(addBusiness = j.addBusiness.copy(value = Some(true)))
+
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[BusinessEntityJourney](_ => updateFunc(businessEntityJourney.some), eori)(
-              Left(ConnectorError(exception))
-            )
+            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney), eori)(Left(ConnectorError(exception)))
           }
+
           assertThrows[Exception](await(performAction("addBusiness" -> "true")))
         }
 
@@ -236,12 +235,12 @@ class BusinessEntityControllerSpec
         }
 
         "user selected Yes" in {
-          def updateFunc(beOpt: Option[BusinessEntityJourney]) =
-            beOpt.map(x => x.copy(addBusiness = x.addBusiness.copy(value = Some(true))))
+          def update(j: BusinessEntityJourney) = j.copy(addBusiness = j.addBusiness.copy(value = Some(true)))
+
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[BusinessEntityJourney](_ => updateFunc(BusinessEntityJourney().some), eori)(
+            mockUpdate2[BusinessEntityJourney](_ => update(BusinessEntityJourney()), eori)(
               Right(BusinessEntityJourney(addBusiness = AddBusinessFormPage(true.some)))
             )
           }
@@ -259,8 +258,8 @@ class BusinessEntityControllerSpec
       "Test to update add business" in {
         val initialBE = BusinessEntityJourney()
         val updatedBE = initialBE.copy(addBusiness = AddBusinessFormPage(true.some))
-        val result = controller.updateAddBusiness(FormValues("true"))(initialBE.some)
-        result shouldBe updatedBE.some
+        val result = controller.updateAddBusiness(FormValues("true"))(initialBE)
+        result shouldBe updatedBE
       }
 
     }
@@ -382,24 +381,20 @@ class BusinessEntityControllerSpec
 
         "call to update business entity journey fails" in {
 
-          def update(opt: Option[BusinessEntityJourney]) = opt.map { businessEntity =>
-            businessEntity.copy(eori = businessEntity.eori.copy(value = Some(EORI("123456789010"))))
-          }
+          def update(j: BusinessEntityJourney) = j.copy(eori = j.eori.copy(value = Some(EORI("123456789010"))))
 
           val businessEntityJourney = BusinessEntityJourney()
             .copy(
               addBusiness = AddBusinessFormPage(true.some),
               eori = AddEoriFormPage(eori1.some)
             )
-            .some
+
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertakingWithErrorResponse(eori4)(Right(None))
-            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(
-              Left(ConnectorError(exception))
-            )
+            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Left(ConnectorError(exception)))
           }
 
           assertThrows[Exception](await(performAction("businessEntityEori" -> "123456789010")))
@@ -475,9 +470,7 @@ class BusinessEntityControllerSpec
         }
 
         "user is an undertaking lead" in {
-          def update(opt: Option[BusinessEntityJourney]) = opt.map { businessEntity =>
-            businessEntity.copy(eori = businessEntity.eori.copy(value = Some(eori4)))
-          }
+          def update(j: BusinessEntityJourney) = j.copy(eori = j.eori.copy(value = Some(eori4)))
 
           val businessEntityJourney = BusinessEntityJourney()
             .copy(
@@ -492,9 +485,7 @@ class BusinessEntityControllerSpec
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[BusinessEntityJourney](eori1)(Right("add-member"))
             mockRetrieveUndertakingWithErrorResponse(eori4)(Right(None))
-            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney.some), eori1)(
-              Right(updatedBusinessJourney)
-            )
+            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(Right(updatedBusinessJourney))
           }
           checkIsRedirect(
             performAction("businessEntityEori" -> "123456789010"),
@@ -509,8 +500,8 @@ class BusinessEntityControllerSpec
           eori = AddEoriFormPage(value = EORI("GB123456789012").some),
           oldEORI = EORI("GB123456789010").some
         )
-        val result = controller.updateEori(FormValues("GB123456789012"))(initialBE.some)
-        result shouldBe updatedBE.some
+        val result = controller.updateEori(FormValues("GB123456789012"))(initialBE)
+        result shouldBe updatedBE
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -244,11 +244,6 @@ class EligibilityControllerSpec
 
       }
 
-      "test for update customer waiver" in {
-        val updatedJourney = eligibilityJourney.copy(customsWaivers = CustomsWaiversFormPage(value = false.some))
-        val result = controller.updateCustomWaiver(false)(eligibilityJourney)
-        result shouldBe updatedJourney
-      }
     }
 
     "handling request to get will you claim" must {
@@ -404,11 +399,6 @@ class EligibilityControllerSpec
 
       }
 
-      "test for update will you claim" in {
-        val updatedJourney = eligibilityJourney.copy(willYouClaim = WillYouClaimFormPage(true.some))
-        val result = controller.updateWillYouClaim(true)(eligibilityJourney)
-        result shouldBe updatedJourney
-      }
     }
 
     "handling request to get Not eligible" must {
@@ -613,11 +603,6 @@ class EligibilityControllerSpec
 
       }
 
-      "test for update main business check" in {
-        val updatedJourney = eligibilityJourney.copy(mainBusinessCheck = MainBusinessCheckFormPage(value = true.some))
-        val result = controller.updateMainBusinessCheck(true)(eligibilityJourney)
-        result shouldBe updatedJourney
-      }
     }
 
     "handling request to get terms" must {
@@ -708,12 +693,6 @@ class EligibilityControllerSpec
           mockSendAuditEvent(expectedAuditEvent)
         }
         checkIsRedirect(performAction("terms" -> "true"), routes.EligibilityController.getCreateUndertaking().url)
-      }
-
-      "test for update terms and conditions" in {
-        val updatedJourney = eligibilityJourney.copy(acceptTerms = AcceptTermsFormPage(value = true.some))
-        val result = controller.updateAcceptTerms(true)(eligibilityJourney)
-        result shouldBe updatedJourney
       }
 
     }
@@ -847,12 +826,6 @@ class EligibilityControllerSpec
         }
       }
 
-      "test for update eori check" in {
-        val updatedJourney = EligibilityJourney().copy(eoriCheck = EoriCheckFormPage(value = true.some))
-        val result = controller.updateEoriCheck(true)(EligibilityJourney())
-        result shouldBe updatedJourney
-      }
-
     }
 
     "handling request to getIncorrectEori" must {
@@ -959,13 +932,6 @@ class EligibilityControllerSpec
 
       }
 
-      "test for update Create Undertaking" in {
-
-        val initialEJ = eligibilityJourney.copy(createUndertaking = CreateUndertakingFormPage())
-        val updatedJourney = initialEJ.copy(createUndertaking = CreateUndertakingFormPage(value = true.some))
-        val result = controller.updateCreateUndertaking(true)(initialEJ)
-        result shouldBe updatedJourney
-      }
     }
   }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -196,7 +196,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[EligibilityJourney](eori)(Right(previousUrl))
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("customswaivers" -> "true")))
         }
@@ -224,7 +224,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori1)(Right(previousUrl))
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Right(eligibilityJourney.copy(customsWaivers = CustomsWaiversFormPage(inputValue.some)))
             )
           }
@@ -350,7 +350,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("willyouclaim" -> "true")))
         }
@@ -385,7 +385,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Right(updatedEJ))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Right(updatedEJ))
           }
 
           checkIsRedirect(
@@ -564,7 +564,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("mainbusinesscheck" -> "true")))
         }
@@ -596,7 +596,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Right(updatedEligibilityJourney(input))
             )
           }
@@ -693,7 +693,7 @@ class EligibilityControllerSpec
         "call to update eligibility journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("terms" -> "true")))
         }
@@ -704,7 +704,7 @@ class EligibilityControllerSpec
         val updatedJourney = eligibilityJourney.copy(acceptTerms = AcceptTermsFormPage(true.some))
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Right(updatedJourney))
+          mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Right(updatedJourney))
           mockSendAuditEvent(expectedAuditEvent)
         }
         checkIsRedirect(performAction("terms" -> "true"), routes.EligibilityController.getCreateUndertaking().url)
@@ -806,7 +806,7 @@ class EligibilityControllerSpec
         "eligibility journey fail to update" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -832,7 +832,7 @@ class EligibilityControllerSpec
         def testRedirection(input: Boolean, nextCall: String) =
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Right(EligibilityJourney(eoriCheck = EoriCheckFormPage(input.some)))
             )
 
@@ -933,7 +933,7 @@ class EligibilityControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
+            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -946,7 +946,7 @@ class EligibilityControllerSpec
 
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
+          mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
             Right(EligibilityJourney(createUndertaking = CreateUndertakingFormPage(true.some)))
           )
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -180,8 +180,7 @@ class EligibilityControllerSpec
 
       val eligibilityJourney = EligibilityJourney(eoriCheck = EoriCheckFormPage(value = true.some))
 
-      def update(eligibilityJourneyOpt: Option[EligibilityJourney]) = eligibilityJourneyOpt
-        .map(_.copy(customsWaivers = CustomsWaiversFormPage(true.some)))
+      def update(ej: EligibilityJourney) = ej.copy(customsWaivers = CustomsWaiversFormPage(true.some))
 
       "throw technical error" when {
 
@@ -197,7 +196,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[EligibilityJourney](eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("customswaivers" -> "true")))
         }
@@ -225,7 +224,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori1)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Right(eligibilityJourney.copy(customsWaivers = CustomsWaiversFormPage(inputValue.some)))
             )
           }
@@ -247,8 +246,8 @@ class EligibilityControllerSpec
 
       "test for update customer waiver" in {
         val updatedJourney = eligibilityJourney.copy(customsWaivers = CustomsWaiversFormPage(value = false.some))
-        val result = controller.updateCustomWaiver(false)(eligibilityJourney.some)
-        result shouldBe updatedJourney.some
+        val result = controller.updateCustomWaiver(false)(eligibilityJourney)
+        result shouldBe updatedJourney
       }
     }
 
@@ -334,8 +333,7 @@ class EligibilityControllerSpec
         willYouClaim = WillYouClaimFormPage(false.some)
       )
 
-      def update(ejOpt: Option[EligibilityJourney]) = ejOpt
-        .map(ej => ej.copy(willYouClaim = ej.willYouClaim.copy(value = true.some)))
+      def update(ej: EligibilityJourney) = ej.copy(willYouClaim = ej.willYouClaim.copy(value = true.some))
 
       "throw technical error" when {
 
@@ -352,7 +350,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("willyouclaim" -> "true")))
         }
@@ -387,7 +385,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Right(updatedEJ))
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Right(updatedEJ))
           }
 
           checkIsRedirect(
@@ -408,8 +406,8 @@ class EligibilityControllerSpec
 
       "test for update will you claim" in {
         val updatedJourney = eligibilityJourney.copy(willYouClaim = WillYouClaimFormPage(true.some))
-        val result = controller.updateWillYouClaim(true)(eligibilityJourney.some)
-        result shouldBe updatedJourney.some
+        val result = controller.updateWillYouClaim(true)(eligibilityJourney)
+        result shouldBe updatedJourney
       }
     }
 
@@ -548,8 +546,8 @@ class EligibilityControllerSpec
       def updatedEligibilityJourney(input: Boolean) =
         eligibilityJourney.copy(mainBusinessCheck = MainBusinessCheckFormPage(input.some))
 
-      def update(ejOpt: Option[EligibilityJourney]) = ejOpt
-        .map(ej => ej.copy(mainBusinessCheck = ej.mainBusinessCheck.copy(value = true.some)))
+      def update(ej: EligibilityJourney) =
+        ej.copy(mainBusinessCheck = ej.mainBusinessCheck.copy(value = true.some))
 
       "throw technical error" when {
 
@@ -566,7 +564,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("mainbusinesscheck" -> "true")))
         }
@@ -598,7 +596,7 @@ class EligibilityControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious(eori)(Right(previousUrl))
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Right(updatedEligibilityJourney(input))
             )
           }
@@ -617,8 +615,8 @@ class EligibilityControllerSpec
 
       "test for update main business check" in {
         val updatedJourney = eligibilityJourney.copy(mainBusinessCheck = MainBusinessCheckFormPage(value = true.some))
-        val result = controller.updateMainBusinessCheck(true)(eligibilityJourney.some)
-        result shouldBe updatedJourney.some
+        val result = controller.updateMainBusinessCheck(true)(eligibilityJourney)
+        result shouldBe updatedJourney
       }
     }
 
@@ -681,8 +679,7 @@ class EligibilityControllerSpec
         signOut = SignOutFormPage(true.some)
       )
 
-      def update(ejOpt: Option[EligibilityJourney]) = ejOpt
-        .map(ej => ej.copy(acceptTerms = ej.acceptTerms.copy(value = true.some)))
+      def update(ej: EligibilityJourney) = ej.copy(acceptTerms = ej.acceptTerms.copy(value = true.some))
 
       "throw technical error" when {
 
@@ -696,7 +693,7 @@ class EligibilityControllerSpec
         "call to update eligibility journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("terms" -> "true")))
         }
@@ -707,7 +704,7 @@ class EligibilityControllerSpec
         val updatedJourney = eligibilityJourney.copy(acceptTerms = AcceptTermsFormPage(true.some))
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(Right(updatedJourney))
+          mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(Right(updatedJourney))
           mockSendAuditEvent(expectedAuditEvent)
         }
         checkIsRedirect(performAction("terms" -> "true"), routes.EligibilityController.getCreateUndertaking().url)
@@ -715,8 +712,8 @@ class EligibilityControllerSpec
 
       "test for update terms and conditions" in {
         val updatedJourney = eligibilityJourney.copy(acceptTerms = AcceptTermsFormPage(value = true.some))
-        val result = controller.updateAcceptTerms(true)(eligibilityJourney.some)
-        result shouldBe updatedJourney.some
+        val result = controller.updateAcceptTerms(true)(eligibilityJourney)
+        result shouldBe updatedJourney
       }
 
     }
@@ -802,15 +799,14 @@ class EligibilityControllerSpec
             .withFormUrlEncodedBody(data: _*)
         )
 
-      def update(eligibilityJourneyOpt: Option[EligibilityJourney]) = eligibilityJourneyOpt
-        .map(_.copy(customsWaivers = CustomsWaiversFormPage(true.some)))
+      def update(ej: EligibilityJourney) = ej.copy(customsWaivers = CustomsWaiversFormPage(true.some))
 
       "throw technical error" when {
 
         "eligibility journey fail to update" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -836,7 +832,7 @@ class EligibilityControllerSpec
         def testRedirection(input: Boolean, nextCall: String) =
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Right(EligibilityJourney(eoriCheck = EoriCheckFormPage(input.some)))
             )
 
@@ -853,8 +849,8 @@ class EligibilityControllerSpec
 
       "test for update eori check" in {
         val updatedJourney = EligibilityJourney().copy(eoriCheck = EoriCheckFormPage(value = true.some))
-        val result = controller.updateEoriCheck(true)(EligibilityJourney().some)
-        result shouldBe updatedJourney.some
+        val result = controller.updateEoriCheck(true)(EligibilityJourney())
+        result shouldBe updatedJourney
       }
 
     }
@@ -922,8 +918,7 @@ class EligibilityControllerSpec
             .withFormUrlEncodedBody(data: _*)
         )
 
-      def update(eligibilityJourneyOpt: Option[EligibilityJourney]) = eligibilityJourneyOpt
-        .map(_.copy(createUndertaking = CreateUndertakingFormPage(true.some)))
+      def update(ej: EligibilityJourney) = ej.copy(createUndertaking = CreateUndertakingFormPage(true.some))
 
       "throw technical error" when {
 
@@ -938,7 +933,7 @@ class EligibilityControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
+            mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -951,7 +946,7 @@ class EligibilityControllerSpec
 
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockUpdate[EligibilityJourney](_ => update(eligibilityJourney.some), eori1)(
+          mockUpdate2[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
             Right(EligibilityJourney(createUndertaking = CreateUndertakingFormPage(true.some)))
           )
         }
@@ -968,8 +963,8 @@ class EligibilityControllerSpec
 
         val initialEJ = eligibilityJourney.copy(createUndertaking = CreateUndertakingFormPage())
         val updatedJourney = initialEJ.copy(createUndertaking = CreateUndertakingFormPage(value = true.some))
-        val result = controller.updateCreateUndertaking(true)(initialEJ.some)
-        result shouldBe updatedJourney.some
+        val result = controller.updateCreateUndertaking(true)(initialEJ)
+        result shouldBe updatedJourney
       }
     }
   }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
@@ -41,9 +41,17 @@ trait JourneyStoreSupport { this: MockFactory =>
       .expects(input, eori, *)
       .returning(result.fold(Future.failed, Future.successful))
 
+  @deprecated("use mockUpdate2 and rename when all usages of this method removed", "")
   def mockUpdate[A](f: Option[A] => Option[A], eori: EORI)(result: Either[ConnectorError, A]) =
     (mockJourneyStore
       .update(_: Option[A] => Option[A])(_: ClassTag[A], _: EORI, _: Format[A]))
+      .expects(*, *, eori, *)
+      .returning(result.fold(Future.failed, Future.successful))
+
+  // TODO - rename when all usages of mockUpdate have been replaced
+  def mockUpdate2[A](f: A => A, eori: EORI)(result: Either[ConnectorError, A]) =
+    (mockJourneyStore
+      .update2(_: A => A)(_: ClassTag[A], _: EORI, _: Format[A]))
       .expects(*, *, eori, *)
       .returning(result.fold(Future.failed, Future.successful))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
@@ -41,17 +41,9 @@ trait JourneyStoreSupport { this: MockFactory =>
       .expects(input, eori, *)
       .returning(result.fold(Future.failed, Future.successful))
 
-  @deprecated("use mockUpdate2 and rename when all usages of this method removed", "")
-  def mockUpdate[A](f: Option[A] => Option[A], eori: EORI)(result: Either[ConnectorError, A]) =
+  def mockUpdate[A](f: A => A, eori: EORI)(result: Either[ConnectorError, A]) =
     (mockJourneyStore
-      .update(_: Option[A] => Option[A])(_: ClassTag[A], _: EORI, _: Format[A]))
-      .expects(*, *, eori, *)
-      .returning(result.fold(Future.failed, Future.successful))
-
-  // TODO - rename when all usages of mockUpdate have been replaced
-  def mockUpdate2[A](f: A => A, eori: EORI)(result: Either[ConnectorError, A]) =
-    (mockJourneyStore
-      .update2(_: A => A)(_: ClassTag[A], _: EORI, _: Format[A]))
+      .update(_: A => A)(_: ClassTag[A], _: EORI, _: Format[A]))
       .expects(*, *, eori, *)
       .returning(result.fold(Future.failed, Future.successful))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
@@ -83,7 +83,7 @@ class NoBusinessPresentControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -94,7 +94,7 @@ class NoBusinessPresentControllerSpec
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking1.some))
-          mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(
+          mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(
             Right(businessEntityJourney1)
           )
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
@@ -75,8 +75,7 @@ class NoBusinessPresentControllerSpec
     "handling request to post No Business Pesent" must {
       def performAction() = controller.postNoBusinessPresent(FakeRequest())
 
-      def update(businessEntityOpt: Option[BusinessEntityJourney]) =
-        businessEntityOpt.map(_.copy(isLeadSelectJourney = true.some))
+      def update(j: BusinessEntityJourney) = j.copy(isLeadSelectJourney = true.some)
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
@@ -84,7 +83,7 @@ class NoBusinessPresentControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1.some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -95,7 +94,7 @@ class NoBusinessPresentControllerSpec
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking1.some))
-          mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1.some), eori1)(
+          mockUpdate2[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(
             Right(businessEntityJourney1)
           )
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -23,12 +23,12 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, FormValues, NilSubmissionDate, SubsidyUpdate, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, NilSubmissionDate, SubsidyUpdate, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.NilReturnJourney.Forms.NilReturnFormPage
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EscService, NilReturnJourney, Store}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services._
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{eori1, undertaking, undertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{eori1, undertaking, undertakingRef}
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -172,13 +172,6 @@ class NoClaimNotificationControllerSpec
           routes.AccountController.getAccountPage().url
         )
 
-      }
-
-      "test to update nil return values" in {
-        val initialNilReturnJourney = NilReturnJourney()
-        val updatedNilReturnJourney = NilReturnJourney(nilReturn = NilReturnFormPage(true.some), nilReturnCounter = 1)
-        val result = controller.updateNilReturnValues(FormValues("true"))(initialNilReturnJourney)
-        result shouldBe updatedNilReturnJourney
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -119,7 +119,7 @@ class NoClaimNotificationControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockTimeProviderToday(currentDay)
-            mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("noClaimNotification" -> "true")))
         }
@@ -129,7 +129,7 @@ class NoClaimNotificationControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockTimeProviderToday(currentDay)
-            mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
+            mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
             mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
               Left(ConnectorError(exception))
             )
@@ -161,7 +161,7 @@ class NoClaimNotificationControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockTimeProviderToday(currentDay)
-          mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
+          mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
           mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
             Right(undertakingRef)
           )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -94,9 +94,9 @@ class NoClaimNotificationControllerSpec
       val nilReturnJourney = NilReturnJourney()
       val updatedNilReturnJourney = NilReturnJourney(NilReturnFormPage(true.some), 1)
 
-      def update(nrjOpt: Option[NilReturnJourney]) = nrjOpt.map { nrj =>
-        nrj.copy(nilReturn = nrj.nilReturn.copy(value = Some(true)), nilReturnCounter = 1)
-      }
+      def update(j: NilReturnJourney) =
+        j.copy(nilReturn = j.nilReturn.copy(value = Some(true)), nilReturnCounter = 1)
+
       def performAction(data: (String, String)*) = controller
         .postNoClaimNotification(
           FakeRequest()
@@ -110,9 +110,7 @@ class NoClaimNotificationControllerSpec
         val nilReturnJourney = NilReturnJourney()
         val updatedNilReturnJourney = NilReturnJourney(NilReturnFormPage(true.some), 1)
 
-        def update(nrjOpt: Option[NilReturnJourney]) = nrjOpt.map { nrj =>
-          nrj.copy(nilReturn = nrj.nilReturn.copy(value = Some(true)), nilReturnCounter = 1)
-        }
+        def update(j: NilReturnJourney) = j.copy(nilReturn = j.nilReturn.copy(value = Some(true)), nilReturnCounter = 1)
 
         val exception = new Exception("oh no")
 
@@ -121,8 +119,7 @@ class NoClaimNotificationControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockTimeProviderToday(currentDay)
-            mockUpdate[NilReturnJourney](_ => update(nilReturnJourney.some), eori1)(Left(ConnectorError(exception)))
-
+            mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("noClaimNotification" -> "true")))
         }
@@ -132,7 +129,7 @@ class NoClaimNotificationControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockTimeProviderToday(currentDay)
-            mockUpdate[NilReturnJourney](_ => update(nilReturnJourney.some), eori1)(Right(updatedNilReturnJourney))
+            mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
             mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
               Left(ConnectorError(exception))
             )
@@ -164,7 +161,7 @@ class NoClaimNotificationControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockTimeProviderToday(currentDay)
-          mockUpdate[NilReturnJourney](_ => update(nilReturnJourney.some), eori1)(Right(updatedNilReturnJourney))
+          mockUpdate2[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
           mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay)))(
             Right(undertakingRef)
           )
@@ -180,8 +177,8 @@ class NoClaimNotificationControllerSpec
       "test to update nil return values" in {
         val initialNilReturnJourney = NilReturnJourney()
         val updatedNilReturnJourney = NilReturnJourney(nilReturn = NilReturnFormPage(true.some), nilReturnCounter = 1)
-        val result = controller.updateNilReturnValues(FormValues("true"))(initialNilReturnJourney.some)
-        result shouldBe updatedNilReturnJourney.some
+        val result = controller.updateNilReturnValues(FormValues("true"))(initialNilReturnJourney)
+        result shouldBe updatedNilReturnJourney
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -171,15 +171,14 @@ class SelectNewLeadControllerSpec
         val exception = new Exception("oh no!")
         val emailParamsBE = SingleEORIEmailParameter(eori4, undertaking1.name, undertakingRef, "promoteAsLeadEmailToBE")
 
-        def update(newLeadJourneyOpt: Option[NewLeadJourney]) =
-          newLeadJourneyOpt.map(_.copy(selectNewLead = SelectNewLeadFormPage(eori4.some)))
+        def update(j: NewLeadJourney) = j.copy(selectNewLead = SelectNewLeadFormPage(eori4.some))
 
         "call to update new lead journey fails" in {
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(Left(ConnectorError(exception)))
+            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
@@ -189,7 +188,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(
+            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
@@ -202,7 +201,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(
+            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -216,7 +215,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(
+            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -243,8 +242,7 @@ class SelectNewLeadControllerSpec
 
       "redirect to next page" when {
 
-        def update(newLeadJourneyOpt: Option[NewLeadJourney]): Option[NewLeadJourney] =
-          newLeadJourneyOpt.map(_.copy(selectNewLead = SelectNewLeadFormPage(eori4.some)))
+        def update(j: NewLeadJourney) = j.copy(selectNewLead = SelectNewLeadFormPage(eori4.some))
 
         def testRedirection(templateIdBE: String, templateIdLead: String, lang: String): Unit = {
 
@@ -255,7 +253,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney().some), eori1)(
+            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -292,8 +290,7 @@ class SelectNewLeadControllerSpec
       def performAction() = controller.getLeadEORIChanged(FakeRequest())
       behave like authBehaviour(() => performAction())
 
-      def update(businessEntityJourneyOpt: Option[BusinessEntityJourney]) =
-        businessEntityJourneyOpt.map(_.copy(isLeadSelectJourney = None))
+      def update(b: BusinessEntityJourney) = b.copy(isLeadSelectJourney = None)
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
@@ -333,8 +330,8 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
-            mockUpdate[BusinessEntityJourney](
-              _ => update(businessEntityJourneyLead.copy(eori = AddEoriFormPage(eori4.some)).some),
+            mockUpdate2[BusinessEntityJourney](
+              _ => update(businessEntityJourneyLead.copy(eori = AddEoriFormPage(eori4.some))),
               eori1
             )(Left(ConnectorError(exception)))
           }
@@ -347,12 +344,11 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
-            mockUpdate[BusinessEntityJourney](
+            mockUpdate2[BusinessEntityJourney](
               _ =>
                 update(
                   businessEntityJourneyLead
                     .copy(eori = AddEoriFormPage(eori4.some))
-                    .some
                 ),
               eori1
             )(Right(businessEntityJourneyLead))
@@ -370,12 +366,11 @@ class SelectNewLeadControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
-          mockUpdate[BusinessEntityJourney](
+          mockUpdate2[BusinessEntityJourney](
             _ =>
               update(
                 businessEntityJourneyLead
                   .copy(eori = AddEoriFormPage(eori4.some))
-                  .some
               ),
             eori1
           )(Right(businessEntityJourneyLead))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -178,7 +178,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
@@ -188,7 +188,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
@@ -201,7 +201,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -215,7 +215,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -253,7 +253,7 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
             mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
@@ -330,7 +330,7 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
-            mockUpdate2[BusinessEntityJourney](
+            mockUpdate[BusinessEntityJourney](
               _ => update(businessEntityJourneyLead.copy(eori = AddEoriFormPage(eori4.some))),
               eori1
             )(Left(ConnectorError(exception)))
@@ -344,7 +344,7 @@ class SelectNewLeadControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
-            mockUpdate2[BusinessEntityJourney](
+            mockUpdate[BusinessEntityJourney](
               _ =>
                 update(
                   businessEntityJourneyLead
@@ -366,7 +366,7 @@ class SelectNewLeadControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
-          mockUpdate2[BusinessEntityJourney](
+          mockUpdate[BusinessEntityJourney](
             _ =>
               update(
                 businessEntityJourneyLead

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -189,7 +189,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[SubsidyJourney](identity, eori1)(Left(ConnectorError(exception)))
+            mockUpdate[SubsidyJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("reportPayment" -> "true")))
 
@@ -218,7 +218,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[SubsidyJourney](identity, eori1)(Right(subsidyJourney))
+            mockUpdate[SubsidyJourney](identity, eori1)(Right(subsidyJourney))
           }
           checkIsRedirect(performAction(("reportPayment", input)), nextCall)
         }
@@ -314,7 +314,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[SubsidyJourney](eori1)(Right(Some(subsidyJourney)))
-            mockUpdate2[SubsidyJourney](j => j.copy(claimDate = ClaimDateFormPage(updatedDate.some)), eori1)(
+            mockUpdate[SubsidyJourney](j => j.copy(claimDate = ClaimDateFormPage(updatedDate.some)), eori1)(
               Right(subsidyJourney.copy(claimDate = ClaimDateFormPage(updatedDate.some)))
             )
           }
@@ -499,7 +499,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
-            mockUpdate2[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("claim-amount" -> "123.45")))
         }
@@ -552,11 +552,6 @@ class SubsidyControllerSpec
           claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some)
         )
 
-        val subsidyJourney2 = SubsidyJourney(
-          reportPayment = ReportPaymentFormPage(true.some),
-          claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some)
-        )
-
         def update(subsidyJourney: SubsidyJourney) =
           subsidyJourney.copy(claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some))
 
@@ -564,7 +559,7 @@ class SubsidyControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
           mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
-          mockUpdate2[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(subsidyJourney))
+          mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(subsidyJourney))
         }
 
         checkIsRedirect(
@@ -695,7 +690,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[SubsidyJourney](eori1)(Right("add-claim-amount"))
-            mockUpdate2[SubsidyJourney](
+            mockUpdate[SubsidyJourney](
               _ => update(subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(None))),
               eori1
             )(Left(ConnectorError(exception)))
@@ -759,7 +754,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGetPrevious[SubsidyJourney](eori1)(Right(routes.SubsidyController.getClaimAmount().url))
-            mockUpdate2[SubsidyJourney](_ => update(subsidyJourney, optionalEORI.some), eori1)(
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney, optionalEORI.some), eori1)(
               Right(updatedSubsidyJourney)
             )
           }
@@ -831,7 +826,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[SubsidyJourney](eori1)(Right(Some(subsidyJourney)))
-            mockUpdate2[SubsidyJourney](
+            mockUpdate[SubsidyJourney](
               j => j.copy(publicAuthority = PublicAuthorityFormPage(Some("My Authority"))),
               eori1
             )(
@@ -1256,7 +1251,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate2[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
@@ -1265,7 +1260,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.copy(reference = None).some))
-            mockUpdate2[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
@@ -1274,7 +1269,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate2[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
             mockTimeProviderToday(currentDate)
             mockCreateSubsidy(
               undertakingRef,
@@ -1288,7 +1283,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate2[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
+            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
             mockTimeProviderToday(currentDate)
             mockCreateSubsidy(
               undertakingRef,
@@ -1309,7 +1304,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate2[SubsidyJourney](
+            mockUpdate[SubsidyJourney](
               _ => update(subsidyJourneyExisting),
               eori1
             )(Right(updatedSJ))
@@ -1341,7 +1336,7 @@ class SubsidyControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking1.some))
-            mockUpdate2[SubsidyJourney](
+            mockUpdate[SubsidyJourney](
               _ => update(subsidyJourney),
               eori1
             )(Right(updatedSJ))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -27,12 +27,12 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.UndertakingUpdated
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, Sector, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, FormValues, Language, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Language, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 
 import java.time.LocalDateTime
 import scala.collection.JavaConverters._
@@ -319,7 +319,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -361,7 +361,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
-            mockUpdate2[UndertakingJourney](identity, eori1)(
+            mockUpdate[UndertakingJourney](identity, eori1)(
               Right(updatedUndertaking)
             )
           }
@@ -524,7 +524,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
-            mockUpdate2[UndertakingJourney](_ => update(currentUndertaking), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[UndertakingJourney](_ => update(currentUndertaking), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingSector" -> "2")))
         }
@@ -563,7 +563,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGetPrevious[UndertakingJourney](eori1)(Right("undertaking-name"))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourney), eori1)(Right(updatedUndertaking))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourney), eori1)(Right(updatedUndertaking))
           }
           checkIsRedirect(performAction("undertakingSector" -> "3"), nextCall)
         }
@@ -699,12 +699,9 @@ class UndertakingControllerSpec
 
         "call to update undertaking journey fails" in {
 
-          def updateFunc(ujOpt: Option[UndertakingJourney]) =
-            ujOpt.map(x => x.copy(cya = x.cya.copy(value = true.some)))
-
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
+            mockUpdate[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
         }
@@ -713,7 +710,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
+            mockUpdate[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
         }
@@ -722,7 +719,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
+            mockUpdate[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
         }
@@ -733,7 +730,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
+            mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
@@ -747,7 +744,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
+            mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
             mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
@@ -764,7 +761,7 @@ class UndertakingControllerSpec
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
+            mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
             mockRetrieveEmail(eori)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockSendEmail(validEmailAddress, emailParameter, templateId)(Right(EmailSendResult.EmailSent))
@@ -835,7 +832,7 @@ class UndertakingControllerSpec
         "call to update undertaking confirmation fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourney), eori1)(Left(ConnectorError(exception)))
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("confirm" -> "true")))
         }
@@ -844,7 +841,7 @@ class UndertakingControllerSpec
       "redirect to next page" in {
         inSequence {
           mockAuthWithNecessaryEnrolment()
-          mockUpdate2[UndertakingJourney](_ => update(undertakingJourney), eori1)(Right(undertakingJourneyComplete))
+          mockUpdate[UndertakingJourney](_ => update(undertakingJourney), eori1)(Right(undertakingJourneyComplete))
         }
 
         checkIsRedirect(performAction("confirm" -> "true"), routes.BusinessEntityController.getAddBusinessEntity().url)
@@ -898,7 +895,7 @@ class UndertakingControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -938,7 +935,7 @@ class UndertakingControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(isAmend = true))
             )
           }
@@ -982,7 +979,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Left(ConnectorError(exception))
             )
           }
@@ -994,7 +991,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage()))
             )
           }
@@ -1006,7 +1003,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage()))
             )
           }
@@ -1018,7 +1015,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some)))
             )
             mockRetrieveUndertaking(eori)(Future.failed(exception))
@@ -1030,7 +1027,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some)))
             )
             mockRetrieveUndertaking(eori)(Future.successful(None))
@@ -1042,7 +1039,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some)))
             )
             mockRetrieveUndertaking(eori)(Future.successful(undertaking1.copy(reference = None).some))
@@ -1056,7 +1053,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
-            mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(isAmend = true))
             )
             mockRetrieveUndertaking(eori)(Future.successful(undertaking1.some))
@@ -1073,7 +1070,7 @@ class UndertakingControllerSpec
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
-          mockUpdate2[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
+          mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
             Right(undertakingJourneyComplete.copy(isAmend = true))
           )
           mockRetrieveUndertaking(eori)(Future.successful(undertaking1.some))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 
 class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
 
-  "BecomeLeadJourneySpec" when {
+  "BecomeLeadJourney" when {
 
     "steps is called" should {
 
@@ -35,6 +35,7 @@ class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
         )
       }
     }
+
     "uris correct" should {
 
       "Become lead" in {
@@ -55,5 +56,6 @@ class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
           .url
       }
     }
+
   }
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourneySpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.services
+
+import cats.implicits.catsSyntaxOptionId
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.FormPages.{AddBusinessFormPage, AddEoriFormPage}
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.eori1
+
+class BusinessEntityJourneySpec extends AnyWordSpecLike with Matchers {
+
+  "BusinessEntityJourney" should {
+
+    "return an updated instance with the specified eori when setEori is called" in {
+      BusinessEntityJourney().setEori(eori1) shouldBe BusinessEntityJourney(eori = AddEoriFormPage(eori1.some))
+    }
+
+    "return an updated instance with the specified boolean value when setAddBusiness is called" in {
+      BusinessEntityJourney().setAddBusiness(true) shouldBe
+        BusinessEntityJourney(addBusiness = AddBusinessFormPage(true.some))
+    }
+  }
+}

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EligibilityJourneySpec.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
+import cats.implicits.catsSyntaxOptionId
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms.{CustomsWaiversFormPage, EoriCheckFormPage, MainBusinessCheckFormPage, WillYouClaimFormPage}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EligibilityJourney.Forms.{AcceptTermsFormPage, CreateUndertakingFormPage, CustomsWaiversFormPage, EoriCheckFormPage, MainBusinessCheckFormPage, WillYouClaimFormPage}
 
 class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
@@ -106,6 +107,39 @@ class EligibilityJourneySpec extends AnyWordSpecLike with Matchers {
 
     }
 
+    "set methods are called" should {
+
+      "return an updated instance with the specified WillYouClaim boolean value" in {
+        EligibilityJourney().setWillYouClaim(true) shouldBe
+          EligibilityJourney(willYouClaim = WillYouClaimFormPage(true.some))
+      }
+
+      "return an updated instance with the specified CustomsWaiver boolean value" in {
+        EligibilityJourney().setCustomsWaiver(true) shouldBe
+          EligibilityJourney(customsWaivers = CustomsWaiversFormPage(true.some))
+      }
+
+      "return an updated instance with the specified MainBusinessCheck boolean value" in {
+        EligibilityJourney().setMainBusinessCheck(true) shouldBe
+          EligibilityJourney(mainBusinessCheck = MainBusinessCheckFormPage(true.some))
+      }
+
+      "return an updated instance with the specified AcceptTerms boolean value" in {
+        EligibilityJourney().setAcceptTerms(true) shouldBe
+          EligibilityJourney(acceptTerms = AcceptTermsFormPage(true.some))
+      }
+
+      "return an updated instance with the specified EoriCheck boolean value" in {
+        EligibilityJourney().setEoriCheck(true) shouldBe
+          EligibilityJourney(eoriCheck = EoriCheckFormPage(true.some))
+      }
+
+      "return an updated instance with the specified CreateUndertaking boolean value" in {
+        EligibilityJourney().setCreateUndertaking(true) shouldBe
+          EligibilityJourney(createUndertaking = CreateUndertakingFormPage(true.some))
+      }
+
+    }
   }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/NilReturnJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/NilReturnJourneySpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.services
+
+import cats.implicits.catsSyntaxOptionId
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.NilReturnJourney.Forms.NilReturnFormPage
+
+class NilReturnJourneySpec extends AnyWordSpecLike with Matchers {
+
+  "NilReturnJourney" when {
+
+    "hasNilJourneyStarted is called" should {
+      "return true if counter is 1" in {
+        NilReturnJourney(nilReturnCounter = 1).hasNilJourneyStarted shouldBe true
+      }
+
+      "return false otherwise" in {
+        NilReturnJourney().hasNilJourneyStarted shouldBe false
+      }
+    }
+
+    "isNilJourneyDoneRecently" should {
+      "return true if counter is 2" in {
+        NilReturnJourney(nilReturnCounter = 2).isNilJourneyDoneRecently shouldBe true
+
+      }
+      "return false otherwise" in {
+        NilReturnJourney(nilReturnCounter = 1).isNilJourneyDoneRecently shouldBe false
+      }
+    }
+
+    "setNilReturnValues" should {
+      "return an updated instance with the specified boolean value and reset the counter to 1" in {
+        NilReturnJourney(nilReturnCounter = 2).setNilReturnValues(true) shouldBe
+          NilReturnJourney(nilReturn = NilReturnFormPage(true.some), nilReturnCounter = 1)
+      }
+    }
+
+    "incrementNilReturnCounter" should {
+      "return an updated instance with the counter incremented by 1" in {
+        NilReturnJourney().incrementNilReturnCounter shouldBe NilReturnJourney(nilReturnCounter = 1)
+      }
+    }
+
+    "canIncrementNilReturnCounter" should {
+
+      "return true if hasNilJourneyStarted returns true" in {
+        NilReturnJourney(nilReturnCounter = 1).canIncrementNilReturnCounter shouldBe true
+      }
+
+      "return true if isNilJourneyDoneRecently returns true" in {
+        NilReturnJourney(nilReturnCounter = 2).canIncrementNilReturnCounter shouldBe true
+      }
+
+      "return false otherwise" in {
+        NilReturnJourney().canIncrementNilReturnCounter shouldBe false
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Summary of changes
* revised store update method to take a function of `A => A` instead of `Option[A] => Option[A]` - the options are unnecesary and complexity at the call sites
* moved journey update methods out of the controllers into their respective journey classes
* added further test coverage where required
* other minor tidy ups 