### PR TITLE
ESC-562 Move undertaking and subsidy caching into ESC Service

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.cache
+
+import com.mongodb.WriteConcern
+import org.mongodb.scala.model.Filters
+import play.api.Configuration
+import play.api.libs.json.{Reads, Writes}
+import uk.gov.hmrc.eusubsidycompliancefrontend.cache.UndertakingCache.DefaultCacheTtl
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.mongo.cache.{CacheIdType, DataKey, MongoCacheRepository}
+import uk.gov.hmrc.mongo.{CurrentTimestampSupport, MongoComponent}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+import scala.reflect.ClassTag
+
+object EoriIdType extends CacheIdType[EORI] {
+  override def run: EORI => EORI = identity
+}
+
+// TODO - got access to the collection so there may be a way forward here
+@Singleton
+class UndertakingCache @Inject() (
+  mongoComponent: MongoComponent,
+  configuration: Configuration
+)(implicit ec: ExecutionContext) {
+
+  private val cache = new MongoCacheRepository[EORI](
+    mongoComponent = mongoComponent,
+    collectionName = "undertakingCache",
+    ttl = DefaultCacheTtl,
+    timestampSupport = new CurrentTimestampSupport,
+    cacheIdType = EoriIdType
+  )
+
+  def get[A : ClassTag](eori: EORI)(implicit reads: Reads[A]): Future[Option[A]] = {
+    println(s"Undertaking cache GET: $eori")
+    cache
+      .get[A](eori)(dataKeyForType[A])
+  }
+
+  def put[A : ClassTag](eori: EORI, in: A)(implicit writes: Writes[A]): Future[A] = {
+    println(s"Undertaking cache PUT: $eori")
+    cache
+      .put[A](eori)(DataKey(in.getClass.getSimpleName), in)
+      .map(_ => in)
+  }
+
+  // TODO - consider renaming this to delete undertaking
+  def delete[A : ClassTag](ref: UndertakingRef): Future[Unit] = {
+    println(s"Undertaking cache DELETE: $ref")
+    cache
+      .collection
+      .withWriteConcern(WriteConcern.ACKNOWLEDGED)
+      .deleteMany(Filters.equal("data.Undertaking.reference", ref))
+      .toFuture()
+      .map(_ => ())
+  }
+
+  private def dataKeyForType[A](implicit ct: ClassTag[A]) = DataKey[A](ct.runtimeClass.getSimpleName)
+
+}
+
+object UndertakingCache {
+  val DefaultCacheTtl: FiniteDuration = 24 hours
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
@@ -42,7 +42,7 @@ class UndertakingCache @Inject() (
   configuration: Configuration
 )(implicit ec: ExecutionContext) {
 
-  private val cache = new MongoCacheRepository[EORI](
+  private lazy val cache = new MongoCacheRepository[EORI](
     mongoComponent = mongoComponent,
     collectionName = "undertakingCache",
     ttl = DefaultCacheTtl,
@@ -56,7 +56,7 @@ class UndertakingCache @Inject() (
       .get[A](eori)(dataKeyForType[A])
   }
 
-  def put[A : ClassTag](eori: EORI, in: A)(implicit writes: Writes[A]): Future[A] = {
+  def put[A](eori: EORI, in: A)(implicit writes: Writes[A]): Future[A] = {
     println(s"Undertaking cache PUT: $eori")
     cache
       .put[A](eori)(DataKey(in.getClass.getSimpleName), in)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
@@ -82,9 +82,7 @@ class UndertakingCache @Inject() (
         .map(_ => in)
     }
 
-  def deleteUndertaking(ref: UndertakingRef): Future[Unit] = {
-    println(s"Deleting Undertaking with ref: $ref from cache")
-
+  def deleteUndertaking(ref: UndertakingRef): Future[Unit] =
     indexedCollection.flatMap { c =>
       c.updateMany(
           filter = Filters.equal(UndertakingReference, ref),
@@ -93,12 +91,8 @@ class UndertakingCache @Inject() (
         .toFuture()
         .map(_ => ())
     }
-  }
 
-
-  def deleteUndertakingSubsidies(ref: UndertakingRef): Future[Unit] = {
-    println(s"Deleting UndertakingSubsidies with ref: $ref from cache")
-
+  def deleteUndertakingSubsidies(ref: UndertakingRef): Future[Unit] =
     indexedCollection.flatMap { c =>
       c.updateMany(
           filter = Filters.equal(UndertakingSubsidiesIdentifier, ref),
@@ -107,7 +101,6 @@ class UndertakingCache @Inject() (
         .toFuture()
         .map(_ => ())
     }
-  }
 
   private def dataKeyForType[A](implicit ct: ClassTag[A]) = DataKey[A](ct.runtimeClass.getSimpleName)
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
@@ -63,8 +63,7 @@ class UndertakingCache @Inject() (
       .map(_ => in)
   }
 
-  // TODO - consider renaming this to delete undertaking
-  def delete[A : ClassTag](ref: UndertakingRef): Future[Unit] = {
+  def deleteUndertaking(ref: UndertakingRef): Future[Unit] = {
     println(s"Undertaking cache DELETE: $ref")
     cache
       .collection

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
@@ -86,7 +86,7 @@ class UndertakingCache @Inject() (
     indexedCollection.flatMap { c =>
       c.updateMany(
           filter = Filters.equal(UndertakingReference, ref),
-          update = Updates.unset(s"data.Undertaking")
+          update = Updates.unset("data.Undertaking")
         )
         .toFuture()
         .map(_ => ())
@@ -96,7 +96,7 @@ class UndertakingCache @Inject() (
     indexedCollection.flatMap { c =>
       c.updateMany(
           filter = Filters.equal(UndertakingSubsidiesIdentifier, ref),
-          update = Updates.unset(s"data.UndertakingSubsidies")
+          update = Updates.unset("data.UndertakingSubsidies")
         )
         .toFuture()
         .map(_ => ())

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -122,9 +122,7 @@ class AccountController @Inject() (
         undertakingReference <- undertaking.reference.toContext
         searchRange = Some((currentDay.toEarliestTaxYearStart, currentDay))
         retrieveRequest = SubsidyRetrieve(undertakingReference, searchRange)
-        subsidies <- store
-          .getOrCreate[UndertakingSubsidies](() => escService.retrieveSubsidy(retrieveRequest))
-          .toContext
+        subsidies <- escService.retrieveSubsidy(retrieveRequest).toContext
       } yield Ok(
         leadAccountPage(
           undertaking,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEsc
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailType
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{SubsidyRetrieve, Undertaking, UndertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{SubsidyRetrieve, Undertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
@@ -21,9 +21,9 @@ import cats.implicits._
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{SubsidyRetrieve, Undertaking, UndertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{SubsidyRetrieve, Undertaking, UndertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.TaxYearSyntax.LocalDateTaxYearOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
@@ -39,7 +39,6 @@ class FinancialDashboardController @Inject() (
   escService: EscService,
   financialDashboardPage: FinancialDashboardPage,
   mcc: MessagesControllerComponents,
-  store: Store,
   timeProvider: TimeProvider
 )(implicit val appConfig: AppConfig, ec: ExecutionContext)
     extends BaseController(mcc) {
@@ -58,7 +57,7 @@ class FinancialDashboardController @Inject() (
       undertaking <- escService.retrieveUndertaking(eori).toContext
       r <- undertaking.reference.toContext
       s = SubsidyRetrieve(r, searchRange)
-      subsidies <- store.getOrCreate(() => escService.retrieveSubsidy(s)).toContext
+      subsidies <- escService.retrieveSubsidy(s).toContext
     } yield (undertaking, subsidies)
 
     result

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -406,7 +406,6 @@ class SubsidyController @Inject() (
           ref <- undertaking.reference.toContext
           currentDate = timeProvider.today
           _ <- escService.createSubsidy(toSubsidyUpdate(journey, ref, currentDate)).toContext
-          _ <- store.delete[UndertakingSubsidies].toContext
           _ <- store.put(SubsidyJourney()).toContext
           _ =
             if (journey.isAmend)
@@ -511,7 +510,6 @@ class SubsidyController @Inject() (
       reference <- undertaking.reference.toContext
       nonHmrcSubsidy <- getNonHmrcSubsidy(transactionId, reference)
       _ <- escService.removeSubsidy(reference, nonHmrcSubsidy).toContext
-      _ <- store.delete[UndertakingSubsidies].toContext
       _ = auditService.sendEvent[NonCustomsSubsidyRemoved](
         AuditEvent.NonCustomsSubsidyRemoved(request.authorityId, reference)
       )

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -159,8 +159,8 @@ class SubsidyController @Inject() (
 
     val searchRange = timeProvider.today.toSearchRange.some
 
-    store
-      .getOrCreate[UndertakingSubsidies](() => escService.retrieveSubsidy(SubsidyRetrieve(r, searchRange)))
+    escService
+      .retrieveSubsidy(SubsidyRetrieve(r, searchRange))
       .map(Option(_))
       .fallbackTo(Option.empty.toFuture)
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -497,6 +497,7 @@ class SubsidyController @Inject() (
       reference <- undertaking.reference.toContext
       nonHmrcSubsidy <- getNonHmrcSubsidy(transactionId, reference)
     } yield BadRequest(confirmRemovePage(formWithErrors, nonHmrcSubsidy))
+
     result.fold(handleMissingSessionData("nonHMRC subsidy"))(identity)
   }
 
@@ -504,8 +505,6 @@ class SubsidyController @Inject() (
     transactionId: String,
     undertaking: Undertaking
   )(implicit request: AuthenticatedEscRequest[AnyContent]): Future[Result] = {
-    implicit val eori: EORI = request.eoriNumber
-
     val result = for {
       reference <- undertaking.reference.toContext
       nonHmrcSubsidy <- getNonHmrcSubsidy(transactionId, reference)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -172,7 +172,7 @@ class UndertakingController @Inject() (
               None,
               List(BusinessEntity(eori, leadEORI = true))
             )
-            undertakingCreated <- createUndertakingAndSendEmail(undertaking, eori, updatedJourney).toContext
+            undertakingCreated <- createUndertakingAndSendEmail(undertaking, updatedJourney).toContext
           } yield undertakingCreated
           result.fold(handleMissingSessionData("Undertaking create journey"))(identity)
         }
@@ -181,11 +181,10 @@ class UndertakingController @Inject() (
 
   private def createUndertakingAndSendEmail(
     undertaking: Undertaking,
-    eori: EORI,
     undertakingJourney: UndertakingJourney
-  )(implicit request: AuthenticatedEscRequest[_]): Future[Result] =
+  )(implicit request: AuthenticatedEscRequest[_], eori: EORI): Future[Result] =
     for {
-      ref <- escService.createUndertaking(undertaking, eori)
+      ref <- escService.createUndertaking(undertaking)
       _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
         eori,
         None,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -185,7 +185,7 @@ class UndertakingController @Inject() (
     undertakingJourney: UndertakingJourney
   )(implicit request: AuthenticatedEscRequest[_]): Future[Result] =
     for {
-      ref <- escService.createUndertaking(undertaking)
+      ref <- escService.createUndertaking(undertaking, eori)
       _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
         eori,
         None,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -65,6 +65,7 @@ class EscService @Inject() (
         .orElseF {
           retrieveUndertakingAndHandleErrors(eori).flatMap {
             case Right(Some(undertaking)) =>
+              // TODO - review this - why do we map over the reference?
               undertaking.reference.map(r => undertakingCache.put(eori, undertaking))
               undertaking.some.toFuture
             case Right(None) => Option.empty[Undertaking].toFuture
@@ -111,12 +112,14 @@ class EscService @Inject() (
         ref
       }
 
+  // TODO - check this - we shouldn't need to delete the undertaking here
   def createSubsidy(subsidyUpdate: SubsidyUpdate)(implicit hc: HeaderCarrier): Future[UndertakingRef] =
     escConnector
       .createSubsidy(subsidyUpdate)
       .map { response =>
+        // TODO - delete cached subsidy data for all users
         val ref = handleResponse[UndertakingRef](response, "add member")
-        undertakingCache.deleteUndertaking(ref)
+//        undertakingCache.deleteUndertaking(ref)
         ref
       }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -65,9 +65,7 @@ class EscService @Inject() (
         .orElseF {
           retrieveUndertakingAndHandleErrors(eori).flatMap {
             case Right(Some(undertaking)) =>
-              println(s"Caching undertaking: $undertaking")
               undertaking.reference.map(r => undertakingCache.put(eori, undertaking))
-              println(s"Cached undertaking")
               undertaking.some.toFuture
             case Right(None) => Option.empty[Undertaking].toFuture
             case Left(ex) => Future.failed[Option[Undertaking]](ex)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -50,14 +50,13 @@ class EscService @Inject() (
       }
 
 
-  def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier, eori: EORI): Future[UndertakingRef] =
+  def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[UndertakingRef] =
     escConnector
       .updateUndertaking(undertaking)
       .flatMap { response =>
         for {
           ref <- handleResponse[UndertakingRef](response, "update undertaking").toFuture
           _ <- undertakingCache.deleteUndertaking(ref)
-          _ <- undertakingCache.put[Undertaking](eori, undertaking)
         } yield ref
       }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyStore.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyStore.scala
@@ -60,10 +60,6 @@ class JourneyStore @Inject() (
     get[A].toContext
       .getOrElseF(put(default))
 
-  override def getOrCreate[A : ClassTag](f: () => Future[A])(implicit eori: EORI, format: Format[A]): Future[A] =
-    get[A].toContext
-      .getOrElseF(f().flatMap(put[A]))
-
   override def delete[A : ClassTag](implicit eori: EORI): Future[Unit] =
     delete[A](eori)(dataKeyForType[A])
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Store.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Store.scala
@@ -30,8 +30,6 @@ trait Store {
 
   def getOrCreate[A : ClassTag](default: A)(implicit eori: EORI, format: Format[A]): Future[A]
 
-  def getOrCreate[A : ClassTag](f: () => Future[A])(implicit eori: EORI, format: Format[A]): Future[A]
-
   def put[A](in: A)(implicit eori: EORI, writes: Writes[A]): Future[A]
 
   def update[A : ClassTag](f: A => A)(implicit eori: EORI, format: Format[A]): Future[A]

--- a/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCacheSpec.scala
+++ b/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCacheSpec.scala
@@ -101,6 +101,20 @@ class UndertakingCacheSpec
         repository.get[Undertaking](eori2).futureValue shouldBe None
       }
 
+      "leave undertaking subsidies but not undertakings present in the cache" in {
+        repository.put(eori1, undertaking).futureValue shouldBe undertaking
+        repository.put(eori2, undertaking).futureValue shouldBe undertaking
+        repository.put[UndertakingSubsidies](eori1, undertakingSubsidies).futureValue shouldBe undertakingSubsidies
+        repository.put[UndertakingSubsidies](eori2, undertakingSubsidies).futureValue shouldBe undertakingSubsidies
+
+        repository.deleteUndertaking(undertakingRef).futureValue shouldBe (())
+
+        repository.get[Undertaking](eori1).futureValue shouldBe None
+        repository.get[Undertaking](eori2).futureValue shouldBe None
+        repository.get[UndertakingSubsidies](eori1).futureValue should contain(undertakingSubsidies)
+        repository.get[UndertakingSubsidies](eori2).futureValue should contain(undertakingSubsidies)
+      }
+
     }
 
     "get UndertakingSubsidies is called" must {
@@ -129,10 +143,24 @@ class UndertakingCacheSpec
         repository.get[UndertakingSubsidies](eori1).futureValue should contain(undertakingSubsidies)
       }
 
-      "delete matching undertakings with the specified ref" in {
+      "delete matching undertaking subsidies with the specified ref" in {
         repository.put(eori1, undertakingSubsidies).futureValue shouldBe undertakingSubsidies
         repository.put(eori2, undertakingSubsidies).futureValue shouldBe undertakingSubsidies
         repository.deleteUndertakingSubsidies(undertakingRef).futureValue shouldBe (())
+        repository.get[UndertakingSubsidies](eori1).futureValue shouldBe None
+        repository.get[UndertakingSubsidies](eori2).futureValue shouldBe None
+      }
+
+      "leave undertakings but not undertaking subsidies present in the cache" in {
+        repository.put[Undertaking](eori1, undertaking).futureValue shouldBe undertaking
+        repository.put[Undertaking](eori2, undertaking).futureValue shouldBe undertaking
+        repository.put[UndertakingSubsidies](eori1, undertakingSubsidies).futureValue shouldBe undertakingSubsidies
+        repository.put[UndertakingSubsidies](eori2, undertakingSubsidies).futureValue shouldBe undertakingSubsidies
+
+        repository.deleteUndertakingSubsidies(undertakingRef).futureValue shouldBe (())
+
+        repository.get[Undertaking](eori1).futureValue should contain(undertaking)
+        repository.get[Undertaking](eori2).futureValue should contain(undertaking)
         repository.get[UndertakingSubsidies](eori1).futureValue shouldBe None
         repository.get[UndertakingSubsidies](eori2).futureValue shouldBe None
       }

--- a/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCacheSpec.scala
+++ b/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCacheSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.cache
+
+import cats.implicits.catsSyntaxOptionId
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.test.DefaultAwaitTimeout
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.transport
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, IndustrySectorLimit, UndertakingName, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, Undertaking}
+import uk.gov.hmrc.mongo.cache.CacheItem
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class UndertakingCacheSpec
+  extends AnyWordSpec
+    with DefaultPlayMongoRepositorySupport[CacheItem]
+    with ScalaFutures
+    with DefaultAwaitTimeout
+    with Matchers {
+
+  override protected def repository = new UndertakingCache(mongoComponent)
+
+  private val eori1 = EORI("GB123456789012")
+  private val eori2 = EORI("GB123456789013")
+
+  private val undertakingRef = UndertakingRef("UR123456")
+
+  private val businessEntity1 = BusinessEntity(EORI(eori1), leadEORI = true)
+  private val businessEntity2 = BusinessEntity(EORI(eori2), leadEORI = false)
+
+  private val undertaking1 = Undertaking(
+    undertakingRef.some,
+    UndertakingName("TestUndertaking"),
+    transport,
+    IndustrySectorLimit(12.34).some,
+    LocalDate.of(2021, 1, 18).some,
+    List(businessEntity1, businessEntity2)
+  )
+
+  "UndertakingCache" when {
+
+    "get is called" must {
+
+      "return None when the cache is empty" in {
+        repository.get[Undertaking](eori1).futureValue shouldBe None
+      }
+
+      "return None where there is no matching item in the cache" in {
+        repository.put(eori1, undertaking1).futureValue shouldBe undertaking1
+        repository.get[Undertaking](eori2).futureValue shouldBe None
+      }
+
+      "return the item where present in the cache" in {
+        repository.put(eori1, undertaking1).futureValue shouldBe undertaking1
+        repository.get[Undertaking](eori1).futureValue should contain(undertaking1)
+      }
+    }
+
+    "deleteUndertaking is called" must {
+
+      "do nothing if no matching undertaking references are found" in {
+        repository.put(eori1, undertaking1).futureValue shouldBe undertaking1
+        repository.deleteUndertaking(UndertakingRef("foo")).futureValue shouldBe (())
+        repository.get[Undertaking](eori1).futureValue should contain(undertaking1)
+      }
+
+      "delete matching undertakings with the specified ref" in {
+        repository.put(eori1, undertaking1).futureValue shouldBe undertaking1
+        repository.put(eori2, undertaking1).futureValue shouldBe undertaking1
+        repository.deleteUndertaking(undertakingRef).futureValue shouldBe (())
+        repository.get[Undertaking](eori1).futureValue shouldBe None
+        repository.get[Undertaking](eori2).futureValue shouldBe None
+      }
+
+    }
+
+  }
+
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -19,8 +19,8 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"         %% "bootstrap-test-play-28"  % bootStrapVersion % Test,
-    "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % hmrcMongoVersion % Test,
+    "uk.gov.hmrc"         %% "bootstrap-test-play-28"  % bootStrapVersion % "test, it",
+    "uk.gov.hmrc.mongo"   %% "hmrc-mongo-test-play-28" % hmrcMongoVersion % "test, it",
     "org.jsoup"            % "jsoup"                   % "1.14.3"         % Test,
     "com.vladsch.flexmark" % "flexmark-all"            % "0.36.8"         % "test, it",
     "org.scalatestplus"   %% "mockito-3-4"             % "3.2.10.0"       % "test, it",

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -83,7 +83,7 @@ class AccountControllerSpec
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
             mockTimeToday(fixedDate)
             mockGetOrCreate(eori1)(Right(nilJourneyCreate))
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies))
+            mockRetrieveSubsidy(subsidyRetrieveForFixedDate)(undertakingSubsidies.toFuture)
           }
           checkPageIsDisplayed(
             performAction(),
@@ -150,7 +150,7 @@ class AccountControllerSpec
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
             mockTimeToday(currentDate)
             mockGetOrCreate[NilReturnJourney](eori1)(Right(nilJourneyCreate))
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies))
+            mockRetrieveSubsidy(subsidyRetrieveForDate(currentDate))(undertakingSubsidies.toFuture)
           }
           checkPageIsDisplayed(
             performAction(),
@@ -186,10 +186,11 @@ class AccountControllerSpec
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
             mockTimeToday(currentDate)
             mockGetOrCreate[NilReturnJourney](eori1)(Right(nilReturnJourney))
+<<<<<<< HEAD
             if(hasFiledNilReturnRecently) {
               mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNJ))
             }
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies))
+            mockRetrieveSubsidy(subsidyRetrieveForDate(currentDate))(undertakingSubsidies.toFuture)
           }
           checkPageIsDisplayed(
             performAction(),
@@ -221,13 +222,11 @@ class AccountControllerSpec
             mockGetOrCreate(eori1)(Right(UndertakingJourney()))
             mockTimeToday(currentDate)
             mockGetOrCreate(eori1)(Right(nilJourneyCreate))
-            mockGetOrCreateF(eori1)(
-              Right(
-                undertakingSubsidies.copy(
-                  nonHMRCSubsidyUsage = List.empty,
-                  hmrcSubsidyUsage = List.empty
-                )
-              )
+            mockRetrieveSubsidy(subsidyRetrieveForDate(currentDate))(
+              undertakingSubsidies.copy(
+                nonHMRCSubsidyUsage = List.empty,
+                hmrcSubsidyUsage = List.empty
+              ).toFuture
             )
           }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -186,7 +186,6 @@ class AccountControllerSpec
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
             mockTimeToday(currentDate)
             mockGetOrCreate[NilReturnJourney](eori1)(Right(nilReturnJourney))
-<<<<<<< HEAD
             if(hasFiledNilReturnRecently) {
               mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNJ))
             }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -80,8 +80,8 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(result: Future[UndertakingSubsidies]) =
     (mockEscService
-      .retrieveSubsidy(_: SubsidyRetrieve)(_: HeaderCarrier))
-      .expects(subsidyRetrieve, *)
+      .retrieveSubsidy(_: SubsidyRetrieve)(_: HeaderCarrier, _: EORI))
+      .expects(subsidyRetrieve, *, *)
       .returning(result)
 
   def mockRemoveSubsidy(reference: UndertakingRef, nonHmrcSubsidy: NonHmrcSubsidy)(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -50,8 +50,8 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   def mockUpdateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
-      .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
-      .expects(undertaking, *)
+      .updateUndertaking(_: Undertaking)(_: HeaderCarrier, _: EORI))
+      .expects(undertaking, *, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 
   def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -30,8 +30,8 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   def mockCreateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
-      .createUndertaking(_: Undertaking)(_: HeaderCarrier))
-      .expects(undertaking, *)
+      .createUndertaking(_: Undertaking)(_: HeaderCarrier, _: EORI))
+      .expects(undertaking, *, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 
   def mockRetrieveUndertaking(eori: EORI)(result: Future[Option[Undertaking]]) =

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -50,8 +50,8 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   def mockUpdateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
-      .updateUndertaking(_: Undertaking)(_: HeaderCarrier, _: EORI))
-      .expects(undertaking, *, *)
+      .updateUndertaking(_: Undertaking)(_: HeaderCarrier))
+      .expects(undertaking, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 
   def mockAddMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{subsidyRetrieveForDate, subsidyRetrieveForFixedDate, undertaking, undertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{subsidyRetrieveForDate, undertaking, undertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.util.FakeTimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.FinancialDashboardPage

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService, Store}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{undertaking, undertakingSubsidies}
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{subsidyRetrieveForDate, subsidyRetrieveForFixedDate, undertaking, undertakingSubsidies}
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.util.FakeTimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.FinancialDashboardPage
@@ -69,7 +69,7 @@ class FinancialDashboardControllerSpec
       "return the dashboard page for a logged in user with a valid EORI" in {
         mockAuthWithNecessaryEnrolment()
         mockRetrieveUndertaking(eori)(undertaking.some.toFuture)
-        mockGetOrCreateF(eori)(Right(undertakingSubsidies))
+        mockRetrieveSubsidy(subsidyRetrieveForDate(fakeTimeProvider.today))(undertakingSubsidies.toFuture)
 
         running(fakeApplication) {
           val request = FakeRequest(GET, routes.FinancialDashboardController.getFinancialDashboard().url)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/JourneyStoreSupport.scala
@@ -42,12 +42,6 @@ trait JourneyStoreSupport { this: MockFactory =>
       .expects(*, *, eori, *)
       .returning(result.fold(Future.failed, _.toFuture))
 
-  def mockGetOrCreateF[A](eori: EORI)(result: Either[ConnectorError, A]) =
-    (mockJourneyStore
-      .getOrCreate(_: () => Future[A])(_: ClassTag[A], _: EORI, _: Format[A]))
-      .expects(*, *, eori, *)
-      .returning(result.fold(Future.failed, _.toFuture))
-
   def mockPut[A](input: A, eori: EORI)(result: Either[ConnectorError, A]) =
     (mockJourneyStore
       .put(_: A)(_: EORI, _: Writes[A]))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -63,6 +63,10 @@ class SubsidyControllerSpec
   private val exception = new Exception("oh no!")
   private val currentDate = LocalDate.of(2022, 10, 9)
 
+  private val subsidyRetrieveWithDates = subsidyRetrieve.copy(
+    inDateRange = Some((LocalDate.of(2020, 4, 6), LocalDate.of(2022, 10, 9)))
+  )
+
   "SubsidyControllerSpec" when {
 
     "handling request to get report payment page" must {
@@ -105,7 +109,7 @@ class SubsidyControllerSpec
             mockGetOrCreate[SubsidyJourney](eori1)(Right(subsidyJourney))
             mockTimeToday(currentDate)
             mockTimeToday(currentDate)
-            mockGetOrCreateF[UndertakingSubsidies](eori1)(Right(subsidies))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(subsidies.toFuture)
           }
         }
 
@@ -201,7 +205,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Left(ConnectorError(exception)))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies.toFuture)
             mockTimeToday(currentDate)
           }
           checkFormErrorIsDisplayed(
@@ -1049,7 +1053,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Left(ConnectorError(exception)))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction(transactionId)))
         }
@@ -1059,7 +1063,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies.toFuture)
           }
           assertThrows[Exception](await(performAction(transactionId)))
         }
@@ -1094,8 +1098,9 @@ class SubsidyControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockTimeToday(currentDate)
-          mockGetOrCreateF(eori1)(Right(undertakingSubsidies1))
+          mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
         }
+
         checkPageIsDisplayed(
           performAction(transactionId),
           messageFromMessageKey("subsidy.remove.title"),
@@ -1145,7 +1150,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Left(ConnectorError(exception)))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
         }
@@ -1155,7 +1160,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies1))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
             mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
@@ -1170,7 +1175,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies1))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
           }
           checkFormErrorIsDisplayed(
             performAction()("TID1234"),
@@ -1187,7 +1192,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies1))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
             mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Right(undertakingRef))
             mockDelete(eori1)(Right(()))
             mockSendAuditEvent[NonCustomsSubsidyRemoved](AuditEvent.NonCustomsSubsidyRemoved("1123", undertakingRef))
@@ -1444,7 +1449,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Left(ConnectorError(exception)))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -1454,7 +1459,7 @@ class SubsidyControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockTimeToday(currentDate)
-            mockGetOrCreateF(eori1)(Right(undertakingSubsidies1))
+            mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
             mockPut[SubsidyJourney](subsidyJourneyWithReportPaymentForm, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -1467,7 +1472,7 @@ class SubsidyControllerSpec
           mockAuthWithNecessaryEnrolment()
           mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
           mockTimeToday(currentDate)
-          mockGetOrCreateF(eori1)(Right(undertakingSubsidies1))
+          mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
           mockPut[SubsidyJourney](subsidyJourneyWithReportPaymentForm, eori1)(
             Right(subsidyJourneyWithReportPaymentForm)
           )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1194,7 +1194,6 @@ class SubsidyControllerSpec
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
             mockRemoveSubsidy(undertakingRef, nonHmrcSubsidyList1.head)(Right(undertakingRef))
-            mockDelete(eori1)(Right(()))
             mockSendAuditEvent[NonCustomsSubsidyRemoved](AuditEvent.NonCustomsSubsidyRemoved("1123", undertakingRef))
           }
           checkIsRedirect(
@@ -1334,7 +1333,6 @@ class SubsidyControllerSpec
               undertakingRef,
               SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, currentDate)
             )(Right(undertakingRef))
-            mockDelete(eori1)(Right(()))
             mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
@@ -1359,7 +1357,6 @@ class SubsidyControllerSpec
               undertakingRef,
               SubsidyController.toSubsidyUpdate(updatedSJ, undertakingRef, currentDate)
             )(Right(undertakingRef))
-            mockDelete(eori1)(Right(()))
             mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Right(SubsidyJourney()))
             mockSendAuditEvent[AuditEvent.NonCustomsSubsidyUpdated](
               AuditEvent.NonCustomsSubsidyUpdated(
@@ -1392,7 +1389,6 @@ class SubsidyControllerSpec
               undertakingRef,
               SubsidyController.toSubsidyUpdate(updatedSJ, undertakingRef, currentDate)
             )(Right(undertakingRef))
-            mockDelete(eori1)(Right(()))
             mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Right(SubsidyJourney()))
             mockSendAuditEvent[AuditEvent.NonCustomsSubsidyAdded](
               AuditEvent.NonCustomsSubsidyAdded(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -40,6 +40,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
+// TODO - review coverage of caching logic and ensure all cases are covered
 class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
   private val mockEscConnector: EscConnector = mock[EscConnector]
@@ -415,7 +416,9 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
       "return successfully" when {
 
         "the http call succeeds and the body of the response can be parsed" in {
+          mockCacheGet[UndertakingSubsidies](eori1)(Right(Option.empty))
           mockRetrieveSubsidy(subsidyRetrieve)(Right(HttpResponse(OK, undertakingSubsidiesJson, emptyHeaders)))
+          mockCachePut(eori1, undertakingSubsidies)(Right(undertakingSubsidies))
           val result = service.retrieveSubsidy(subsidyRetrieve)
           await(result) shouldBe undertakingSubsidies
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -40,7 +40,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-// TODO - review coverage of caching logic and ensure all cases are covered
 class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
   private val mockEscConnector: EscConnector = mock[EscConnector]
@@ -99,6 +98,10 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
   private def mockCacheDeleteUndertaking(ref: UndertakingRef)(result: Either[Exception, Unit]) =
     when(mockUndertakingCache.deleteUndertaking(argEq(ref)))
+      .thenReturn(result.fold(Future.failed, _.toFuture))
+
+  private def mockCacheDeleteUndertakingSubsidies(ref: UndertakingRef)(result: Either[Exception, Unit]) =
+    when(mockUndertakingCache.deleteUndertakingSubsidies(argEq(ref)))
       .thenReturn(result.fold(Future.failed, _.toFuture))
 
   private val undertakingRefJson = Json.toJson(undertakingRef)
@@ -374,7 +377,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
         "the http call succeeds and the body of the response can be parsed" in {
           mockCreateSubsidy(subsidyUpdate)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
-          mockCacheDeleteUndertaking(undertakingRef)(Right(()))
+          mockCacheDeleteUndertakingSubsidies(undertakingRef)(Right(()))
           val result = service.createSubsidy(subsidyUpdate)
           await(result) shouldBe undertakingRef
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -121,7 +121,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockFactory {
   private implicit val hc: HeaderCarrier = HeaderCarrier()
   private implicit val e: EORI = CommonTestData.eori1
 
-  "EscServiceSpec" when {
+  "EscService" when {
 
     "handling request to create an undertaking" must {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -146,15 +146,13 @@ object CommonTestData {
     None
   )
 
-  def subsidyRetrieveForDate(d: LocalDate) = {
-    println(s"Got date: $d")
+  def subsidyRetrieveForDate(d: LocalDate) =
     subsidyRetrieve.copy(
       inDateRange = Some((
         d.toEarliestTaxYearStart,
         d
       ))
     )
-  }
 
   val subsidyRetrieveForFixedDate = subsidyRetrieve.copy(
     inDateRange = Some((LocalDate.of(2018, 4, 6), LocalDate.of(2021, 1, 20)))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.NewLeadJourney.Forms.Sel
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.TaxYearSyntax.LocalDateTaxYearOps
 
 import java.time.{LocalDate, LocalDateTime}
 
@@ -143,6 +144,20 @@ object CommonTestData {
   val subsidyRetrieve = SubsidyRetrieve(
     undertakingRef,
     None
+  )
+
+  def subsidyRetrieveForDate(d: LocalDate) = {
+    println(s"Got date: $d")
+    subsidyRetrieve.copy(
+      inDateRange = Some((
+        d.toEarliestTaxYearStart,
+        d
+      ))
+    )
+  }
+
+  val subsidyRetrieveForFixedDate = subsidyRetrieve.copy(
+    inDateRange = Some((LocalDate.of(2018, 4, 6), LocalDate.of(2021, 1, 20)))
   )
 
   val undertakingSubsidies1 = undertakingSubsidies.copy(nonHMRCSubsidyUsage = nonHmrcSubsidyList1)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -73,7 +73,7 @@ object CommonTestData {
   )
 
   val nonHmrcSubsidy = NonHmrcSubsidy(
-    subsidyUsageTransactionId = None,
+    subsidyUsageTransactionId = Some(SubsidyRef("AB12345")),
     allocationDate = LocalDate.of(2022, 1, 1),
     submissionDate = fixedDate,
     publicAuthority = "Local Authority".some,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -120,6 +120,8 @@ object CommonTestData {
     List(businessEntity1, businessEntity2)
   )
 
+  val undertakingWithoutRef = undertaking.copy(reference = None)
+
   val undertaking1 = Undertaking(
     undertakingRef.some,
     UndertakingName("TestUndertaking"),


### PR DESCRIPTION
Summary of changes
* responsibility for Undertaking and UndertakingSubsidies caching delegated to the ESC Service removing caching logic from controllers
* introduced `UndertakingCache` which caches Undertaking and UndertakingSubsidies with `it` test
* cached data invalidated for all users on update
* revised tests and removed dead code
* other minor tidy ups