### PR TITLE
ESC-562 undertaking and subsidy caching with invalidation for all users

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -20,7 +20,7 @@ import cats.data.EitherT
 import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
 import com.google.inject.{Inject, Singleton}
 import play.api.http.Status.{NOT_FOUND, OK}
-import play.api.libs.json.{JsSuccess, JsValue, Reads}
+import play.api.libs.json.Reads
 import uk.gov.hmrc.eusubsidycompliancefrontend.cache.UndertakingCache
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
@@ -29,7 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.HttpResponseSyntax.HttpResponseOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax.FutureOptionToOptionTOps
 import uk.gov.hmrc.http.UpstreamErrorResponse.WithStatusCode
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -165,13 +165,4 @@ class EscService @Inject() (
             .parseJSON[A]
             .getOrElse(sys.error(s"Error parsing response for $action"))
     )
-}
-
-object EscService {
-  implicit val reads: Reads[UpstreamErrorResponse] = (json: JsValue) => JsSuccess(
-    UpstreamErrorResponse(
-      (json \ "message").as[String],
-      (json \ "statusCode").as[Int]
-    )
-  )
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -473,7 +473,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
         "the http call succeeds and the body of the response can be parsed" in {
           mockCacheGet[UndertakingSubsidies](eori1)(Right(Option.empty))
           mockRemoveSubsidy(undertakingRef, nonHmrcSubsidy)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
-          mockCacheDeleteUndertakingSubsidies(undertakingRef)(Right(undertakingSubsidies))
+          mockCacheDeleteUndertakingSubsidies(undertakingRef)(Right(()))
           val result = service.removeSubsidy(undertakingRef, nonHmrcSubsidy)
           await(result) shouldBe undertakingRef
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -226,6 +226,13 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
         "the http call succeeds the body of the response can be parsed" when {
 
+          "the undertaking is present in the cache" in {
+            mockCacheGet[Undertaking](eori1)(Right(undertaking.some))
+            mockCachePut(eori1, undertaking)(Right(undertaking))
+            val result = service.retrieveUndertaking(eori1)
+            await(result) shouldBe undertaking.some
+          }
+
           "http response status is 200 and response can be parsed" in {
             mockCacheGet[Undertaking](eori1)(Right(None))
             mockRetrieveUndertaking(eori1)(Right(HttpResponse(OK, undertakingJson, emptyHeaders)))
@@ -425,6 +432,13 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
       }
 
       "return successfully" when {
+
+        "the undertaking subsidies are present in the cache" in {
+          mockCacheGet[UndertakingSubsidies](eori1)(Right(undertakingSubsidies.some))
+          mockCachePut(eori1, undertakingSubsidies)(Right(undertakingSubsidies))
+          val result = service.retrieveSubsidy(subsidyRetrieve)
+          await(result) shouldBe undertakingSubsidies
+        }
 
         "the http call succeeds and the body of the response can be parsed" in {
           mockCacheGet[UndertakingSubsidies](eori1)(Right(Option.empty))


### PR DESCRIPTION
Summary of changes
* added missing test coverage for EscService cache handling and removeSubsidies call
* removed unused Reads instance for UpstreamErrorResponse