### PR TITLE
Esc 355 kickout page for no email

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import cats.data.OptionT
 import cats.implicits._
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.eusubsidycompliancefrontend.actions.{EscCDSActionBuilders, EscInitialActionBuilder}
+import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscInitialActionBuilder
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{SubsidyRetrieve, Undertaking, UndertakingSubsidies}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -17,21 +17,29 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
+import play.api.Configuration
 import play.api.data.Form
 import play.api.data.Forms.mapping
+import play.api.i18n.MessagesApi
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscCDSActionBuilders
+import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEscRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, Language, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessEntityPromoted
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, DoubleEORIEmailParameter, SingleEORIAndDateEmailParameter, SingleEORIEmailParameter}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult.{EmailNotSent, EmailSent}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendResult, EmailType}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 
+import java.util.Locale
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class SelectNewLeadController @Inject() (
   mcc: MessagesControllerComponents,
@@ -41,7 +49,8 @@ class SelectNewLeadController @Inject() (
   sendEmailHelperService: SendEmailHelperService,
   auditService: AuditService,
   selectNewLeadPage: SelectNewLeadPage,
-  leadEORIChangedPage: LeadEORIChangedPage
+  leadEORIChangedPage: LeadEORIChangedPage,
+  emailNotVerifiedForLeadPromotionPage: EmailNotVerifiedForLeadPromotionPage
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc)
     with LeadOnlyUndertakingSupport {
@@ -91,14 +100,7 @@ class SelectNewLeadController @Inject() (
             val updatedLead = newLeadJourney.selectNewLead.copy(value = eoriBE.some)
             newLeadJourney.copy(selectNewLead = updatedLead)
           }
-          _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-            eoriBE,
-            None,
-            promoteOtherAsLeadEmailToBusinessEntity,
-            undertaking,
-            undertakingRef,
-            None
-          )
+          _ = auditService.sendEvent(BusinessEntityPromoted(undertakingRef, request.authorityId, eori, eoriBE))
           _ <- sendEmailHelperService.retrieveEmailAddressAndSendEmail(
             eori,
             eoriBE.some,
@@ -107,9 +109,50 @@ class SelectNewLeadController @Inject() (
             undertakingRef,
             None
           )
-          _ = auditService.sendEvent(BusinessEntityPromoted(undertakingRef, request.authorityId, eori, eoriBE))
-        } yield Redirect(routes.SelectNewLeadController.getLeadEORIChanged())
+          result <- sendEmailHelperService
+            .retrieveEmailAddressAndSendEmail(
+              eoriBE,
+              None,
+              promoteOtherAsLeadEmailToBusinessEntity,
+              undertaking,
+              undertakingRef,
+              None
+            )
+            .map(redirectTo)
+        } yield result
       }
+
+//      def handleFormSubmission1(form: FormValues) = {
+//        val eoriBE = EORI(form.value)
+//        val undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("Undertaking Ref"))
+//        for {
+//          _ <- store.update[NewLeadJourney] { newLeadJourney =>
+//            val updatedLead = newLeadJourney.selectNewLead.copy(value = eoriBE.some)
+//            newLeadJourney.copy(selectNewLead = updatedLead)
+//          }
+//        } yield ()
+//        auditService.sendEvent(BusinessEntityPromoted(undertakingRef, request.authorityId, eori, eoriBE))
+//        sendEmailHelperService.retrieveEmailAddressAndSendEmail(
+//          eori,
+//          eoriBE.some,
+//          promoteOtherAsLeadEmailToLead,
+//          undertaking,
+//          undertakingRef,
+//          None
+//        )
+//
+//        sendEmailHelperService
+//          .retrieveEmailAddressAndSendEmail(
+//            eoriBE,
+//            None,
+//            promoteOtherAsLeadEmailToBusinessEntity,
+//            undertaking,
+//            undertakingRef,
+//            None
+//          )
+//          .map(redirectTo)
+//
+//      }
 
       selectNewLeadForm
         .bindFromRequest()
@@ -118,6 +161,13 @@ class SelectNewLeadController @Inject() (
           handleFormSubmission
         )
     }
+  }
+// TODO implement the same check while removing and adding BE member once the guidance pages for them are designed
+  /// may be combined them into one function
+  private def redirectTo(emailResult: EmailSendResult) = emailResult match {
+    case EmailNotSent => Redirect(routes.SelectNewLeadController.emailNotVerified)
+    case EmailSent => Redirect(routes.SelectNewLeadController.getLeadEORIChanged())
+    case _ => handleMissingSessionData("Email result Response")
   }
 
   def getLeadEORIChanged = withCDSAuthenticatedUser.async { implicit request =>
@@ -135,6 +185,17 @@ class SelectNewLeadController @Inject() (
           )
         case None => Redirect(routes.SelectNewLeadController.getSelectNewLead()).toFuture
       }
+    }
+  }
+
+  def emailNotVerified = withCDSAuthenticatedUser.async { implicit request =>
+    implicit val eori: EORI = request.eoriNumber
+    store.get[NewLeadJourney].flatMap {
+      case Some(newLeadJourney) =>
+        val beEori =
+          newLeadJourney.selectNewLead.value.getOrElse(handleMissingSessionData("Selected EORi for promotion"))
+        store.put[NewLeadJourney](NewLeadJourney()).map(_ => Ok(emailNotVerifiedForLeadPromotionPage(beEori)))
+      case None => Redirect(routes.SelectNewLeadController.getSelectNewLead()).toFuture
     }
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -17,29 +17,25 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
-import play.api.Configuration
 import play.api.data.Form
 import play.api.data.Forms.mapping
-import play.api.i18n.MessagesApi
+
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscCDSActionBuilders
-import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEscRequest
+
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, Language, Undertaking}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessEntityPromoted
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailParameters.{DoubleEORIAndDateEmailParameter, DoubleEORIEmailParameter, SingleEORIAndDateEmailParameter, SingleEORIEmailParameter}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult.{EmailNotSent, EmailSent}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailParameters, EmailSendResult, EmailType}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 
-import java.util.Locale
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class SelectNewLeadController @Inject() (
   mcc: MessagesControllerComponents,
@@ -121,38 +117,6 @@ class SelectNewLeadController @Inject() (
             .map(redirectTo)
         } yield result
       }
-
-//      def handleFormSubmission1(form: FormValues) = {
-//        val eoriBE = EORI(form.value)
-//        val undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("Undertaking Ref"))
-//        for {
-//          _ <- store.update[NewLeadJourney] { newLeadJourney =>
-//            val updatedLead = newLeadJourney.selectNewLead.copy(value = eoriBE.some)
-//            newLeadJourney.copy(selectNewLead = updatedLead)
-//          }
-//        } yield ()
-//        auditService.sendEvent(BusinessEntityPromoted(undertakingRef, request.authorityId, eori, eoriBE))
-//        sendEmailHelperService.retrieveEmailAddressAndSendEmail(
-//          eori,
-//          eoriBE.some,
-//          promoteOtherAsLeadEmailToLead,
-//          undertaking,
-//          undertakingRef,
-//          None
-//        )
-//
-//        sendEmailHelperService
-//          .retrieveEmailAddressAndSendEmail(
-//            eoriBE,
-//            None,
-//            promoteOtherAsLeadEmailToBusinessEntity,
-//            undertaking,
-//            undertakingRef,
-//            None
-//          )
-//          .map(redirectTo)
-//
-//      }
 
       selectNewLeadForm
         .bindFromRequest()

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailSendResult.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailSendResult.scala
@@ -27,6 +27,8 @@ object EmailSendResult {
 
   case object EmailSent extends EmailSendResult
   case object EmailSentFailure extends EmailSendResult
+  case object EmailNotSent extends EmailSendResult
 
   implicit val format: Format[EmailSendResult] = Jsonx.formatSealed[EmailSendResult]
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/RetrieveEmailService.scala
@@ -20,7 +20,7 @@ import cats.implicits.catsSyntaxOptionId
 import com.google.inject.{Inject, Singleton}
 import play.api.http.Status._
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.RetrieveEmailConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.EmailAddressResponse
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailAddress, EmailAddressResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailType, RetrieveEmailResponse}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.HttpResponseSyntax.HttpResponseOps

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/EmailNotVerifiedForLeadPromotionPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/EmailNotVerifiedForLeadPromotionPage.scala.html
@@ -1,0 +1,37 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+@import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.P
+@import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.H1
+@import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+@import uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+
+@this(layout: Layout)
+
+
+@(beEori: EORI)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@key = @{"emailUnverifiedForLeadPromotion"}
+@title = @{messages(s"$key.title", beEori.toString)}
+
+@layout(pageTitle = Some(title)) {
+    @H1(title)
+    @P(messages(s"$key.p1"))
+    @P(messages(s"$key.p2"))
+    @P(messages(s"$key.p3"))
+
+    <div><a href="@controllers.routes.AccountController.getAccountPage().url" class="govuk-link">@messages("common.go-account-home")</a></div>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -119,3 +119,4 @@ GET        /lead-undertaking-no-business-present                                
 POST       /lead-undertaking-no-business-present                                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoBusinessPresentController.postNoBusinessPresent
 
 GET        /financial-dashboard                                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.FinancialDashboardController.getFinancialDashboard
+GET        /lead-undertaking-promote-business-entity-email-unverified                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SelectNewLeadController.emailNotVerified

--- a/conf/messages
+++ b/conf/messages
@@ -411,3 +411,9 @@ become-admin-confirmation.p2=The current administrator (EORI number {0}) has bee
 cdsEnrolmentMissing.title = You must register for the Custom Declaration Service (CDS)
 cdsEnrolmentMissing.p1 = Find out how to <a href="https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service" class="govuk-link">register for the Custom Declaration Service</a>
 cdsEnrolmentMissing.p2 = You have been logged out.
+
+#emailUnverifiedForLeadPromotion
+emailUnverifiedForLeadPromotion.title = {0} does not have a verified e-mail address
+emailUnverifiedForLeadPromotion.p1 = The selected EORI number does not have a verified email address. This means they will not be notified that you have asked them to become undertaking administrator.
+emailUnverifiedForLeadPromotion.p2 = The business/EORI number you have added will need to <a href="https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service" class="govuk-link">register with CDS</a>.
+emailUnverifiedForLeadPromotion.p3 = They will then need to login to the service and accept the terms and conditions before they can become the undertaking administrator.

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -490,10 +490,6 @@ class SelectNewLeadControllerSpec
 
       "redirect to next page" when {
 
-        "user is not an undertaking lead" in {
-          testLeadOnlyRedirect(performAction)
-        }
-
         "call to fetch new lead journey came back with None" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -158,7 +158,8 @@ class SelectNewLeadControllerSpec
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
-        val emailParamsBE = SingleEORIEmailParameter(eori4, undertaking1.name, undertakingRef, "promoteAsLeadEmailToBE")
+        val emailParamsLead =
+          DoubleEORIEmailParameter(eori1, eori4, undertaking1.name, undertakingRef, "promoteAsLeadEmailToLead")
 
         def update(j: NewLeadJourney) = j.copy(selectNewLead = SelectNewLeadFormPage(eori4.some))
 
@@ -172,7 +173,7 @@ class SelectNewLeadControllerSpec
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
 
-        "call to fetch business entity email address fails" in {
+        "call to fetch Lead email address fails" in {
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -180,12 +181,13 @@ class SelectNewLeadControllerSpec
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
-            mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
+            mockSendAuditEvent(AuditEvent.BusinessEntityPromoted(undertakingRef, "1123", eori1, eori4))
+            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
 
-        "call to fetch lead email address fails" in {
+        "call to fetch Business entity email address fails" in {
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -193,9 +195,12 @@ class SelectNewLeadControllerSpec
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
-            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
-            mockSendEmail(validEmailAddress, emailParamsBE, "template_BE_as_lead_EN")(Right(EmailSendResult.EmailSent))
-            mockRetrieveEmail(eori1)(Left(ConnectorError(exception)))
+            mockSendAuditEvent(AuditEvent.BusinessEntityPromoted(undertakingRef, "1123", eori1, eori4))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockSendEmail(validEmailAddress, emailParamsLead, "template_BE_as_lead_mail_to_lead_EN")(
+              Right(EmailSendResult.EmailSent)
+            )
+            mockRetrieveEmail(eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)(English.code)))
         }
@@ -207,7 +212,8 @@ class SelectNewLeadControllerSpec
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
-            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockSendAuditEvent(AuditEvent.BusinessEntityPromoted(undertakingRef, "1123", eori1, eori4))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
           }
           assertThrows[Exception](await(performAction("selectNewLead" -> eori4)("fr")))
         }
@@ -233,7 +239,14 @@ class SelectNewLeadControllerSpec
 
         def update(j: NewLeadJourney) = j.copy(selectNewLead = SelectNewLeadFormPage(eori4.some))
 
-        def testRedirection(templateIdBE: String, templateIdLead: String, lang: String): Unit = {
+        def testRedirection(
+          templateIdBE: String,
+          templateIdLead: String,
+          lang: String,
+          emailType: EmailType,
+          emailSendResult: EmailSendResult,
+          nextCall: String
+        ): Unit = {
 
           val emailParamsBE =
             SingleEORIEmailParameter(eori4, undertaking1.name, undertakingRef, "promoteAsLeadEmailToBE")
@@ -245,24 +258,61 @@ class SelectNewLeadControllerSpec
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
             )
-            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
-            mockSendEmail(validEmailAddress, emailParamsBE, templateIdBE)(Right(EmailSendResult.EmailSent))
+            mockSendAuditEvent(AuditEvent.BusinessEntityPromoted(undertakingRef, "1123", eori1, eori4))
             mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
             mockSendEmail(validEmailAddress, emailParamLead, templateIdLead)(Right(EmailSendResult.EmailSent))
-            mockSendAuditEvent(AuditEvent.BusinessEntityPromoted(undertakingRef, "1123", eori1, eori4))
+            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(emailType, validEmailAddress.some)))
+            mockSendEmail(validEmailAddress, emailParamsBE, templateIdBE)(Right(emailSendResult))
           }
           checkIsRedirect(
             performAction("selectNewLead" -> eori4)(lang),
-            routes.SelectNewLeadController.getLeadEORIChanged()
+            nextCall
           )
         }
 
         "the language selected by user is  English" in {
-          testRedirection("template_BE_as_lead_EN", "template_BE_as_lead_mail_to_lead_EN", English.code)
+          testRedirection(
+            "template_BE_as_lead_EN",
+            "template_BE_as_lead_mail_to_lead_EN",
+            English.code,
+            EmailType.VerifiedEmail,
+            EmailSendResult.EmailSent,
+            routes.SelectNewLeadController.getLeadEORIChanged().url
+          )
         }
 
         "the language selected by user is  Welsh" in {
-          testRedirection("template_BE_as_lead_CY", "template_BE_as_lead_mail_to_lead_CY", Welsh.code)
+          testRedirection(
+            "template_BE_as_lead_CY",
+            "template_BE_as_lead_mail_to_lead_CY",
+            Welsh.code,
+            EmailType.VerifiedEmail,
+            EmailSendResult.EmailSent,
+            routes.SelectNewLeadController.getLeadEORIChanged().url
+          )
+        }
+
+        "email address of BE is unverified" in {
+          val emailParamLead =
+            DoubleEORIEmailParameter(eori1, eori4, undertaking.name, undertakingRef, "promoteAsLeadEmailToLead")
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
+            mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
+              Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
+            )
+            mockSendAuditEvent(AuditEvent.BusinessEntityPromoted(undertakingRef, "1123", eori1, eori4))
+            mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+            mockSendEmail(validEmailAddress, emailParamLead, "template_BE_as_lead_mail_to_lead_EN")(
+              Right(EmailSendResult.EmailSent)
+            )
+            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.UnVerifiedEmail, validEmailAddress.some)))
+          }
+          checkIsRedirect(
+            performAction("selectNewLead" -> eori4)(English.code),
+            routes.SelectNewLeadController.emailNotVerified().url
+          )
+
         }
       }
 
@@ -386,6 +436,67 @@ class SelectNewLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
+            mockGet[NewLeadJourney](eori1)(Right(None))
+          }
+          checkIsRedirect(performAction(), routes.SelectNewLeadController.getSelectNewLead().url)
+
+        }
+      }
+
+    }
+
+    "handling request to Email not verified" must {
+
+      def performAction() = controller.emailNotVerified(FakeRequest())
+      behave like authBehaviourWithPredicate(() => performAction())
+
+      def update(b: BusinessEntityJourney) = b.copy(isLeadSelectJourney = None)
+
+      "throw technical error" when {
+        val exception = new Exception("oh no!")
+        "call to get New lead journey  fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[NewLeadJourney](eori1)(Left(ConnectorError(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+        "call to reset New lead journey  fails" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
+            mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
+            mockPut[NewLeadJourney](NewLeadJourney(), eori1)(Left(ConnectorError(exception)))
+          }
+          assertThrows[Exception](await(performAction()))
+        }
+
+      }
+
+      "display the page" in {
+
+        inSequence {
+          mockAuthWithNecessaryEnrolment()
+          mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
+          mockPut[NewLeadJourney](NewLeadJourney(), eori1)(Right(NewLeadJourney()))
+        }
+        checkPageIsDisplayed(
+          performAction(),
+          messageFromMessageKey("emailUnverifiedForLeadPromotion.title", eori4.toString),
+          isLeadJourney = true
+        )
+
+      }
+
+      "redirect to next page" when {
+
+        "user is not an undertaking lead" in {
+          testLeadOnlyRedirect(performAction)
+        }
+
+        "call to fetch new lead journey came back with None" in {
+          inSequence {
+            mockAuthWithNecessaryEnrolment()
             mockGet[NewLeadJourney](eori1)(Right(None))
           }
           checkIsRedirect(performAction(), routes.SelectNewLeadController.getSelectNewLead().url)


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-355

ticket to create a new kickout page , if the business entity member to be promoted don't have a verified email address. 
A similar ticket is coming up for adding/removing BE member
- test cases
Raising PR to get the comments will not merge it till Carwyn's  changes are confirmed