### PR TITLE
Esc 550 fix date

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
@@ -49,6 +49,8 @@ case class ClaimDateFormProvider(timeProvider: TimeProvider) extends FormProvide
       .verifying(Constraint(dateInAllowedRange(_)))
       .transform(
         { case (d, m, y) =>
+          // day month and year string first formatted like d M YYYY, to get rid of 0 prefix in day/month value entered by the User
+          //The formatted string then changed to LocalDate to fetch the date and month using the getDayOfMonth,getMonthValue  functions
           val date = LocalDate.parse(LocalDate.of(y.toInt, m.toInt, d.toInt).format(dateFormatter), dateFormatter)
           DateFormValues(date.getDayOfMonth.toString, date.getMonthValue.toString, y)
         },

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
@@ -33,7 +33,7 @@ case class ClaimDateFormProvider(timeProvider: TimeProvider) extends FormProvide
 
   override val form: Form[DateFormValues] = Form(mapping)
 
-  private val dateFormatter = DateTimeFormatter.ofPattern("dd MM yyyy")
+  private val dateFormatter = DateTimeFormatter.ofPattern("d M yyyy")
 
   private def formValueMapping = tuple(
     "day" -> text,
@@ -47,7 +47,13 @@ case class ClaimDateFormProvider(timeProvider: TimeProvider) extends FormProvide
       .verifying(Constraint(allDateValuesEntered(_)))
       .verifying(Constraint(dateIsValid(_)))
       .verifying(Constraint(dateInAllowedRange(_)))
-      .transform({ case (d, m, y) => DateFormValues(d, m, y) }, d => (d.day, d.month, d.year))
+      .transform(
+        { case (d, m, y) =>
+          val date = LocalDate.parse(LocalDate.of(y.toInt, m.toInt, d.toInt).format(dateFormatter), dateFormatter)
+          DateFormValues(date.getDayOfMonth.toString, date.getMonthValue.toString, y)
+        },
+        d => (d.day, d.month, d.year)
+      )
 
   private val dateIsValid: RawFormValues => ValidationResult = {
     case (d, m, y) if Try(s"$d$m$y".toInt).isFailure => invalid("date.invalidentry")


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-550
The bug for date occurred because the user entered 09 in the month and the data was saved like  this in the journey.
since we don't have any value for date.09 inn the messages conf file. It appeared as it is in the Form.
-This PR is for  fixing this bug where now code trims the prefixed 0 in date and month place entered by user. 
-Plus the error message , which says "Enter the date you were awarded the payment. Date must be 06 04 2021, or later." the prefixed 0 from the day and month has been removed as per discussion with Dan. So it should be like this "Enter the date you were awarded the payment. Date must be 6 4 2021, or later."