### PR TITLE
ESC-551 update HmrcSubsidy model to align to v3.0 of the SCP09 spec

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/HmrcSubsidy.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/HmrcSubsidy.scala
@@ -28,7 +28,8 @@ case class HmrcSubsidy(
   declarantEORI: EORI, // n.b. SCP09 uses looser validation but will stick with ours
   consigneeEORI: EORI,
   taxType: Option[TaxType],
-  amount: Option[SubsidyAmount],
+  hmrcSubsidyAmtGBP: Option[SubsidyAmount],
+  hmrcSubsidyAmtEUR: Option[SubsidyAmount],
   tradersOwnRefUCR: Option[TraderRef]
 )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/models/FinancialDashboardSummary.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/models/FinancialDashboardSummary.scala
@@ -92,7 +92,7 @@ object FinancialDashboardSummary {
 
     val hmrcSubsidiesByTaxYearStart: Map[LocalDate, SubsidyAmount] = sumByTaxYear(
       subsidies.hmrcSubsidyUsage
-        .map(i => i.acceptanceDate.toTaxYearStart -> i.amount.getOrElse(SubsidyAmount.Zero))
+        .map(i => i.acceptanceDate.toTaxYearStart -> i.hmrcSubsidyAmtEUR.getOrElse(SubsidyAmount.Zero))
     )
 
     val nonHmrcSubsidiesByTaxYearStart: Map[LocalDate, SubsidyAmount] = sumByTaxYear(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -67,7 +67,8 @@ object CommonTestData {
     declarantEORI = eori1,
     consigneeEORI = eori3,
     taxType = Some(TaxType("1")),
-    amount = Some(subsidyAmount),
+    hmrcSubsidyAmtGBP = Some(subsidyAmount),
+    hmrcSubsidyAmtEUR = Some(subsidyAmount),
     tradersOwnRefUCR = Some(traderRef)
   )
 


### PR DESCRIPTION
Summary of changes
* replace HMRC subsidy `amount` field with new currency specific amount fields introduced in the latest version of the `SCP09` specification