### PR TITLE
ESC-528 Revise error handling on undertaking retrieval in connector

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -48,8 +48,8 @@ class EscConnector @Inject() (
     http
       .POST[Undertaking, HttpResponse](s"$escURL/$createUndertakingPath", undertaking)
       .map(Right(_))
-      .recover { case e =>
-        Left(ConnectorError(e))
+      .recover {
+        case e => Left(ConnectorError(e))
       }
 
   def updateUndertaking(
@@ -62,13 +62,14 @@ class EscConnector @Inject() (
         Left(ConnectorError(e))
       }
 
-  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] =
+  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
       .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
       .map { r =>
         if (r.status == OK) Right(r)
-        else Left(UpstreamErrorResponse(s"Unexpected response from ESC - got HTTP ${r.status}", r.status))
+        else Left(ConnectorError(UpstreamErrorResponse(s"Unexpected response from ESC - got HTTP ${r.status}", r.status)))
       }
+      .recover { case e => Left(ConnectorError(e)) }
 
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -62,14 +62,13 @@ class EscConnector @Inject() (
         Left(ConnectorError(e))
       }
 
-  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
+  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] =
     http
       .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
       .map { r =>
         if (r.status == OK) Right(r)
-        else Left(ConnectorError(UpstreamErrorResponse(s"Unexpected response from ESC - got HTTP ${r.status}", r.status)))
+        else Left(UpstreamErrorResponse(s"Unexpected response - got HTTP ${r.status}", r.status))
       }
-      .recover { case e => Left(ConnectorError(e)) }
 
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -17,10 +17,11 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{Inject, Singleton}
+import play.api.http.Status.OK
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidyAmendment}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -61,12 +62,12 @@ class EscConnector @Inject() (
         Left(ConnectorError(e))
       }
 
-  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
+  def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] =
     http
       .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
-      .map(Right(_))
-      .recover { case ex =>
-        Left(ConnectorError(ex))
+      .map { r =>
+        if (r.status == OK) Right(r)
+        else Left(UpstreamErrorResponse(s"Unexpected response from ESC - got HTTP ${r.status}", r.status))
       }
 
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -134,7 +134,7 @@ class BusinessEntityController @Inject() (
       BadRequest(eoriPage(eoriForm.withError(businessEntityEori, errorMessageKey).fill(form), previous)).toFuture
 
     def handleValidEori(form: FormValues, previous: Uri): Future[Result] =
-      escService.retrieveUndertakingWithErrorResponse(EORI(form.value)).flatMap {
+      escService.retrieveUndertakingAndHandleErrors(EORI(form.value)).flatMap {
 
         case Right(Some(_)) => getErrorResponse("businessEntityEori.eoriInUse", previous, form)
         case Left(_) => getErrorResponse(s"error.$businessEntityEori.required", previous, form)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -50,8 +50,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
       case Left(ex) => throw ex
     }
 
-  // TODO - this method could be private since our public API just throws an exception or returns an option
-  def retrieveUndertakingAndHandleErrors(eori: EORI)(implicit hc: HeaderCarrier) = {
+  def retrieveUndertakingAndHandleErrors(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, Option[Undertaking]]] = {
 
     def parseResponse(response: HttpResponse) =
       response
@@ -62,7 +61,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
     EitherT(escConnector.retrieveUndertaking(eori))
       .flatMapF(r => parseResponse(r).toFuture)
       .recover {
-        case WithStatusCode(NOT_FOUND) => None
+        case ConnectorError(_, WithStatusCode(NOT_FOUND)) => None
       }
       .value
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -50,7 +50,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
       case Left(ex) => throw ex
     }
 
-  def retrieveUndertakingAndHandleErrors(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, Option[Undertaking]]] = {
+  def retrieveUndertakingAndHandleErrors(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Option[Undertaking]]] = {
 
     def parseResponse(response: HttpResponse) =
       response
@@ -61,7 +61,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
     EitherT(escConnector.retrieveUndertaking(eori))
       .flatMapF(r => parseResponse(r).toFuture)
       .recover {
-        case ConnectorError(_, WithStatusCode(NOT_FOUND)) => None
+        case WithStatusCode(NOT_FOUND) => None
       }
       .value
   }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -16,12 +16,13 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.connector
 
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should._
 import org.scalatest.wordspec._
 import play.api.libs.json.JsString
 import play.api.test.Helpers._
-import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
+import uk.gov.hmrc.http.HttpResponse
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -30,20 +31,21 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
   val currentDate = LocalDate.of(2021, 1, 20)
 
-  def connectorBehaviour(
+  // TODO - any changes here may break the email connector specs - check
+  def connectorBehaviour[A](
     mockResponse: Option[HttpResponse] => Unit,
-    performCall: () => Future[Either[ConnectorError, HttpResponse]]
+    performCall: () => Future[Either[A, HttpResponse]]
   ) = {
+
     "do a get http call and return the result" in {
       List(
         HttpResponse(200, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
-        HttpResponse(500, "{}")
       ).foreach { httpResponse =>
         withClue(s"For http response [${httpResponse.toString}]") {
           mockResponse(Some(httpResponse))
 
-          await(performCall()) shouldBe Right(httpResponse)
+          performCall().futureValue shouldBe Right(httpResponse)
         }
       }
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -31,7 +31,6 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
   val currentDate = LocalDate.of(2021, 1, 20)
 
-  // TODO - any changes here may break the email connector specs - check
   def connectorBehaviour[A](
     mockResponse: Option[HttpResponse] => Unit,
     performCall: () => Future[Either[A, HttpResponse]]

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -41,6 +41,7 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       List(
         HttpResponse(200, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
+        HttpResponse(500, "{}")
       ).foreach { httpResponse =>
         withClue(s"For http response [${httpResponse.toString}]") {
           mockResponse(Some(httpResponse))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -412,7 +412,7 @@ class BusinessEntityControllerSpec
 
         def testEORIvalidation(
           data: (String, String)*
-        )(retrieveResponse: Either[ConnectorError, Option[Undertaking]], errorMessageKey: String): Unit = {
+        )(retrieveResponse: Either[UpstreamErrorResponse, Option[Undertaking]], errorMessageKey: String): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
@@ -448,7 +448,7 @@ class BusinessEntityControllerSpec
 
         "eori submitted is not stored in SMTP" in {
           testEORIvalidation("businessEntityEori" -> "123456789010")(
-            Left(ConnectorError(UpstreamErrorResponse("EORI not present in SMTP", 406))),
+            Left(UpstreamErrorResponse("EORI not present in SMTP", 406)),
             "error.businessEntityEori.required"
           )
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -412,7 +412,7 @@ class BusinessEntityControllerSpec
 
         def testEORIvalidation(
           data: (String, String)*
-        )(retrieveResponse: Either[UpstreamErrorResponse, Option[Undertaking]], errorMessageKey: String): Unit = {
+        )(retrieveResponse: Either[ConnectorError, Option[Undertaking]], errorMessageKey: String): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
@@ -448,7 +448,7 @@ class BusinessEntityControllerSpec
 
         "eori submitted is not stored in SMTP" in {
           testEORIvalidation("businessEntityEori" -> "123456789010")(
-            Left(UpstreamErrorResponse("EORI not present in SMTP", 406)),
+            Left(ConnectorError(UpstreamErrorResponse("EORI not present in SMTP", 406))),
             "error.businessEntityEori.required"
           )
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -43,7 +43,7 @@ trait EscServiceSupport { this: ControllerSpec =>
     eori: EORI
   )(result: Either[UpstreamErrorResponse, Option[Undertaking]]) =
     (mockEscService
-      .retrieveUndertakingWithErrorResponse(_: EORI)(_: HeaderCarrier))
+      .retrieveUndertakingAndHandleErrors(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
       .returning(result.toFuture)
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -73,6 +73,16 @@ class SubsidyControllerSpec
       "throw technical error" when {
         val exception = new Exception("oh no")
 
+        "call to get undertaking from EIS fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[Undertaking](eori1)(Right(Option.empty))
+            mockRetrieveUndertaking(eori1)(Future.failed(new RuntimeException("Oh no!")))
+          }
+
+          assertThrows[Exception](await(performAction()))
+        }
+
         "call to get subsidy journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -1464,8 +1474,6 @@ class SubsidyControllerSpec
     }
 
   }
-
-}
 
 object SubsidyControllerSpec {
   case class RemoveSubsidyRow(key: String, value: String)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1090,6 +1090,7 @@ class SubsidyControllerSpec
             nonHmrcSubsidy.traderReference.getOrElse("")
           )
         )
+
         inSequence {
           mockAuthWithNecessaryEnrolment()
           mockGet[Undertaking](eori1)(Right(undertaking.some))
@@ -1474,6 +1475,7 @@ class SubsidyControllerSpec
     }
 
   }
+}
 
 object SubsidyControllerSpec {
   case class RemoveSubsidyRow(key: String, value: String)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -21,7 +21,6 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.http.Status.NOT_ACCEPTABLE
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
@@ -31,7 +30,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -56,7 +55,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .expects(undertaking, *)
       .returning(result.toFuture)
 
-  private def mockRetrieveUndertaking(eori: EORI)(result: Either[ConnectorError, HttpResponse]) =
+  private def mockRetrieveUndertaking(eori: EORI)(result: Either[UpstreamErrorResponse, HttpResponse]) =
     (mockEscConnector
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
@@ -217,17 +216,18 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
             await(result) shouldBe undertaking.some
           }
 
-          "http response status is 404 and response body is not there" in {
-            mockRetrieveUndertaking(eori1)(Right(HttpResponse(NOT_FOUND, " ")))
-            val result = service.retrieveUndertaking(eori1)
-            await(result) shouldBe None
-          }
+          // TODO - ensure these cases are covered
+//          "http response status is 404 and response body is not there" in {
+//            mockRetrieveUndertaking(eori1)(Right(HttpResponse(NOT_FOUND, " ")))
+//            val result = service.retrieveUndertaking(eori1)
+//            await(result) shouldBe None
+//          }
 
-          "http response status is 406 and response body is parsed" in {
-            mockRetrieveUndertaking(eori1)(Right(HttpResponse(NOT_ACCEPTABLE, upstreamErrorResponse, emptyHeaders)))
-            val result = service.retrieveUndertaking(eori1)
-            await(result) shouldBe None
-          }
+//          "http response status is 406 and response body is parsed" in {
+//            mockRetrieveUndertaking(eori1)(Right(HttpResponse(NOT_ACCEPTABLE, upstreamErrorResponse, emptyHeaders)))
+//            val result = service.retrieveUndertaking(eori1)
+//            await(result) shouldBe None
+//          }
 
         }
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -209,14 +209,14 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
             await(result) shouldBe undertaking.some
           }
 
-        }
-
-        "return an error" when {
-
-          "http response status is 404 and response body is not there" in {
+          "http response status is 404 and response body is empty" in {
             mockRetrieveUndertaking(eori1)(Left(UpstreamErrorResponse("Unexpected response - got HTTP 404", NOT_FOUND)))
             await(service.retrieveUndertaking(eori1)) shouldBe None
           }
+
+        }
+
+        "return an error" when {
 
           "http response status is 406 and response body is parsed" in {
             val ex = UpstreamErrorResponse("Unexpected response - got HTTP 406", NOT_ACCEPTABLE)
@@ -224,6 +224,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
             an[UpstreamErrorResponse] should be thrownBy await(service.retrieveUndertaking(eori1))
           }
         }
+
       }
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -26,11 +26,12 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
Summary of changes
* the undertaking retrieval code in the connector has been revised to return a Right on HTTP 200, and a Left on all other responses
* revised the ESC service to take appropriate action depending on whether a Left or Right is returned by the connector
* updated tests to account for this change 

Note - this fixes an issue where an error connecting to EIS would be interpreted as 'no undertaking present' by the frontend. 