### PR TITLE
ESC-590 enforce earliest allowed claim date of 2021-01-01 to align with ETMP

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpers.scala
@@ -20,6 +20,8 @@ import java.time.{LocalDate, Month}
 
 object TaxYearHelpers {
 
+  private val EarliestSupportedDate = LocalDate.of(2021, 1, 1)
+
   def taxYearStartForDate(d: LocalDate): LocalDate = {
     val taxYearStartForDateYear = LocalDate.of(d.getYear, Month.APRIL, 6)
     if (d.isBefore(taxYearStartForDateYear)) taxYearStartForDateYear.minusYears(1)
@@ -33,7 +35,11 @@ object TaxYearHelpers {
 
   // Since the allowed date range is the current and previous 2 tax years the earliest allowed date is then the start
   // of the earliest tax year.
-  def earliestAllowedDate(d: LocalDate): LocalDate = taxYearStartForDate(d).minusYears(2)
+  def earliestAllowedDate(d: LocalDate): LocalDate = {
+    val startDate = taxYearStartForDate(d).minusYears(2)
+    if (startDate.isBefore(EarliestSupportedDate)) EarliestSupportedDate
+    else startDate
+  }
 
   // Returns the date range for the standard 3 tax year search range. That is, the current and previous 2 tax years.
   def searchRange(d: LocalDate): (LocalDate, LocalDate) = (earliestAllowedDate(d), d)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthAndSessionDataBehaviour.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthAndSessionDataBehaviour.scala
@@ -20,9 +20,9 @@ import com.typesafe.config.ConfigFactory
 import play.api.Configuration
 import play.api.mvc.Result
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
-import uk.gov.hmrc.auth.core.{BearerTokenExpired, Enrolment, EnrolmentIdentifier, Enrolments, InvalidBearerToken, MissingBearerToken, NoActiveSession, SessionRecordNotFound}
+import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{eori1, eori4}
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.eori1
 
 import java.net.URLEncoder
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
@@ -20,7 +20,7 @@ import cats.implicits.catsSyntaxOptionId
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
-import uk.gov.hmrc.auth.core.retrieve.{CompositeRetrieval, Credentials, EmptyRetrieval, OptionalRetrieval, Retrieval, ~}
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, EmptyRetrieval, Retrieval, ~}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -24,15 +24,12 @@ import play.api.mvc.Cookie
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessEntityPromotedSelf
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.SingleEORIEmailParameter
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult.EmailSent
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Language}
-
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormPages.{BecomeLeadEoriFormPage, TermsAndConditionsFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -93,7 +93,6 @@ class BusinessEntityControllerSpec
 
   private val invalidEOris = List("GA1234567890", "AB1234567890")
   private val invalidLengthEOris = List("1234567890", "12345678901234", "GB1234567890")
-  private val currentDate = LocalDate.of(2022, 10, 9)
 
   "BusinessEntityControllerSpec" when {
 
@@ -881,8 +880,6 @@ class BusinessEntityControllerSpec
         )
 
       "throw a technical error" when {
-        val exception = new Exception("oh no!")
-
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
             mockAuthWithEORIEnrolment(eori4)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
@@ -82,7 +82,7 @@ class FinancialDashboardControllerSpec
             .fromUndertakingSubsidies(
               undertaking = undertaking,
               subsidies = undertakingSubsidies,
-              startDate = LocalDate.parse("2019-04-06"),
+              startDate = LocalDate.parse("2021-01-01"),
               endDate = fakeTimeProvider.today
             )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, SingleEORIAndDateEmailParameter}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailSendResult, EmailType, RetrieveEmailResponse}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, AuditServiceSupport, EscService, RetrieveEmailService, SendEmailHelperService, SendEmailService, Store}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -64,7 +64,7 @@ class SubsidyControllerSpec
   private val currentDate = LocalDate.of(2022, 10, 9)
 
   private val subsidyRetrieveWithDates = subsidyRetrieve.copy(
-    inDateRange = Some((LocalDate.of(2020, 4, 6), LocalDate.of(2022, 10, 9)))
+    inDateRange = Some((LocalDate.of(2021, 1, 1), LocalDate.of(2022, 10, 9)))
   )
 
   "SubsidyControllerSpec" when {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
@@ -78,11 +78,11 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     }
 
     "return date in future error if date is in the future" in {
-      validateAndCheckError((day + 1).toString, "1", "9999")("date.in-future", "6 4 2019", "5 4 2021")
+      validateAndCheckError((day + 1).toString, "1", "9999")("date.in-future", "1 1 2021", "5 4 2021")
     }
 
     "return date outside of tax year range error for date before the start of the tax year range" in {
-      validateAndCheckError("1", "1", "1900")("date.outside-allowed-tax-year-range", "6 4 2019")
+      validateAndCheckError("1", "1", "1900")("date.outside-allowed-tax-year-range", "1 1 2021")
     }
 
     "return no errors for todays date" in {
@@ -94,11 +94,11 @@ class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
     }
 
     "return no errors for a date in the past that is equal to the start of the allowed tax year range" in {
-      validateAndCheckSuccess("6", "4", (year - 3).toString)
+      validateAndCheckSuccess("1", "1", "2021")
     }
 
     "return no errors for a date with 0 as prefix in month" in {
-      validateAndCheckSuccess("6", "04", (year - 3).toString)
+      validateAndCheckSuccess("6", "04", (year-1).toString)
     }
 
   }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -157,7 +157,7 @@ object CommonTestData {
     )
 
   val subsidyRetrieveForFixedDate = subsidyRetrieve.copy(
-    inDateRange = Some((LocalDate.of(2018, 4, 6), LocalDate.of(2021, 1, 20)))
+    inDateRange = Some((LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 20)))
   )
 
   val undertakingSubsidies1 = undertakingSubsidies.copy(nonHMRCSubsidyUsage = nonHmrcSubsidyList1)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpersSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/util/TaxYearHelpersSpec.scala
@@ -23,27 +23,27 @@ import java.time.LocalDate
 
 class TaxYearHelpersSpec extends AnyWordSpecLike with Matchers {
 
-  private val BeforeTaxYearEnd  = LocalDate.parse("2022-03-01")
-  private val LastDayOfTaxYear  = LocalDate.parse("2022-04-05")
-  private val FirstDayOfTaxYear = LocalDate.parse("2022-04-06")
-  private val AfterTaxYearEnd   = LocalDate.parse("2022-05-01")
+  private val BeforeTaxYearEnd  = LocalDate.parse("2024-03-01")
+  private val LastDayOfTaxYear  = LocalDate.parse("2024-04-05")
+  private val FirstDayOfTaxYear = LocalDate.parse("2024-04-06")
+  private val AfterTaxYearEnd   = LocalDate.parse("2024-05-01")
 
   "taxYearStartForDate" must {
 
     "return a tax year starting in the previous year if the date falls before the end of the tax year" in {
-      TaxYearHelpers.taxYearStartForDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2021-04-06")
+      TaxYearHelpers.taxYearStartForDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2023-04-06")
     }
 
     "return a tax year starting in the previous year if the date falls on last day of the old tax year" in {
-      TaxYearHelpers.taxYearStartForDate(LastDayOfTaxYear) mustBe LocalDate.parse("2021-04-06")
+      TaxYearHelpers.taxYearStartForDate(LastDayOfTaxYear) mustBe LocalDate.parse("2023-04-06")
     }
 
     "return a tax year starting in the same year if the date falls on first day of the new tax year" in {
-      TaxYearHelpers.taxYearStartForDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2022-04-06")
+      TaxYearHelpers.taxYearStartForDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2024-04-06")
     }
 
     "return a tax year starting in the same year if the date falls after the start of the new tax year" in {
-      TaxYearHelpers.taxYearStartForDate(AfterTaxYearEnd) mustBe LocalDate.parse("2022-04-06")
+      TaxYearHelpers.taxYearStartForDate(AfterTaxYearEnd) mustBe LocalDate.parse("2024-04-06")
     }
 
   }
@@ -51,19 +51,19 @@ class TaxYearHelpersSpec extends AnyWordSpecLike with Matchers {
   "taxYearEndForDate" must {
 
     "return a tax year ending in the current year if the date falls before the end of the old tax year" in {
-      TaxYearHelpers.taxYearEndForDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2022-04-05")
+      TaxYearHelpers.taxYearEndForDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2024-04-05")
     }
 
     "return a tax year ending in the current year if the date falls on the last day of the old tax year" in {
-      TaxYearHelpers.taxYearEndForDate(LastDayOfTaxYear) mustBe LocalDate.parse("2022-04-05")
+      TaxYearHelpers.taxYearEndForDate(LastDayOfTaxYear) mustBe LocalDate.parse("2024-04-05")
     }
 
     "return a tax year ending in the following year if the date falls on the first day of the new tax year" in {
-      TaxYearHelpers.taxYearEndForDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2023-04-05")
+      TaxYearHelpers.taxYearEndForDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2025-04-05")
     }
 
     "return a tax year ending in the following year if the date falls after the first day of the new tax year" in {
-      TaxYearHelpers.taxYearEndForDate(AfterTaxYearEnd) mustBe LocalDate.parse("2023-04-05")
+      TaxYearHelpers.taxYearEndForDate(AfterTaxYearEnd) mustBe LocalDate.parse("2025-04-05")
     }
 
   }
@@ -71,19 +71,23 @@ class TaxYearHelpersSpec extends AnyWordSpecLike with Matchers {
   "earliestAllowedDate" must {
 
     "return the start of the earliest allowed date if the date falls before the end of the old tax year" in {
-      TaxYearHelpers.earliestAllowedDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2019-04-06")
+      TaxYearHelpers.earliestAllowedDate(BeforeTaxYearEnd) mustBe LocalDate.parse("2021-04-06")
     }
 
     "return the start of the earliest allowed tax year if the date falls on the last day of the old tax year" in {
-      TaxYearHelpers.earliestAllowedDate(LastDayOfTaxYear) mustBe LocalDate.parse("2019-04-06")
+      TaxYearHelpers.earliestAllowedDate(LastDayOfTaxYear) mustBe LocalDate.parse("2021-04-06")
     }
 
     "return the start of the earliest allowed tax year if the date falls on the first day of the new tax year" in {
-      TaxYearHelpers.earliestAllowedDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2020-04-06")
+      TaxYearHelpers.earliestAllowedDate(FirstDayOfTaxYear) mustBe LocalDate.parse("2022-04-06")
     }
 
     "return the start of the earliest allowed tax year if the date falls after the first day of the new tax year" in {
-      TaxYearHelpers.earliestAllowedDate(AfterTaxYearEnd) mustBe LocalDate.parse("2020-04-06")
+      TaxYearHelpers.earliestAllowedDate(AfterTaxYearEnd) mustBe LocalDate.parse("2022-04-06")
+    }
+
+    "return the earliest supported date of 2021-01-01 if the tax year start falls before this" in {
+      TaxYearHelpers.earliestAllowedDate(LocalDate.parse("2021-01-01")) mustBe LocalDate.parse("2021-01-01")
     }
 
   }
@@ -91,7 +95,12 @@ class TaxYearHelpersSpec extends AnyWordSpecLike with Matchers {
   "searchRange" must {
 
     "return a valid 3 tax year search range for the specified date" in {
-      TaxYearHelpers.searchRange(BeforeTaxYearEnd) mustBe((LocalDate.parse("2019-04-06"), BeforeTaxYearEnd))
+      TaxYearHelpers.searchRange(BeforeTaxYearEnd) mustBe((LocalDate.parse("2021-04-06"), BeforeTaxYearEnd))
+    }
+
+    "respect the earliest allowed start date if the earliest tax year start falls before it" in {
+      val date = LocalDate.parse("2022-02-03")
+      TaxYearHelpers.searchRange(date) mustBe((LocalDate.parse("2021-01-01"), date))
     }
 
   }


### PR DESCRIPTION
Summary of changes
* earliest allowed date logic now updated to enforce the earliest allowed date of `2021-01-01` a constraint currently imposted by ETMP
* updated tests and added explicit tests to cover this logic
* fixed compiler warnings 