### PR TITLE
ESC-560 increase request timeouts to 60s

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -103,6 +103,10 @@ microservice {
   }
 }
 
+# Explicitly allow requests of up to 60 seconds
+play.ws.timeout.request = 60 seconds
+ws.timeout.request = 60000
+
 metrics {
   name = ${appName}
   rateUnit = SECONDS


### PR DESCRIPTION
Summary of changes
* increase request timeouts from default of 20s to 60s