### PR TITLE
Esc 399

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -100,7 +100,6 @@ class AccountController @Inject() (
     for {
       ej <- store.getOrCreate[EligibilityJourney](EligibilityJourney()).toContext
       uj <- store.getOrCreate[UndertakingJourney](u).toContext
-      _ <- store.getOrCreate[BusinessEntityJourney](BusinessEntityJourney()).toContext
     } yield (ej, uj)
 
   private def renderAccountPage(undertaking: Undertaking)(implicit r: AuthenticatedEscRequest[AnyContent]) = {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -74,7 +74,6 @@ class BusinessEntityController @Inject() (
       store
         .getOrCreate[BusinessEntityJourney](BusinessEntityJourney())
         .map { journey =>
-          println(" journey is ::" + journey)
           val form = journey.addBusiness.value
             .fold(addBusinessForm)(bool => addBusinessForm.fill(FormValues(bool.toString)))
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -24,7 +24,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BusinessEntityJourney.getValidEori
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Uri
@@ -71,11 +71,10 @@ class BusinessEntityController @Inject() (
   def getAddBusinessEntity: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     withLeadUndertaking { undertaking =>
       implicit val eori: EORI = request.eoriNumber
-
       store
-        .get[BusinessEntityJourney]
-        .toContext
-        .fold(handleMissingSessionData("Business Entity Journey")) { journey =>
+        .getOrCreate[BusinessEntityJourney](BusinessEntityJourney())
+        .map { journey =>
+          println(" journey is ::" + journey)
           val form = journey.addBusiness.value
             .fold(addBusinessForm)(bool => addBusinessForm.fill(FormValues(bool.toString)))
 
@@ -112,18 +111,17 @@ class BusinessEntityController @Inject() (
   def getEori: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     withLeadUndertaking { _ =>
       implicit val eori: EORI = request.eoriNumber
-      journeyTraverseService.getPrevious[BusinessEntityJourney].flatMap { previous =>
-        store.get[BusinessEntityJourney].flatMap {
-          case Some(journey) =>
-            if (!journey.isEligibleForStep) {
-              Redirect(journey.previous).toFuture
-            } else {
-              val form = journey.eori.value.fold(eoriForm)(eori => eoriForm.fill(FormValues(eori)))
-              Ok(eoriPage(form, previous)).toFuture
-            }
-          case _ => handleMissingSessionData("Business Entity Journey")
-        }
+      store.get[BusinessEntityJourney].flatMap {
+        case Some(journey) =>
+          if (!journey.isEligibleForStep) {
+            Redirect(journey.previous).toFuture
+          } else {
+            val form = journey.eori.value.fold(eoriForm)(eori => eoriForm.fill(FormValues(eori)))
+            Ok(eoriPage(form, journey.previous)).toFuture
+          }
+        case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()).toFuture
       }
+
     }
   }
 
@@ -165,7 +163,7 @@ class BusinessEntityController @Inject() (
           } else {
             Ok(businessEntityCyaPage(journey.eori.value.get, journey.previous)).toFuture
           }
-        case _ => handleMissingSessionData("CheckYourAnswers journey")
+        case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()).toFuture
       }
     }
   }
@@ -173,40 +171,44 @@ class BusinessEntityController @Inject() (
   def postCheckYourAnswers: Action[AnyContent] = withAuthenticatedUser.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
 
-    def handleValidAnswers(undertaking: Undertaking) = for {
-      businessEntityJourney <- store
-        .get[BusinessEntityJourney]
-        .map(_.getOrElse(handleMissingSessionData("BusinessEntity Journey")))
-      undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("undertaking ref"))
-      eoriBE = businessEntityJourney.eori.value.getOrElse(handleMissingSessionData("BE EORI"))
+    def handleValidAnswersC(undertaking: Undertaking) = for {
+      businessEntityJourney <- store.get[BusinessEntityJourney].toContext
+      undertakingRef <- undertaking.reference.toContext
+      eoriBE <- businessEntityJourney.eori.value.toContext
       businessEntity = BusinessEntity(eoriBE, leadEORI = false) // resetting the journey as it's final CYA page
       _ <- {
         if (businessEntityJourney.isAmend) {
-          escService.removeMember(
-            undertakingRef,
-            businessEntity.copy(businessEntityIdentifier = businessEntityJourney.oldEORI.get)
-          )
+          escService
+            .removeMember(
+              undertakingRef,
+              businessEntity.copy(businessEntityIdentifier = businessEntityJourney.oldEORI.get)
+            )
+            .toContext
         }
-        escService.addMember(undertakingRef, businessEntity)
+        escService.addMember(undertakingRef, businessEntity).toContext
       }
-      _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-        eoriBE,
-        None,
-        AddMemberEmailToBusinessEntity,
-        undertaking,
-        undertakingRef,
-        None
-      )
-      _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-        eori,
-        eoriBE.some,
-        AddMemberEmailToLead,
-        undertaking,
-        undertakingRef,
-        None
-      )
+      _ <- sendEmailHelperService
+        .retrieveEmailAddressAndSendEmail(
+          eoriBE,
+          None,
+          AddMemberEmailToBusinessEntity,
+          undertaking,
+          undertakingRef,
+          None
+        )
+        .toContext
+      _ <- sendEmailHelperService
+        .retrieveEmailAddressAndSendEmail(
+          eori,
+          eoriBE.some,
+          AddMemberEmailToLead,
+          undertaking,
+          undertakingRef,
+          None
+        )
+        .toContext
       // Clear the cached undertaking so it's retrieved on the next access
-      _ <- store.delete[Undertaking]
+      _ <- store.delete[Undertaking].toContext
       _ =
         if (businessEntityJourney.isAmend)
           auditService.sendEvent(
@@ -214,7 +216,7 @@ class BusinessEntityController @Inject() (
           )
         else
           auditService.sendEvent(AuditEvent.BusinessEntityAdded(undertakingRef, request.authorityId, eori, eoriBE))
-      redirect <- getNext(businessEntityJourney)(eori)
+      redirect <- getNext(businessEntityJourney)(eori).toContext
     } yield redirect
 
     withLeadUndertaking { undertaking =>
@@ -222,7 +224,7 @@ class BusinessEntityController @Inject() (
         .bindFromRequest()
         .fold(
           errors => throw new IllegalStateException(s"value hard-coded, form hacking? $errors"),
-          _ => handleValidAnswers(undertaking)
+          _ => handleValidAnswersC(undertaking).fold(handleMissingSessionData("BusinessEntity Data"))(identity)
         )
     }
   }
@@ -234,7 +236,7 @@ class BusinessEntityController @Inject() (
           case Some(undertaking) =>
             val removeBE = undertaking.getBusinessEntityByEORI(EORI(eoriEntered))
             Ok(removeBusinessPage(removeBusinessForm, removeBE))
-          case _ => handleMissingSessionData("Undertaking journey")
+          case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity())
         }
       }
   }
@@ -249,13 +251,52 @@ class BusinessEntityController @Inject() (
         val removeBE = undertaking.getBusinessEntityByEORI(eori)
         Ok(removeYourselfBEPage(removeYourselfBusinessForm, removeBE, previous, undertaking.name))
 
-      case _ => handleMissingSessionData("Undertaking journey")
+      case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity())
     }
   }
 
   def postRemoveBusinessEntity(eoriEntered: String): Action[AnyContent] = withAuthenticatedUser.async {
     implicit request =>
       implicit val eori: EORI = request.eoriNumber
+
+      def handleValidBE(
+        form: FormValues,
+        undertakingRef: UndertakingRef,
+        removeBE: BusinessEntity,
+        undertaking: Undertaking
+      ) =
+        form.value match {
+          case "true" =>
+            val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today.plusDays(1))
+            for {
+              _ <- escService.removeMember(undertakingRef, removeBE)
+              _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
+                EORI(eoriEntered),
+                None,
+                RemoveMemberEmailToBusinessEntity,
+                undertaking,
+                undertakingRef,
+                removalEffectiveDateString.some
+              )
+              _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
+                eori,
+                EORI(eoriEntered).some,
+                RemoveMemberEmailToLead,
+                undertaking,
+                undertakingRef,
+                removalEffectiveDateString.some
+              )
+              // Clear the cached undertaking so it's retrieved on the next access
+              _ <- store.delete[Undertaking]
+              _ = auditService
+                .sendEvent(
+                  AuditEvent
+                    .BusinessEntityRemoved(undertakingRef, request.authorityId, eori, EORI(eoriEntered))
+                )
+            } yield Redirect(routes.BusinessEntityController.getAddBusinessEntity())
+          case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()).toFuture
+        }
+
       withLeadUndertaking { _ =>
         escService.retrieveUndertaking(EORI(eoriEntered)).flatMap {
           case Some(undertaking) =>
@@ -266,39 +307,7 @@ class BusinessEntityController @Inject() (
               .bindFromRequest()
               .fold(
                 errors => BadRequest(removeBusinessPage(errors, removeBE)).toFuture,
-                success = form => {
-                  form.value match {
-                    case "true" =>
-                      val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today.plusDays(1))
-                      for {
-                        _ <- escService.removeMember(undertakingRef, removeBE)
-                        _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-                          EORI(eoriEntered),
-                          None,
-                          RemoveMemberEmailToBusinessEntity,
-                          undertaking,
-                          undertakingRef,
-                          removalEffectiveDateString.some
-                        )
-                        _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-                          eori,
-                          EORI(eoriEntered).some,
-                          RemoveMemberEmailToLead,
-                          undertaking,
-                          undertakingRef,
-                          removalEffectiveDateString.some
-                        )
-                        // Clear the cached undertaking so it's retrieved on the next access
-                        _ <- store.delete[Undertaking]
-                        _ = auditService
-                          .sendEvent(
-                            AuditEvent
-                              .BusinessEntityRemoved(undertakingRef, request.authorityId, eori, EORI(eoriEntered))
-                          )
-                      } yield Redirect(routes.BusinessEntityController.getAddBusinessEntity())
-                    case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()).toFuture
-                  }
-                }
+                success = form => handleValidBE(form, undertakingRef, removeBE, undertaking)
               )
           case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity()).toFuture
         }
@@ -312,41 +321,41 @@ class BusinessEntityController @Inject() (
       case Some(undertaking) =>
         val undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("undertaking reference"))
         val removeBE: BusinessEntity = undertaking.getBusinessEntityByEORI(loggedInEORI)
+        def handleValidBE(form: FormValues) = form.value match {
+          case "true" =>
+            val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today.plusDays(1))
+            val leadEORI = undertaking.getLeadEORI
+            for {
+              _ <- escService.removeMember(undertakingRef, removeBE)
+              _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
+                loggedInEORI,
+                None,
+                RemoveThemselfEmailToBusinessEntity,
+                undertaking,
+                undertakingRef,
+                removalEffectiveDateString.some
+              )
+              _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
+                leadEORI,
+                loggedInEORI.some,
+                RemoveThemselfEmailToLead,
+                undertaking,
+                undertakingRef,
+                removalEffectiveDateString.some
+              )
+              _ = auditService
+                .sendEvent(
+                  AuditEvent
+                    .BusinessEntityRemovedSelf(undertakingRef, request.authorityId, leadEORI, loggedInEORI)
+                )
+            } yield Redirect(routes.SignOutController.signOut())
+          case _ => Redirect(routes.AccountController.getAccountPage()).toFuture
+        }
         removeYourselfBusinessForm
           .bindFromRequest()
           .fold(
             errors => BadRequest(removeYourselfBEPage(errors, removeBE, previous, undertaking.name)).toFuture,
-            form =>
-              form.value match {
-                case "true" =>
-                  val removalEffectiveDateString = DateFormatter.govDisplayFormat(timeProvider.today.plusDays(1))
-                  val leadEORI = undertaking.getLeadEORI
-                  for {
-                    _ <- escService.removeMember(undertakingRef, removeBE)
-                    _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-                      loggedInEORI,
-                      None,
-                      RemoveThemselfEmailToBusinessEntity,
-                      undertaking,
-                      undertakingRef,
-                      removalEffectiveDateString.some
-                    )
-                    _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-                      leadEORI,
-                      loggedInEORI.some,
-                      RemoveThemselfEmailToLead,
-                      undertaking,
-                      undertakingRef,
-                      removalEffectiveDateString.some
-                    )
-                    _ = auditService
-                      .sendEvent(
-                        AuditEvent
-                          .BusinessEntityRemovedSelf(undertakingRef, request.authorityId, leadEORI, loggedInEORI)
-                      )
-                  } yield Redirect(routes.SignOutController.signOut())
-                case _ => Future(Redirect(routes.AccountController.getAccountPage()))
-              }
+            form => handleValidBE(form)
           )
 
       case _ => handleMissingSessionData("Undertaking journey")

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -130,8 +130,10 @@ class SelectNewLeadController @Inject() (
             _ <- store.update[BusinessEntityJourney](b => b.copy(isLeadSelectJourney = None))
             _ <- store.put[NewLeadJourney](NewLeadJourney())
             selectedEORI = newLeadJourney.selectNewLead.value
-          } yield selectedEORI.fold(Redirect(newLeadJourney.previous))(eori => Ok(leadEORIChangedPage(eori, undertaking.name)))
-        case None => handleMissingSessionData("New Lead journey")
+          } yield selectedEORI.fold(Redirect(newLeadJourney.previous))(eori =>
+            Ok(leadEORIChangedPage(eori, undertaking.name))
+          )
+        case None => Redirect(routes.SelectNewLeadController.getSelectNewLead()).toFuture
       }
     }
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -159,7 +159,8 @@ class SubsidyController @Inject() (
 
     val searchRange = timeProvider.today.toSearchRange.some
 
-    store.getOrCreate[UndertakingSubsidies](() => escService.retrieveSubsidy(SubsidyRetrieve(r, searchRange)))
+    store
+      .getOrCreate[UndertakingSubsidies](() => escService.retrieveSubsidy(SubsidyRetrieve(r, searchRange)))
       .map(Option(_))
       .fallbackTo(Option.empty.toFuture)
   }
@@ -232,13 +233,13 @@ class SubsidyController @Inject() (
         case Some(journey) =>
           journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
             val form = journey.claimDate.value.fold(claimDateForm)(claimDateForm.fill)
-            if(!journey.isEligibleForStep) {
+            if (!journey.isEligibleForStep) {
               Redirect(journey.previous).toFuture
             } else {
               Ok(addClaimDatePage(form, previous)).toFuture
             }
           }
-        case _ => handleMissingSessionData("Subsidy journey")
+        case _ => Redirect(routes.SubsidyController.getReportPayment()).toFuture
       }
     }
   }
@@ -268,7 +269,7 @@ class SubsidyController @Inject() (
       store.get[SubsidyJourney].flatMap {
         case Some(journey) =>
           journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
-            if(!journey.isEligibleForStep) {
+            if (!journey.isEligibleForStep) {
               Redirect(routes.SubsidyController.getClaimDate()).toFuture
             } else {
               val form = journey.addClaimEori.value.fold(claimEoriForm) { optionalEORI =>
@@ -277,7 +278,7 @@ class SubsidyController @Inject() (
               Ok(addClaimEoriPage(form, previous)).toFuture
             }
           }
-        case _ => handleMissingSessionData("Subsidy journey")
+        case _ => Redirect(routes.SubsidyController.getReportPayment()).toFuture
       }
     }
   }
@@ -307,14 +308,14 @@ class SubsidyController @Inject() (
       store.get[SubsidyJourney].flatMap {
         case Some(journey) =>
           journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
-            if(!journey.isEligibleForStep) {
+            if (!journey.isEligibleForStep) {
               Redirect(journey.previous).toFuture
             } else {
               val form = journey.publicAuthority.value.fold(claimPublicAuthorityForm)(claimPublicAuthorityForm.fill)
               Ok(addPublicAuthorityPage(form, previous)).toFuture
             }
           }
-        case _ => handleMissingSessionData("Subsidy journey")
+        case _ => Redirect(routes.SubsidyController.getReportPayment()).toFuture
       }
     }
   }
@@ -342,7 +343,7 @@ class SubsidyController @Inject() (
       implicit val eori: EORI = request.eoriNumber
       store.get[SubsidyJourney].flatMap {
         case Some(journey) =>
-          if(!journey.isEligibleForStep) {
+          if (!journey.isEligibleForStep) {
             Redirect(journey.previous).toFuture
           } else {
             val form = journey.traderRef.value.fold(claimTraderRefForm) { optionalTraderRef =>
@@ -350,7 +351,7 @@ class SubsidyController @Inject() (
             }
             Ok(addTraderReferencePage(form, journey.previous)).toFuture
           }
-        case _ => handleMissingSessionData("Subsidy journey")
+        case _ => Redirect(routes.SubsidyController.getReportPayment()).toFuture
       }
     }
   }
@@ -447,7 +448,7 @@ class SubsidyController @Inject() (
           subsidies <- retrieveSubsidies(reference).toContext
           sub <- subsidies.nonHMRCSubsidyUsage.find(_.subsidyUsageTransactionId.contains(transactionId)).toContext
         } yield Ok(confirmRemovePage(removeSubsidyClaimForm, sub))
-        result.fold(handleMissingSessionData("Subsidy Journey"))(identity)
+        result.fold(Redirect(routes.SubsidyController.getReportPayment()))(identity)
       }
   }
 
@@ -475,7 +476,7 @@ class SubsidyController @Inject() (
           subsidyJourney = SubsidyJourney.fromNonHmrcSubsidy(nonHmrcSubsidy)
           _ <- store.put(subsidyJourney).toContext
         } yield Redirect(routes.SubsidyController.getCheckAnswers())
-        result.fold(handleMissingSessionData("nonHMRC subsidy"))(identity)
+        result.fold(Redirect(routes.SubsidyController.getReportPayment()))(identity)
       }
   }
 
@@ -483,10 +484,10 @@ class SubsidyController @Inject() (
     transactionId: String,
     reference: UndertakingRef
   )(implicit r: AuthenticatedEscRequest[AnyContent]): OptionT[Future, NonHmrcSubsidy] =
-      retrieveSubsidies(reference)
-        .recoverWith({ case _ => Option.empty[UndertakingSubsidies].toFuture })
-        .toContext
-        .flatMap(_.nonHMRCSubsidyUsage.find(_.subsidyUsageTransactionId.contains(transactionId)).toContext)
+    retrieveSubsidies(reference)
+      .recoverWith({ case _ => Option.empty[UndertakingSubsidies].toFuture })
+      .toContext
+      .flatMap(_.nonHMRCSubsidyUsage.find(_.subsidyUsageTransactionId.contains(transactionId)).toContext)
 
   private def handleRemoveSubsidyFormError(
     formWithErrors: Form[FormValues],

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -448,7 +448,7 @@ class SubsidyController @Inject() (
           subsidies <- retrieveSubsidies(reference).toContext
           sub <- subsidies.nonHMRCSubsidyUsage.find(_.subsidyUsageTransactionId.contains(transactionId)).toContext
         } yield Ok(confirmRemovePage(removeSubsidyClaimForm, sub))
-        result.fold(Redirect(routes.SubsidyController.getReportPayment()))(identity)
+        result.fold(handleMissingSessionData("Subsidy Journey"))(identity)
       }
   }
 
@@ -476,7 +476,7 @@ class SubsidyController @Inject() (
           subsidyJourney = SubsidyJourney.fromNonHmrcSubsidy(nonHmrcSubsidy)
           _ <- store.put(subsidyJourney).toContext
         } yield Redirect(routes.SubsidyController.getCheckAnswers())
-        result.fold(Redirect(routes.SubsidyController.getReportPayment()))(identity)
+        result.fold(handleMissingSessionData("nonHMRC subsidy"))(identity)
       }
   }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -81,7 +81,6 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
-            mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
             mockTimeToday(fixedDate)
             mockGetOrCreate(eori1)(Right(nilJourneyCreate))
             mockGetOrCreateF(eori1)(Right(undertakingSubsidies))
@@ -149,7 +148,6 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
-            mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
             mockTimeToday(currentDate)
             mockGetOrCreate[NilReturnJourney](eori1)(Right(nilJourneyCreate))
             mockGetOrCreateF(eori1)(Right(undertakingSubsidies))
@@ -186,7 +184,6 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
-            mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
             mockTimeToday(currentDate)
             mockGetOrCreate[NilReturnJourney](eori1)(Right(nilReturnJourney))
             mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNJ))
@@ -220,13 +217,16 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate(eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate(eori1)(Right(UndertakingJourney()))
-            mockGetOrCreate(eori1)(Right(businessEntityJourney))
             mockTimeToday(currentDate)
             mockGetOrCreate(eori1)(Right(nilJourneyCreate))
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies.copy(
-              nonHMRCSubsidyUsage = List.empty,
-              hmrcSubsidyUsage = List.empty
-            )))
+            mockGetOrCreateF(eori1)(
+              Right(
+                undertakingSubsidies.copy(
+                  nonHMRCSubsidyUsage = List.empty,
+                  hmrcSubsidyUsage = List.empty
+                )
+              )
+            )
           }
 
           checkPageIsDisplayed(
@@ -317,7 +317,6 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori4)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori4)(Right(UndertakingJourney()))
-            mockGetOrCreate[BusinessEntityJourney](eori4)(Right(businessEntityJourney))
             mockTimeToday(fixedDate)
           }
 
@@ -394,7 +393,6 @@ class AccountControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
-            mockGetOrCreate[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
 
@@ -431,7 +429,6 @@ class AccountControllerSpec
                 mockRetrieveUndertaking(eori1)(None.toFuture)
                 mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete))
                 mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
-                mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
               }
               checkIsRedirect(performAction(), routes.EligibilityController.firstEmptyPage())
             }
@@ -443,7 +440,6 @@ class AccountControllerSpec
                 mockRetrieveUndertaking(eori1)(None.toFuture)
                 mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
                 mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
-                mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
               }
               checkIsRedirect(performAction(), routes.UndertakingController.firstEmptyPage())
             }
@@ -455,7 +451,6 @@ class AccountControllerSpec
                 mockRetrieveUndertaking(eori1)(None.toFuture)
                 mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
                 mockGetOrCreate[UndertakingJourney](eori1)(Right(undertakingJourneyComplete1))
-                mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
               }
               checkIsRedirect(performAction(), routes.BusinessEntityController.getAddBusinessEntity())
             }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -294,16 +294,6 @@ class SelectNewLeadControllerSpec
 
         }
 
-        "call to fetch new lead journey came back with None" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[NewLeadJourney](eori1)(Right(None))
-          }
-          assertThrows[Exception](await(performAction()))
-
-        }
-
         "call to fetch new lead journey came back with response but there is no selected EORI in it" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -386,9 +376,20 @@ class SelectNewLeadControllerSpec
 
       }
 
-      "redirect to the account home page" when {
+      "redirect to next page" when {
+
         "user is not an undertaking lead" in {
           testLeadOnlyRedirect(performAction)
+        }
+
+        "call to fetch new lead journey came back with None" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
+            mockGet[NewLeadJourney](eori1)(Right(None))
+          }
+          checkIsRedirect(performAction(), routes.SelectNewLeadController.getSelectNewLead().url)
+
         }
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -256,16 +256,6 @@ class SubsidyControllerSpec
 
         }
 
-        "call to get sessions returns none" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Right(None))
-          }
-          assertThrows[Exception](await(performAction()))
-
-        }
-
       }
 
       "display the page" when {
@@ -292,9 +282,20 @@ class SubsidyControllerSpec
 
       }
 
-      "redirect to the account home page" when {
-        "user is not an undertaking lead" in {
+      "redirect " when {
+
+        "user is not an undertaking lead to account home page" in {
           testLeadOnlyRedirect(performAction)
+        }
+
+        "call to get sessions returns none, to subsidy start journey" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
+            mockGet[SubsidyJourney](eori1)(Right(None))
+          }
+          checkIsRedirect(performAction(), routes.SubsidyController.getReportPayment().url)
+
         }
       }
     }
@@ -591,15 +592,6 @@ class SubsidyControllerSpec
           assertThrows[Exception](await(performAction()))
         }
 
-        " the call to get subsidy journey comes back empty" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Right(None))
-          }
-          assertThrows[Exception](await(performAction()))
-        }
-
       }
 
       "display the page" when {
@@ -649,9 +641,18 @@ class SubsidyControllerSpec
 
       }
 
-      "redirect to the account home page" when {
-        "user is not an undertaking lead" in {
+      "redirect " when {
+        "user is not an undertaking lead, to the account home page" in {
           testLeadOnlyRedirect(performAction)
+        }
+
+        "the call to get subsidy journey comes back empty, to subsidy start journey page" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
+            mockGet[SubsidyJourney](eori1)(Right(None))
+          }
+          checkIsRedirect(performAction(), routes.SubsidyController.getReportPayment().url)
         }
       }
     }
@@ -895,15 +896,6 @@ class SubsidyControllerSpec
           assertThrows[Exception](await(performAction()))
         }
 
-        "the call to get subsidy journey comes back empty" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-            mockGet[SubsidyJourney](eori1)(Right(None))
-          }
-          assertThrows[Exception](await(performAction()))
-        }
-
       }
 
       "display the page" when {
@@ -959,9 +951,19 @@ class SubsidyControllerSpec
 
       }
 
-      "redirect to the account home page" when {
-        "user is not an undertaking lead" in {
+      "redirect " when {
+
+        "user is not an undertaking lead, to the account home page" in {
           testLeadOnlyRedirect(performAction)
+        }
+
+        "the call to get subsidy journey comes back empty, to Start of the journey" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
+            mockGet[SubsidyJourney](eori1)(Right(None))
+          }
+          checkIsRedirect(performAction(), routes.SubsidyController.getReportPayment().url)
         }
       }
 


### PR DESCRIPTION
- MOved the initialisation of journey to the controller - wherever was possible
- The case where journey was  not found during the intermediate steps of the journey( A case which should never happen unless user tries to manipulate through url), It was handled as exception. Now the user is redirected to the first page of the journey instead of showing the technical error page.
- Test cases or the changes