### PR TITLE
ESC-532 introduce common response handling for connectors

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/Connector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/Connector.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
+
+import play.api.http.Status.OK
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
+import uk.gov.hmrc.http.{HttpClient, HttpResponse, UpstreamErrorResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait Connector {
+
+  type ConnectorResult = Future[Either[ConnectorError, HttpResponse]]
+
+  protected val http: HttpClient
+
+  protected def makeRequest(
+    request: HttpClient => Future[HttpResponse]
+  )(implicit ec: ExecutionContext): ConnectorResult =
+    request(http) map { r: HttpResponse =>
+      // TODO - this should cover the full range of 200 responses
+      if (r.status == OK) Right(r)
+      else Left(ConnectorError(
+        UpstreamErrorResponse(s"Unexpected response - got HTTP ${r.status}", r.status)
+      ))
+    } recover {
+      case e: Exception => Left(ConnectorError(e))
+    }
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -32,21 +32,21 @@ class EscConnector @Inject() (
   servicesConfig: ServicesConfig
 )(implicit ec: ExecutionContext) {
 
-  private lazy val escURL: String = servicesConfig.baseUrl("esc")
+  private lazy val escUrl: String = servicesConfig.baseUrl("esc")
 
-  private val createUndertakingPath = "eu-subsidy-compliance/undertaking"
-  private val updateUndertakingPath = "eu-subsidy-compliance/undertaking/update"
-  private val retrieveUndertakingPath = "eu-subsidy-compliance/undertaking/"
-  private val addMemberPath = "eu-subsidy-compliance/undertaking/member"
-  private val removeMemberPath = "eu-subsidy-compliance/undertaking/member/remove"
-  private val updateSubsidyPath = "eu-subsidy-compliance/subsidy/update"
-  private val retrieveSubsidyPath = "eu-subsidy-compliance/subsidy/retrieve"
+  private lazy val createUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking"
+  private lazy val updateUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking/update"
+  private lazy val retrieveUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking"
+  private lazy val addMemberUrl = s"$escUrl/eu-subsidy-compliance/undertaking/member"
+  private lazy val removeMemberUrl = s"$escUrl/eu-subsidy-compliance/undertaking/member/remove"
+  private lazy val updateSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/update"
+  private lazy val retrieveSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/retrieve"
 
   def createUndertaking(
     undertaking: Undertaking
   )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[Undertaking, HttpResponse](s"$escURL/$createUndertakingPath", undertaking)
+      .POST[Undertaking, HttpResponse](createUndertakingUrl, undertaking)
       .map(Right(_))
       .recover {
         case e => Left(ConnectorError(e))
@@ -56,7 +56,7 @@ class EscConnector @Inject() (
     undertaking: Undertaking
   )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[Undertaking, HttpResponse](s"$escURL/$updateUndertakingPath", undertaking)
+      .POST[Undertaking, HttpResponse](updateUndertakingUrl, undertaking)
       .map(Right(_))
       .recover { case e =>
         Left(ConnectorError(e))
@@ -64,7 +64,7 @@ class EscConnector @Inject() (
 
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] =
     http
-      .GET[HttpResponse](s"$escURL/$retrieveUndertakingPath$eori")
+      .GET[HttpResponse](s"$retrieveUndertakingUrl/$eori")
       .map { r =>
         if (r.status == OK) Right(r)
         else Left(UpstreamErrorResponse(s"Unexpected response - got HTTP ${r.status}", r.status))
@@ -74,7 +74,7 @@ class EscConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[BusinessEntity, HttpResponse](s"$escURL/$addMemberPath/$undertakingRef", businessEntity)
+      .POST[BusinessEntity, HttpResponse](s"$addMemberUrl/$undertakingRef", businessEntity)
       .map(Right(_))
       .recover { case e =>
         Left(ConnectorError(e))
@@ -84,7 +84,7 @@ class EscConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[BusinessEntity, HttpResponse](s"$escURL/$removeMemberPath/$undertakingRef", businessEntity)
+      .POST[BusinessEntity, HttpResponse](s"$removeMemberUrl/$undertakingRef", businessEntity)
       .map(Right(_))
       .recover { case e =>
         Left(ConnectorError(e))
@@ -94,7 +94,7 @@ class EscConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[SubsidyUpdate, HttpResponse](s"$escURL/$updateSubsidyPath", subsidyUpdate)
+      .POST[SubsidyUpdate, HttpResponse](updateSubsidyUrl, subsidyUpdate)
       .map(Right(_))
       .recover { case e =>
         Left(ConnectorError(e))
@@ -104,7 +104,7 @@ class EscConnector @Inject() (
     hc: HeaderCarrier
   ): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[SubsidyUpdate, HttpResponse](s"$escURL/$updateSubsidyPath", toSubsidyDelete(nonHmrcSubsidy, undertakingRef))
+      .POST[SubsidyUpdate, HttpResponse](updateSubsidyUrl, toSubsidyDelete(nonHmrcSubsidy, undertakingRef))
       .map(Right(_))
       .recover { case e =>
         Left(ConnectorError(e))
@@ -114,7 +114,7 @@ class EscConnector @Inject() (
     subsidyRetrieve: SubsidyRetrieve
   )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
     http
-      .POST[SubsidyRetrieve, HttpResponse](s"$escURL/$retrieveSubsidyPath", subsidyRetrieve)
+      .POST[SubsidyRetrieve, HttpResponse](retrieveSubsidyUrl, subsidyRetrieve)
       .map(Right(_))
       .recover { case e =>
         Left(ConnectorError(e))
@@ -125,6 +125,7 @@ class EscConnector @Inject() (
       undertakingIdentifier = undertakingRef,
       update = UndertakingSubsidyAmendment(
         List(
+          // TODO - is there a centralised definition of the allowed amendment types?
           nonHmrcSubsidy.copy(amendmentType = Some(EisSubsidyAmendmentType("3")))
         )
       )

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{Inject, Singleton}
 import play.api.http.Status.OK
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -68,6 +68,7 @@ class EscConnector @Inject() (
   def createSubsidy(subsidyUpdate: SubsidyUpdate)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[SubsidyUpdate, HttpResponse](updateSubsidyUrl, subsidyUpdate))
 
+  // TODO - add test coverage for this
   def removeSubsidy(
     undertakingRef: UndertakingRef,
     nonHmrcSubsidy: NonHmrcSubsidy

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -90,7 +90,7 @@ class EscConnector @Inject() (
         Left(ConnectorError(e))
       }
 
-  def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
+  def createSubsidy(subsidyUpdate: SubsidyUpdate)(implicit
     hc: HeaderCarrier
   ): Future[Either[ConnectorError, HttpResponse]] =
     http

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -65,7 +65,6 @@ class EscConnector @Inject() (
   def createSubsidy(subsidyUpdate: SubsidyUpdate)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[SubsidyUpdate, HttpResponse](updateSubsidyUrl, subsidyUpdate))
 
-  // TODO - add test coverage for this
   def removeSubsidy(
     undertakingRef: UndertakingRef,
     nonHmrcSubsidy: NonHmrcSubsidy

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -17,31 +17,24 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{Inject, Singleton}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class RetrieveEmailConnector @Inject() (
-  http: HttpClient,
+  override protected val http: HttpClient,
   servicesConfig: ServicesConfig
-)(implicit ec: ExecutionContext) {
+)(implicit ec: ExecutionContext) extends Connector {
 
   lazy private val cdsURL: String = servicesConfig.baseUrl("cds")
 
-  def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/${eori}/verified-email"
+  private def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/${eori}/verified-email"
 
-  def retrieveEmailByEORI(
-    eori: EORI
-  )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
-    http
-      .GET[HttpResponse](getUri(eori))
-      .map(Right(_))
-      .recover { case e =>
-        Left(ConnectorError(e))
-      }
+  def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): ConnectorResult =
+    makeRequest(_.GET[HttpResponse](getUri(eori)))
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/SendEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/SendEmailConnector.scala
@@ -17,29 +17,23 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
 import com.google.inject.{Inject, Singleton}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendRequest
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class SendEmailConnector @Inject() (
-  http: HttpClient,
+  override protected val http: HttpClient,
   servicesConfig: ServicesConfig
-)(implicit ec: ExecutionContext
-) {
+)(implicit ec: ExecutionContext) extends Connector {
 
   private lazy val baseUrl: String = servicesConfig.baseUrl("email-send")
   private lazy val sendEmailUrl: String = s"$baseUrl/hmrc/email"
 
-  def sendEmail(
-    emailSendRequest: EmailSendRequest
-  )(implicit hc: HeaderCarrier): Future[Either[ConnectorError, HttpResponse]] =
-    http
-      .POST[EmailSendRequest, HttpResponse](sendEmailUrl, emailSendRequest)
-      .map(Right(_))
-      .recover { case e => Left(ConnectorError(e)) }
+  def sendEmail(request: EmailSendRequest)(implicit hc: HeaderCarrier): ConnectorResult =
+    makeRequest(_.POST[EmailSendRequest, HttpResponse](sendEmailUrl, request))
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -67,9 +67,7 @@ class NoClaimNotificationController @Inject() (
             val result = for {
               reference <- undertaking.reference.toContext
               _ <- store.update[NilReturnJourney](_.setNilReturnValues(form.value.toBoolean)).toContext
-              _ <- escService
-                .createSubsidy(reference, SubsidyUpdate(reference, NilSubmissionDate(nilSubmissionDate)))
-                .toContext
+              _ <- escService.createSubsidy(SubsidyUpdate(reference, NilSubmissionDate(nilSubmissionDate))).toContext
               _ = auditService
                 .sendEvent(
                   NonCustomsSubsidyNilReturn(request.authorityId, eori, reference, nilSubmissionDate)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -389,7 +389,7 @@ class SubsidyController @Inject() (
                 _ <- validateSubsidyJourneyFieldsPopulated(journey).toContext
                 ref <- undertaking.reference.toContext
                 currentDate = timeProvider.today
-                _ <- escService.createSubsidy(ref, toSubsidyUpdate(journey, ref, currentDate)).toContext
+                _ <- escService.createSubsidy(toSubsidyUpdate(journey, ref, currentDate)).toContext
                 _ <- store.put(SubsidyJourney()).toContext
                 _ =
                   if (journey.isAmend)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/SubsidyUpdate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/SubsidyUpdate.scala
@@ -17,10 +17,9 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
 import java.time.LocalDate
-
 import cats.implicits._
 import play.api.libs.json.{JsResult, _}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EisSubsidyAmendmentType, UndertakingRef}
 
 import scala.reflect.ClassTag
 
@@ -73,4 +72,12 @@ object SubsidyUpdate {
       JsSuccess(SubsidyUpdate(id, update))
     }
   }
+
+  def forDelete(undertakingIdentifier: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy): SubsidyUpdate =
+    SubsidyUpdate(
+      undertakingIdentifier,
+      UndertakingSubsidyAmendment(List(
+        nonHmrcSubsidy.copy(amendmentType = Some(EisSubsidyAmendmentType("3")))
+      ))
+    )
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -25,7 +25,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityUpdate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyAmount, SubsidyRef, TraderRef, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.getValidEori
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney
 
 import java.time.{LocalDate, LocalDateTime}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BusinessEntityJourney.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
-import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
+import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -109,10 +109,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
         else
           response
             .parseJSON[A]
-            .fold(
-              _ => sys.error(s"Error parsing response for $action"),
-              identity
-            )
+            .getOrElse(sys.error(s"Error parsing response for $action"))
     )
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -50,7 +50,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
       case Left(ex) => throw ex
     }
 
-  def retrieveUndertakingAndHandleErrors(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Option[Undertaking]]] = {
+  def retrieveUndertakingAndHandleErrors(eori: EORI)(implicit hc: HeaderCarrier): Future[Either[ConnectorError, Option[Undertaking]]] = {
 
     def parseResponse(response: HttpResponse) =
       response
@@ -61,7 +61,7 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
     EitherT(escConnector.retrieveUndertaking(eori))
       .flatMapF(r => parseResponse(r).toFuture)
       .recover {
-        case WithStatusCode(NOT_FOUND) => None
+        case ConnectorError(_, WithStatusCode(NOT_FOUND)) => None
       }
       .value
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -80,11 +80,9 @@ class EscService @Inject() (escConnector: EscConnector)(implicit ec: ExecutionCo
       .removeMember(undertakingRef, businessEntity)
       .map(handleResponse[UndertakingRef](_, "remove member"))
 
-  def createSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(implicit
-    hc: HeaderCarrier
-  ): Future[UndertakingRef] =
+  def createSubsidy(subsidyUpdate: SubsidyUpdate)(implicit hc: HeaderCarrier): Future[UndertakingRef] =
     escConnector
-      .createSubsidy(undertakingRef, subsidyUpdate)
+      .createSubsidy(subsidyUpdate)
       .map(handleResponse[UndertakingRef](_, "create subsidy"))
 
   def retrieveSubsidy(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -38,7 +38,6 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
     "do a get http call and return the result" in {
       List(
-        // TODO - cover range of 200 responses?
         HttpResponse(200, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
       ).foreach { httpResponse =>
@@ -49,7 +48,6 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       }
     }
 
-    // TODO - any value in inspecting the actual value inside the Left?
     "return an error" when {
 
       "the server returns a 4xx response" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -40,8 +40,6 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       List(
         HttpResponse(200, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
-        // TODO - exercise error handling
-//        HttpResponse(500, "{}")
       ).foreach { httpResponse =>
         withClue(s"For http response [${httpResponse.toString}]") {
           mockResponse(Some(httpResponse))
@@ -50,13 +48,21 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       }
     }
 
-    // TODO - additional error cases to test here? E.g. 5xx and 4xx responses?
     "return an error" when {
 
       "the future fails" in {
         mockResponse(None)
+        performCall().futureValue.isLeft shouldBe true
+      }
 
-        await(performCall()).isLeft shouldBe true
+      "the server returns a 4xx response" in {
+        mockResponse(Some(HttpResponse(404, "")))
+        performCall().futureValue.isLeft shouldBe true
+      }
+
+      "the server returns a 5xx response" in {
+        mockResponse(Some(HttpResponse(500, "")))
+        performCall().futureValue.isLeft shouldBe true
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -40,16 +40,17 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       List(
         HttpResponse(200, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
-        HttpResponse(500, "{}")
+        // TODO - exercise error handling
+//        HttpResponse(500, "{}")
       ).foreach { httpResponse =>
         withClue(s"For http response [${httpResponse.toString}]") {
           mockResponse(Some(httpResponse))
-
           performCall().futureValue shouldBe Right(httpResponse)
         }
       }
     }
 
+    // TODO - additional error cases to test here? E.g. 5xx and 4xx responses?
     "return an error" when {
 
       "the future fails" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -38,6 +38,7 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
     "do a get http call and return the result" in {
       List(
+        // TODO - cover range of 200 responses?
         HttpResponse(200, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
       ).foreach { httpResponse =>
@@ -48,12 +49,8 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       }
     }
 
+    // TODO - any value in inspecting the actual value inside the Left?
     "return an error" when {
-
-      "the future fails" in {
-        mockResponse(None)
-        performCall().futureValue.isLeft shouldBe true
-      }
 
       "the server returns a 4xx response" in {
         mockResponse(Some(HttpResponse(404, "")))
@@ -65,9 +62,15 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
         performCall().futureValue.isLeft shouldBe true
       }
 
+      "the future fails" in {
+        mockResponse(None)
+        performCall().futureValue.isLeft shouldBe true
+      }
+
     }
   }
 
+  // TODO - review usages of this method
   def connectorBehaviourWithMockTime(
     mockResponse: Option[HttpResponse] => Unit,
     performCall: () => Future[Either[ConnectorError, HttpResponse]],

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -20,16 +20,11 @@ import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should._
 import org.scalatest.wordspec._
 import play.api.libs.json.JsString
-import play.api.test.Helpers._
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.http.HttpResponse
 
-import java.time.LocalDate
 import scala.concurrent.Future
 
 trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
-
-  val currentDate = LocalDate.of(2021, 1, 20)
 
   def connectorBehaviour[A](
     mockResponse: Option[HttpResponse] => Unit,
@@ -63,42 +58,6 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
       "the future fails" in {
         mockResponse(None)
         performCall().futureValue.isLeft shouldBe true
-      }
-
-    }
-  }
-
-  // TODO - review usages of this method
-  def connectorBehaviourWithMockTime(
-    mockResponse: Option[HttpResponse] => Unit,
-    performCall: () => Future[Either[ConnectorError, HttpResponse]],
-    mockTimeResponse: LocalDate => Unit
-  ) = {
-    "do a get http call and return the result" in {
-
-      List(
-        HttpResponse(200, "{}"),
-        HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
-        HttpResponse(500, "{}")
-      ).foreach { httpResponse =>
-        withClue(s"For http response [${httpResponse.toString}]") {
-
-          mockTimeResponse(currentDate)
-          mockResponse(Some(httpResponse))
-
-          await(performCall()) shouldBe Right(httpResponse)
-        }
-      }
-    }
-
-    "return an error" when {
-
-      "the future fails" in {
-
-        mockTimeResponse(currentDate)
-        mockResponse(None)
-
-        await(performCall()).isLeft shouldBe true
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -16,20 +16,18 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.connector
 
-import cats.implicits.catsSyntaxOptionId
 import com.typesafe.config.ConfigFactory
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
-import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND}
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.SubsidyUpdate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -37,6 +35,7 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
   with ScalaFutures {
 
   private val (protocol, host, port) = ("http", "host", "123")
+  private val baseUrl = s"$protocol://$host:$port/eu-subsidy-compliance"
 
   private val config = Configuration(
     ConfigFactory.parseString(s"""
@@ -55,94 +54,57 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
   "EscConnector" when {
 
     "handling request to create Undertaking" must {
-
-      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking"
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, undertaking)(_),
+        mockPost(s"$baseUrl/undertaking", Seq.empty, undertaking)(_),
         () => connector.createUndertaking(undertaking)
       )
-
     }
 
     "handling request to update Undertaking" must {
-
-      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/update"
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, undertaking)(_),
+        mockPost(s"$baseUrl/undertaking/update", Seq.empty, undertaking)(_),
         () => connector.updateUndertaking(undertaking)
       )
-
     }
 
-    // TODO - should be sufficient to use connector behaiour
     "handling request to retrieve Undertaking" must {
-
-      val url = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/$eori1"
-
-      def mockGetResponse(r: HttpResponse) = mockGet(url)(r.some)
-
-      def errorFor(status: Int) =
-        ConnectorError(UpstreamErrorResponse(s"Unexpected response - got HTTP $status", status))
-
-      "return a successful response where an undertaking exists" in {
-        val response = HttpResponse(200, "{}")
-        mockGetResponse(response)
-        connector.retrieveUndertaking(eori1).futureValue shouldBe Right(response)
-      }
-
-      "return an unsuccessful response where an undertaking does not exist" in {
-        val response = HttpResponse(404, "")
-        mockGetResponse(response)
-        connector.retrieveUndertaking(eori1).futureValue shouldBe Left(errorFor(NOT_FOUND))
-      }
-
-      "return an unsuccessful response where the downstream service returns a HTTP 400" in {
-        val response = HttpResponse(400, "")
-        mockGetResponse(response)
-        connector.retrieveUndertaking(eori1).futureValue shouldBe Left(errorFor(BAD_REQUEST))
-      }
-
-      "return an unsuccessful response where the downstream service returns a HTTP 500" in {
-        val response = HttpResponse(500, "")
-        mockGetResponse(response)
-        connector.retrieveUndertaking(eori1).futureValue shouldBe Left(errorFor(INTERNAL_SERVER_ERROR))
-      }
-
+      behave like connectorBehaviour(
+        mockGet(s"$baseUrl/undertaking/$eori1")(_),
+        () => connector.retrieveUndertaking(eori1)
+      )
     }
 
     "handling request to add member in Business Entity Undertaking" must {
-      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/member/UR123456"
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, businessEntity3)(_),
+        mockPost(s"$baseUrl/undertaking/member/UR123456", Seq.empty, businessEntity3)(_),
         () => connector.addMember(UndertakingRef("UR123456"), businessEntity3)
       )
-
     }
 
     "handling request to remove member from Business Entity Undertaking" must {
-      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/member/remove/UR123456"
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, businessEntity3)(_),
+        mockPost(s"$baseUrl/undertaking/member/remove/UR123456", Seq.empty, businessEntity3)(_),
         () => connector.removeMember(UndertakingRef("UR123456"), businessEntity3)
       )
-
     }
 
     "handling request to create subsidy" must {
-      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/subsidy/update"
-
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, subsidyUpdate)(_),
+        mockPost(s"$baseUrl/subsidy/update", Seq.empty, subsidyUpdate)(_),
         () => connector.createSubsidy(subsidyUpdate)
       )
+    }
 
+    "handling request to remove subsidy" must {
+      behave like connectorBehaviour(
+        mockPost(s"$baseUrl/subsidy/update", Seq.empty, SubsidyUpdate.forDelete(undertakingRef, nonHmrcSubsidy))(_),
+        () => connector.removeSubsidy(undertakingRef, nonHmrcSubsidy)
+      )
     }
 
     "handling request to retrieve subsidy" must {
-
-      val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/subsidy/retrieve"
       behave like connectorBehaviour(
-        mockPost(expectedUrl, Seq.empty, subsidyRetrieve)(_),
+        mockPost(s"$baseUrl/subsidy/retrieve", Seq.empty, subsidyRetrieve)(_),
         () => connector.retrieveSubsidy(subsidyRetrieve)
       )
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -74,6 +74,7 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
 
     }
 
+    // TODO - should be sufficient to use connector behaiour
     "handling request to retrieve Undertaking" must {
 
       val url = s"$protocol://$host:$port/eu-subsidy-compliance/undertaking/$eori1"

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -127,13 +127,10 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
 
     "handling request to create subsidy" must {
       val expectedUrl = s"$protocol://$host:$port/eu-subsidy-compliance/subsidy/update"
+
       behave like connectorBehaviour(
         mockPost(expectedUrl, Seq.empty, subsidyUpdate)(_),
-        () =>
-          connector.createSubsidy(
-            undertakingRef,
-            subsidyUpdate
-          )
+        () => connector.createSubsidy(subsidyUpdate)
       )
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND}
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.UndertakingRef
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -79,7 +80,8 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
 
       def mockGetResponse(r: HttpResponse) = mockGet(url)(r.some)
 
-      def errorFor(status: Int) = UpstreamErrorResponse(s"Unexpected response - got HTTP $status", status)
+      def errorFor(status: Int) =
+        ConnectorError(UpstreamErrorResponse(s"Unexpected response - got HTTP $status", status))
 
       "return a successful response where an undertaking exists" in {
         val response = HttpResponse(200, "{}")
@@ -87,7 +89,7 @@ class EscConnectorSpec extends AnyWordSpec with Matchers with MockFactory with H
         connector.retrieveUndertaking(eori1).futureValue shouldBe Right(response)
       }
 
-      "return a successful response where an undertaking does not exist" in {
+      "return an unsuccessful response where an undertaking does not exist" in {
         val response = HttpResponse(404, "")
         mockGetResponse(response)
         connector.retrieveUndertaking(eori1).futureValue shouldBe Left(errorFor(NOT_FOUND))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -414,7 +414,7 @@ class BusinessEntityControllerSpec
 
         def testEORIvalidation(
           data: (String, String)*
-        )(retrieveResponse: Either[UpstreamErrorResponse, Option[Undertaking]], errorMessageKey: String): Unit = {
+        )(retrieveResponse: Either[ConnectorError, Option[Undertaking]], errorMessageKey: String): Unit = {
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockGet[Undertaking](eori1)(Right(undertaking.some))
@@ -459,7 +459,7 @@ class BusinessEntityControllerSpec
 
         "eori submitted is not stored in SMTP" in {
           testEORIvalidation("businessEntityEori" -> "123456789010")(
-            Left(UpstreamErrorResponse("EORI not present in SMTP", 406)),
+            Left(ConnectorError(UpstreamErrorResponse("EORI not present in SMTP", 406))),
             "error.businessEntityEori.required"
           )
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -16,17 +16,18 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, ConnectorError, NonHmrcSubsidy, SubsidyRetrieve, SubsidyUpdate, Undertaking, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
-import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
 trait EscServiceSupport { this: ControllerSpec =>
 
   val mockEscService = mock[EscService]
+
   def mockCreateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
       .createUndertaking(_: Undertaking)(_: HeaderCarrier))
@@ -41,7 +42,7 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   def mockRetrieveUndertakingWithErrorResponse(
     eori: EORI
-  )(result: Either[UpstreamErrorResponse, Option[Undertaking]]) =
+  )(result: Either[ConnectorError, Option[Undertaking]]) =
     (mockEscService
       .retrieveUndertakingAndHandleErrors(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -73,8 +73,8 @@ trait EscServiceSupport { this: ControllerSpec =>
     result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
-      .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
-      .expects(reference, subsidyUpdate, *)
+      .createSubsidy(_: SubsidyUpdate)(_: HeaderCarrier))
+      .expects(subsidyUpdate, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 
   def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(result: Future[UndertakingSubsidies]) =

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -25,14 +25,14 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyControllerSpec
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.NonCustomsSubsidyRemoved
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{SubsidyAmount, SubsidyRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters.BigDecimalFormatter.Syntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters.DateFormatter.Syntax.DateOps
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 
 import java.time.LocalDate
 import scala.collection.JavaConverters.asScalaIteratorConverter

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -77,12 +77,12 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .expects(undertakingRef, businessEntity, *)
       .returning(result.toFuture)
 
-  private def mockCreateSubsidy(undertakingRef: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
+  private def mockCreateSubsidy(subsidyUpdate: SubsidyUpdate)(
     result: Either[ConnectorError, HttpResponse]
   ) =
     (mockEscConnector
-      .createSubsidy(_: UndertakingRef, _: SubsidyUpdate)(_: HeaderCarrier))
-      .expects(undertakingRef, subsidyUpdate, *)
+      .createSubsidy(_: SubsidyUpdate)(_: HeaderCarrier))
+      .expects(subsidyUpdate, *)
       .returning(result.toFuture)
 
   private def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(
@@ -323,30 +323,30 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       "return an error" when {
 
         def isError(): Assertion = {
-          val result = service.createSubsidy(undertakingRef, subsidyUpdate)
+          val result = service.createSubsidy(subsidyUpdate)
           assertThrows[RuntimeException](await(result))
         }
 
         "the http call fails" in {
-          mockCreateSubsidy(undertakingRef, subsidyUpdate)(Left(ConnectorError("")))
+          mockCreateSubsidy(subsidyUpdate)(Left(ConnectorError("")))
           isError()
         }
 
         "the http response doesn't come back with status 200(OK)" in {
-          mockCreateSubsidy(undertakingRef, subsidyUpdate)(
+          mockCreateSubsidy(subsidyUpdate)(
             Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders))
           )
           isError()
         }
 
         "there is no json in the response" in {
-          mockCreateSubsidy(undertakingRef, subsidyUpdate)(Right(HttpResponse(OK, "hi")))
+          mockCreateSubsidy(subsidyUpdate)(Right(HttpResponse(OK, "hi")))
           isError()
         }
 
         "the json in the response can't be parsed" in {
           val json = Json.parse("""{ "a" : 1 }""")
-          mockCreateSubsidy(undertakingRef, subsidyUpdate)(Right(HttpResponse(OK, json, emptyHeaders)))
+          mockCreateSubsidy(subsidyUpdate)(Right(HttpResponse(OK, json, emptyHeaders)))
           isError()
         }
 
@@ -355,8 +355,8 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       "return successfully" when {
 
         "the http call succeeds and the body of the response can be parsed" in {
-          mockCreateSubsidy(undertakingRef, subsidyUpdate)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
-          val result = service.createSubsidy(undertakingRef, subsidyUpdate)
+          mockCreateSubsidy(subsidyUpdate)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
+          val result = service.createSubsidy(subsidyUpdate)
           await(result) shouldBe undertakingRef
         }
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -55,7 +55,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
       .expects(undertaking, *)
       .returning(result.toFuture)
 
-  private def mockRetrieveUndertaking(eori: EORI)(result: Either[UpstreamErrorResponse, HttpResponse]) =
+  private def mockRetrieveUndertaking(eori: EORI)(result: Either[ConnectorError, HttpResponse]) =
     (mockEscConnector
       .retrieveUndertaking(_: EORI)(_: HeaderCarrier))
       .expects(eori, *)
@@ -210,7 +210,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
           }
 
           "http response status is 404 and response body is empty" in {
-            mockRetrieveUndertaking(eori1)(Left(UpstreamErrorResponse("Unexpected response - got HTTP 404", NOT_FOUND)))
+            mockRetrieveUndertaking(eori1)(Left(ConnectorError(UpstreamErrorResponse("Unexpected response - got HTTP 404", NOT_FOUND))))
             await(service.retrieveUndertaking(eori1)) shouldBe None
           }
 
@@ -220,8 +220,8 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
 
           "http response status is 406 and response body is parsed" in {
             val ex = UpstreamErrorResponse("Unexpected response - got HTTP 406", NOT_ACCEPTABLE)
-            mockRetrieveUndertaking(eori1)(Left(ex))
-            an[UpstreamErrorResponse] should be thrownBy await(service.retrieveUndertaking(eori1))
+            mockRetrieveUndertaking(eori1)(Left(ConnectorError(ex)))
+            a[ConnectorError] should be thrownBy await(service.retrieveUndertaking(eori1))
           }
         }
 


### PR DESCRIPTION
Summary of changes
* introduced `Connector` trait that provides a `makeRequest` method that provides common response handling for all connector calls
* revised the logic so any 2xx response results in a Right(...) with any other status code result in a Left(...)
* updated connectors to use `makeRequest` and updated the tests
* added coverage for the `removeSubsidy` method of the ESC Connector
* removed dead code