### PR TITLE
ESC-583 flush stale UndertakingJourney data when user promotes self to lead

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -150,6 +150,8 @@ class BecomeLeadController @Inject() (
             undertakingRef,
             None
           )
+          // Flush any stale undertaking journey data
+           _ <- store.delete[UndertakingJourney]
           _ = auditService.sendEvent[BusinessEntityPromotedSelf](
             AuditEvent.BusinessEntityPromotedSelf(
               undertakingRef,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -440,6 +440,7 @@ class BecomeLeadControllerSpec
             mockSendEmail(validEmailAddress, newLeadParams, templateIdNewLead)(Right(EmailSendResult.EmailSent))
             mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockSendEmail(validEmailAddress, oldLeadParams, templateIdOldLead)(Right(EmailSendResult.EmailSent))
+            mockDelete[UndertakingJourney](eori4)(Right(()))
             mockSendAuditEvent[BusinessEntityPromotedSelf](
               AuditEvent.BusinessEntityPromotedSelf(undertakingRef, "1123", eori1, eori4)
             )
@@ -491,6 +492,7 @@ class BecomeLeadControllerSpec
             mockSendEmail(validEmailAddress, oldLeadParams, "template_removed_as_lead_email_to_previous_lead_EN")(
               Right(EmailSendResult.EmailSent)
             )
+            mockDelete[UndertakingJourney](eori4)(Right(()))
             mockSendAuditEvent[BusinessEntityPromotedSelf](
               AuditEvent.BusinessEntityPromotedSelf(undertakingRef, "1123", eori1, eori4)
             )


### PR DESCRIPTION
Summary of changes
* when a user promotes themselves to lead flush any stale `UndertakingJourney` data from the store to fix a bug where old data could be shown on the edit undertaking screen