### PR TITLE
ESC-598 Introduce separate undertaking model for create requests

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -42,8 +42,8 @@ class EscConnector @Inject() (
   private lazy val updateSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/update"
   private lazy val retrieveSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/retrieve"
 
-  def createUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): ConnectorResult =
-    makeRequest(_.POST[Undertaking, HttpResponse](createUndertakingUrl, undertaking))
+  def createUndertaking(undertaking: WriteableUndertaking)(implicit hc: HeaderCarrier): ConnectorResult =
+    makeRequest(_.POST[WriteableUndertaking, HttpResponse](createUndertakingUrl, undertaking))
 
   def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[Undertaking, HttpResponse](updateUndertakingUrl, undertaking))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -42,8 +42,8 @@ class EscConnector @Inject() (
   private lazy val updateSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/update"
   private lazy val retrieveSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/retrieve"
 
-  def createUndertaking(undertaking: WriteableUndertaking)(implicit hc: HeaderCarrier): ConnectorResult =
-    makeRequest(_.POST[WriteableUndertaking, HttpResponse](createUndertakingUrl, undertaking))
+  def createUndertaking(undertaking: UndertakingCreate)(implicit hc: HeaderCarrier): ConnectorResult =
+    makeRequest(_.POST[UndertakingCreate, HttpResponse](createUndertakingUrl, undertaking))
 
   def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[Undertaking, HttpResponse](updateUndertakingUrl, undertaking))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -152,7 +152,7 @@ class BecomeLeadController @Inject() (
           retrievedUndertaking <- escService
             .retrieveUndertaking(eori)
             .map(_.getOrElse(handleMissingSessionData("Undertaking")))
-          undertakingRef = retrievedUndertaking.reference.getOrElse(handleMissingSessionData("Undertaking ref"))
+          undertakingRef = retrievedUndertaking.reference
           newLead = retrievedUndertaking.undertakingBusinessEntity
             .find(_.businessEntityIdentifier == eori)
             .fold(handleMissingSessionData("lead Business Entity"))(_.copy(leadEORI = true))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -266,7 +266,7 @@ class BusinessEntityController @Inject() (
       withLeadUndertaking { _ =>
         escService.retrieveUndertaking(EORI(eoriEntered)).flatMap {
           case Some(undertaking) =>
-            val undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("undertaking reference"))
+            val undertakingRef = undertaking.reference
             val removeBE: BusinessEntity = undertaking.getBusinessEntityByEORI(EORI(eoriEntered))
 
             removeBusinessForm

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -90,7 +90,7 @@ class SelectNewLeadController @Inject() (
 
       def handleFormSubmission(form: FormValues) = {
         val eoriBE = EORI(form.value)
-        val undertakingRef = undertaking.reference.getOrElse(handleMissingSessionData("Undertaking Ref"))
+        val undertakingRef = undertaking.reference
         for {
           _ <- store.update[NewLeadJourney] { newLeadJourney =>
             val updatedLead = newLeadJourney.selectNewLead.copy(value = eoriBE.some)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailType
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.{AuditService, EmailService, EscService}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
-import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax.{FutureToOptionTOps, OptionToOptionTOps}
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters.DateFormatter
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -521,11 +521,8 @@ class SubsidyController @Inject() (
     previous: String,
     undertaking: Undertaking,
     formWithErrors: Form[FormValues]
-  )(implicit request: AuthenticatedEscRequest[AnyContent]): Future[Result] = {
-
-    val reference = undertaking.reference.getOrElse(handleMissingSessionData("Undertaking Reference"))
-
-    retrieveSubsidies(reference).map { subsidies =>
+  )(implicit request: AuthenticatedEscRequest[AnyContent]): Future[Result] =
+    retrieveSubsidies(undertaking.reference).map { subsidies =>
       val currentDate = timeProvider.today
       BadRequest(
         reportPaymentPage(
@@ -539,7 +536,6 @@ class SubsidyController @Inject() (
         )
       )
     }
-  }
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.{CreateUndertaking, UndertakingDisabled, UndertakingUpdated}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, Undertaking, WriteableUndertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, Undertaking, UndertakingCreate}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
@@ -169,7 +169,7 @@ class UndertakingController @Inject() (
             updatedJourney <- store.update[UndertakingJourney](_.setUndertakingCYA(form.value.toBoolean)).toContext
             undertakingName <- updatedJourney.name.value.toContext
             undertakingSector <- updatedJourney.sector.value.toContext
-            undertaking = WriteableUndertaking(
+            undertaking = UndertakingCreate(
               name = UndertakingName(undertakingName),
               industrySector = undertakingSector,
               List(BusinessEntity(eori, leadEORI = true))
@@ -182,7 +182,7 @@ class UndertakingController @Inject() (
   }
 
   private def createUndertakingAndSendEmail(
-    undertaking: WriteableUndertaking,
+    undertaking: UndertakingCreate,
     undertakingJourney: UndertakingJourney
   )(implicit request: AuthenticatedEscRequest[_], eori: EORI): Future[Result] =
     for {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.{CreateUndertaking, UndertakingDisabled, UndertakingUpdated}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingName, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, Undertaking}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{BusinessEntity, FormValues, Undertaking, WriteableUndertaking}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
@@ -169,12 +169,9 @@ class UndertakingController @Inject() (
             updatedJourney <- store.update[UndertakingJourney](_.setUndertakingCYA(form.value.toBoolean)).toContext
             undertakingName <- updatedJourney.name.value.toContext
             undertakingSector <- updatedJourney.sector.value.toContext
-            undertaking = Undertaking(
-              None,
+            undertaking = WriteableUndertaking(
               name = UndertakingName(undertakingName),
               industrySector = undertakingSector,
-              None,
-              None,
               List(BusinessEntity(eori, leadEORI = true))
             )
             undertakingCreated <- createUndertakingAndSendEmail(undertaking, updatedJourney).toContext
@@ -185,12 +182,12 @@ class UndertakingController @Inject() (
   }
 
   private def createUndertakingAndSendEmail(
-    undertaking: Undertaking,
+    undertaking: WriteableUndertaking,
     undertakingJourney: UndertakingJourney
   )(implicit request: AuthenticatedEscRequest[_], eori: EORI): Future[Result] =
     for {
       ref <- escService.createUndertaking(undertaking)
-      _ <- emailService.sendEmail(eori, CreateUndertaking, undertaking.copy(reference = ref.some))
+      _ <- emailService.sendEmail(eori, CreateUndertaking, undertaking.toUndertakingWithRef(ref))
       auditEventCreateUndertaking = AuditEvent.CreateUndertaking(
         request.authorityId,
         ref,
@@ -320,12 +317,11 @@ class UndertakingController @Inject() (
     request: AuthenticatedEscRequest[_]
   ): Future[Result] =
     if (form.value == "true") {
-      val ref = undertaking.reference.fold(handleMissingSessionData("Undertaking reference"))(identity)
       for {
-        _ <- escService.removeMember(ref, undertaking.getBusinessEntityByEORI(request.eoriNumber))
+        _ <- escService.removeMember(undertaking.reference, undertaking.getBusinessEntityByEORI(request.eoriNumber))
         _ <- undertaking.undertakingBusinessEntity.traverse(be => resetAllJourneys(be.businessEntityIdentifier))
         _ = auditService.sendEvent[UndertakingDisabled](
-          UndertakingDisabled(request.authorityId, ref, timeProvider.today)
+          UndertakingDisabled(request.authorityId, undertaking.reference, timeProvider.today)
         )
       } yield Redirect(routes.UndertakingController.getUndertakingDisabled())
     } else Redirect(routes.AccountController.getAccountPage()).toFuture

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -22,27 +22,6 @@ import java.time.LocalDate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types._
 
-// TODO - naming - UndertakingCreate better?
-case class WriteableUndertaking(
-  name: UndertakingName,
-  industrySector: Sector,
-  undertakingBusinessEntity: List[BusinessEntity]
-) {
-
-  def toUndertakingWithRef(ref: UndertakingRef): Undertaking = Undertaking(
-    reference = ref,
-    name = name,
-    industrySector = industrySector,
-    industrySectorLimit = None,
-    lastSubsidyUsageUpdt = None,
-    undertakingBusinessEntity = undertakingBusinessEntity
-  )
-}
-
-object WriteableUndertaking {
-  implicit val writeableUndertakingFormat: OFormat[WriteableUndertaking] = Json.format[WriteableUndertaking]
-}
-
 case class Undertaking(
   reference: UndertakingRef,
   name: UndertakingName,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -22,10 +22,32 @@ import java.time.LocalDate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types._
 
-case class Undertaking(
-  reference: Option[UndertakingRef],
+// TODO - naming - UndertakingCreate better?
+case class WriteableUndertaking(
   name: UndertakingName,
   industrySector: Sector,
+  undertakingBusinessEntity: List[BusinessEntity]
+) {
+
+  def toUndertakingWithRef(ref: UndertakingRef): Undertaking = Undertaking(
+    reference = ref,
+    name = name,
+    industrySector = industrySector,
+    industrySectorLimit = None,
+    lastSubsidyUsageUpdt = None,
+    undertakingBusinessEntity = undertakingBusinessEntity
+  )
+}
+
+object WriteableUndertaking {
+  implicit val writeableUndertakingFormat: OFormat[WriteableUndertaking] = Json.format[WriteableUndertaking]
+}
+
+case class Undertaking(
+  reference: UndertakingRef,
+  name: UndertakingName,
+  industrySector: Sector,
+  // TODO - should these be options? review API docs
   industrySectorLimit: Option[IndustrySectorLimit],
   lastSubsidyUsageUpdt: Option[LocalDate],
   undertakingBusinessEntity: List[BusinessEntity]

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -26,7 +26,6 @@ case class Undertaking(
   reference: UndertakingRef,
   name: UndertakingName,
   industrySector: Sector,
-  // TODO - should these be options? review API docs
   industrySectorLimit: Option[IndustrySectorLimit],
   lastSubsidyUsageUpdt: Option[LocalDate],
   undertakingBusinessEntity: List[BusinessEntity]

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingCreate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingCreate.scala
@@ -16,9 +16,12 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
+import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{UndertakingName, UndertakingRef}
+
+import java.time.LocalDate
 
 case class UndertakingCreate(
   name: UndertakingName,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingCreate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingCreate.scala
@@ -16,12 +16,9 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
-import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{UndertakingName, UndertakingRef}
-
-import java.time.LocalDate
 
 case class UndertakingCreate(
   name: UndertakingName,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingCreate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingCreate.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.models
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{UndertakingName, UndertakingRef}
+
+case class UndertakingCreate(
+  name: UndertakingName,
+  industrySector: Sector,
+  undertakingBusinessEntity: List[BusinessEntity]
+) {
+
+  def toUndertakingWithRef(ref: UndertakingRef): Undertaking = Undertaking(
+    reference = ref,
+    name = name,
+    industrySector = industrySector,
+    industrySectorLimit = None,
+    lastSubsidyUsageUpdt = None,
+    undertakingBusinessEntity = undertakingBusinessEntity
+  )
+}
+
+object UndertakingCreate {
+  implicit val writeableUndertakingFormat: OFormat[UndertakingCreate] = Json.format[UndertakingCreate]
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.audit
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.Undertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.WriteableUndertaking
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityAddeed.BusinessDetailsAdded
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoteItself.BusinessEntityPromoteItselfDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoted.LeadPromoteDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityUpdated.BusinessDetailsUpdated
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyAmount, SubsidyRef, TraderRef, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.Sector.Sector
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyAmount, SubsidyRef, TraderRef, UndertakingName, UndertakingRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney
 
 import java.time.{LocalDate, LocalDateTime}
@@ -52,7 +52,7 @@ object AuditEvent {
 
   final case class CreateUndertaking(
     ggDetails: String,
-    eisRequest: Undertaking,
+    eisRequest: WriteableUndertaking,
     eisResponse: EISResponse
   ) extends AuditEvent {
     override val auditType: String = "CreateUndertakingEIS"
@@ -64,7 +64,7 @@ object AuditEvent {
     def apply(
       ggCredId: String,
       ref: UndertakingRef,
-      undertaking: Undertaking,
+      undertaking: WriteableUndertaking,
       timeNow: LocalDateTime
     ): CreateUndertaking = {
       val eisResponse = EISResponse(
@@ -74,8 +74,7 @@ object AuditEvent {
         )
       )
       AuditEvent.CreateUndertaking(ggCredId, undertaking, eisResponse)
-    }
-    import uk.gov.hmrc.eusubsidycompliancefrontend.models.json.digital.undertakingFormat //Do not delete
+    } //Do not delete
     implicit val writes: Writes[CreateUndertaking] = Json.writes
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.audit
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.WriteableUndertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.UndertakingCreate
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityAddeed.BusinessDetailsAdded
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoteItself.BusinessEntityPromoteItselfDetails
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.businessEntityPromoted.LeadPromoteDetails
@@ -52,7 +52,7 @@ object AuditEvent {
 
   final case class CreateUndertaking(
     ggDetails: String,
-    eisRequest: WriteableUndertaking,
+    eisRequest: UndertakingCreate,
     eisResponse: EISResponse
   ) extends AuditEvent {
     override val auditType: String = "CreateUndertakingEIS"
@@ -64,7 +64,7 @@ object AuditEvent {
     def apply(
       ggCredId: String,
       ref: UndertakingRef,
-      undertaking: WriteableUndertaking,
+      undertaking: UndertakingCreate,
       timeNow: LocalDateTime
     ): CreateUndertaking = {
       val eisResponse = EISResponse(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/digital/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/digital/package.scala
@@ -77,7 +77,6 @@ package object digital {
         case "OK" =>
           val responseDetail: JsLookupResult =
             retrieveUndertakingResponse \ "retrieveUndertakingResponse" \ "responseDetail"
-          // TODO - ok to make this mandatory? Check API
           val undertakingRef: UndertakingRef = (responseDetail \ "undertakingReference").as[UndertakingRef]
           val undertakingName: UndertakingName = (responseDetail \ "undertakingName").as[UndertakingName]
           val industrySector: Sector = (responseDetail \ "industrySector").as[Sector]

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/digital/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/digital/package.scala
@@ -77,7 +77,8 @@ package object digital {
         case "OK" =>
           val responseDetail: JsLookupResult =
             retrieveUndertakingResponse \ "retrieveUndertakingResponse" \ "responseDetail"
-          val undertakingRef: Option[String] = (responseDetail \ "undertakingReference").asOpt[String]
+          // TODO - ok to make this mandatory? Check API
+          val undertakingRef: UndertakingRef = (responseDetail \ "undertakingReference").as[UndertakingRef]
           val undertakingName: UndertakingName = (responseDetail \ "undertakingName").as[UndertakingName]
           val industrySector: Sector = (responseDetail \ "industrySector").as[Sector]
           val industrySectorLimit: IndustrySectorLimit =
@@ -91,7 +92,7 @@ package object digital {
             (responseDetail \ "undertakingBusinessEntity").as[List[BusinessEntity]]
           JsSuccess(
             Undertaking(
-              undertakingRef.map(UndertakingRef(_)),
+              undertakingRef,
               undertakingName,
               industrySector,
               industrySectorLimit.some,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/package.scala
@@ -158,14 +158,14 @@ package object eis {
 
   // convenience reads so we can store a created undertaking
   // TODO - confirm that this change is ok
-  val undertakingRequestReads: Reads[WriteableUndertaking] = new Reads[WriteableUndertaking] {
-    override def reads(json: JsValue): JsResult[WriteableUndertaking] = {
+  val undertakingRequestReads: Reads[UndertakingCreate] = new Reads[UndertakingCreate] {
+    override def reads(json: JsValue): JsResult[UndertakingCreate] = {
       val businessEntity: BusinessEntity = BusinessEntity(
         (json \ "createUndertakingRequest" \ "requestDetail" \ "businessEntity" \ "idValue").as[EORI],
         leadEORI = true
       )
       JsSuccess(
-        WriteableUndertaking(
+        UndertakingCreate(
           (json \ "createUndertakingRequest" \ "requestDetail" \ "undertakingName").as[UndertakingName],
           (json \ "createUndertakingRequest" \ "requestDetail" \ "industrySector").as[Sector],
           List(businessEntity)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/package.scala
@@ -157,7 +157,6 @@ package object eis {
     }
 
   // convenience reads so we can store a created undertaking
-  // TODO - confirm that this change is ok
   val undertakingRequestReads: Reads[UndertakingCreate] = new Reads[UndertakingCreate] {
     override def reads(json: JsValue): JsResult[UndertakingCreate] = {
       val businessEntity: BusinessEntity = BusinessEntity(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/json/eis/package.scala
@@ -157,19 +157,17 @@ package object eis {
     }
 
   // convenience reads so we can store a created undertaking
-  val undertakingRequestReads: Reads[Undertaking] = new Reads[Undertaking] {
-    override def reads(json: JsValue): JsResult[Undertaking] = {
+  // TODO - confirm that this change is ok
+  val undertakingRequestReads: Reads[WriteableUndertaking] = new Reads[WriteableUndertaking] {
+    override def reads(json: JsValue): JsResult[WriteableUndertaking] = {
       val businessEntity: BusinessEntity = BusinessEntity(
         (json \ "createUndertakingRequest" \ "requestDetail" \ "businessEntity" \ "idValue").as[EORI],
-        true
+        leadEORI = true
       )
       JsSuccess(
-        Undertaking(
-          None,
+        WriteableUndertaking(
           (json \ "createUndertakingRequest" \ "requestDetail" \ "undertakingName").as[UndertakingName],
           (json \ "createUndertakingRequest" \ "requestDetail" \ "industrySector").as[Sector],
-          None,
-          None,
           List(businessEntity)
         )
       )

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/types/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/types/package.scala
@@ -135,7 +135,7 @@ package object types extends SimpleJson {
 
   type EisSubsidyAmendmentType = String @@ EisSubsidyAmendmentType.Tag
   object EisSubsidyAmendmentType
-      extends RegexValidatedString( // todo consider enum
+      extends RegexValidatedString( // TODO: consider enum
         regex = "1|2|3"
       )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailService.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.{RetrieveEmailConnecto
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email._
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.HttpResponseSyntax.HttpResponseOps
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -87,12 +87,11 @@ class EmailService @Inject() (
     request: AuthenticatedEscRequest[_],
     messagesApi: MessagesApi
   ): Future[EmailSendResult] = {
-    val undertakingRef: UndertakingRef = undertaking.reference.getOrElse(sys.error("No reference found on undertaking"))
     retrieveEmailByEORI(eori1).flatMap { retrieveEmailResponse =>
       retrieveEmailResponse.emailType match {
         case EmailType.VerifiedEmail =>
           val templateId = getEmailTemplateId(templateKey)
-          val parameters = EmailParameters(eori1, eori2, undertaking.name, undertakingRef, removeEffectiveDate)
+          val parameters = EmailParameters(eori1, eori2, undertaking.name, undertaking.reference, removeEffectiveDate)
           retrieveEmailResponse.emailAddress.map { emailAddress =>
             sendEmail(emailAddress, parameters, templateId)
           } getOrElse sys.error("Email address not found")

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -45,7 +45,6 @@ class EscService @Inject() (
       .flatMap { response =>
         for {
           ref <- handleResponse[UndertakingRef](response, "create undertaking").toFuture
-          // TODO - should we actually fetch the undertaking here since we don't have all the data?
           _ <- undertakingCache.put[Undertaking](eori, undertaking.toUndertakingWithRef(ref))
         } yield ref
       }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -39,13 +39,14 @@ class EscService @Inject() (
   undertakingCache: UndertakingCache
 )(implicit ec: ExecutionContext) {
 
-  def createUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier, eori: EORI): Future[UndertakingRef] =
+  def createUndertaking(undertaking: WriteableUndertaking)(implicit hc: HeaderCarrier, eori: EORI): Future[UndertakingRef] =
     escConnector
       .createUndertaking(undertaking)
       .flatMap { response =>
         for {
           ref <- handleResponse[UndertakingRef](response, "create undertaking").toFuture
-          _ <- undertakingCache.put[Undertaking](eori, undertaking.copy(reference = ref.some))
+          // TODO - should we actually fetch the undertaking here since we don't have all the data?
+          _ <- undertakingCache.put[Undertaking](eori, undertaking.toUndertakingWithRef(ref))
         } yield ref
       }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -39,7 +39,7 @@ class EscService @Inject() (
   undertakingCache: UndertakingCache
 )(implicit ec: ExecutionContext) {
 
-  def createUndertaking(undertaking: WriteableUndertaking)(implicit hc: HeaderCarrier, eori: EORI): Future[UndertakingRef] =
+  def createUndertaking(undertaking: UndertakingCreate)(implicit hc: HeaderCarrier, eori: EORI): Future[UndertakingRef] =
     escConnector
       .createUndertaking(undertaking)
       .flatMap { response =>

--- a/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCacheSpec.scala
+++ b/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCacheSpec.scala
@@ -48,7 +48,7 @@ class UndertakingCacheSpec
   private val businessEntity2 = BusinessEntity(EORI(eori2), leadEORI = false)
 
   private val undertaking = Undertaking(
-    undertakingRef.some,
+    undertakingRef,
     UndertakingName("TestUndertaking"),
     transport,
     IndustrySectorLimit(12.34).some,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -61,7 +61,7 @@ class EscConnectorSpec
     "handling request to create Undertaking" must {
       behave like connectorBehaviour(
         mockPost(s"$baseUrl/undertaking", Seq.empty, undertaking)(_),
-        () => connector.createUndertaking(undertaking)
+        () => connector.createUndertaking(writeableUndertaking)
       )
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -60,7 +60,7 @@ class EscConnectorSpec
 
     "handling request to create Undertaking" must {
       behave like connectorBehaviour(
-        mockPost(s"$baseUrl/undertaking", Seq.empty, undertaking)(_),
+        mockPost(s"$baseUrl/undertaking", Seq.empty, writeableUndertaking)(_),
         () => connector.createUndertaking(writeableUndertaking)
       )
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -378,14 +378,15 @@ class BecomeLeadControllerSpec
           assertThrows[Exception](await(performAction()(English.code)))
         }
 
-        "call to fetch undertaking passes but come back wth undertaking with no undertaking ref" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment(eori4)
-            mockGet[BecomeLeadJourney](eori4)(Right(newBecomeLeadJourney.some))
-            mockRetrieveUndertaking(eori4)(undertaking1.copy(reference = None).some.toFuture)
-          }
-          assertThrows[Exception](await(performAction()(English.code)))
-        }
+        // TODO - can this happen?
+//        "call to fetch undertaking passes but come back wth undertaking with no undertaking ref" in {
+//          inSequence {
+//            mockAuthWithNecessaryEnrolment(eori4)
+//            mockGet[BecomeLeadJourney](eori4)(Right(newBecomeLeadJourney.some))
+//            mockRetrieveUndertaking(eori4)(undertaking1.copy(reference = None).some.toFuture)
+//          }
+//          assertThrows[Exception](await(performAction()(English.code)))
+//        }
 
         "call to fetch undertaking come back with undertaking with logged In EORI absent" in {
           inSequence {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -378,16 +378,6 @@ class BecomeLeadControllerSpec
           assertThrows[Exception](await(performAction()(English.code)))
         }
 
-        // TODO - can this happen?
-//        "call to fetch undertaking passes but come back wth undertaking with no undertaking ref" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment(eori4)
-//            mockGet[BecomeLeadJourney](eori4)(Right(newBecomeLeadJourney.some))
-//            mockRetrieveUndertaking(eori4)(undertaking1.copy(reference = None).some.toFuture)
-//          }
-//          assertThrows[Exception](await(performAction()(English.code)))
-//        }
-
         "call to fetch undertaking come back with undertaking with logged In EORI absent" in {
           inSequence {
             mockAuthWithNecessaryEnrolment(eori4)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -574,15 +574,6 @@ class BusinessEntityControllerSpec
       "throw technical error" when {
         val exception = new Exception("oh no")
 
-        // TODO - check this, can this actually happen?
-//        "call to get undertaking return undertaking without undertaking ref" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment()
-//            mockRetrieveUndertaking(eori1)(undertaking.copy(reference = None).some.toFuture)
-//          }
-//          assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
-//        }
-
         "call to get business entity fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -574,13 +574,14 @@ class BusinessEntityControllerSpec
       "throw technical error" when {
         val exception = new Exception("oh no")
 
-        "call to get undertaking return undertaking without undertaking ref" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking.copy(reference = None).some.toFuture)
-          }
-          assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
-        }
+        // TODO - check this, can this actually happen?
+//        "call to get undertaking return undertaking without undertaking ref" in {
+//          inSequence {
+//            mockAuthWithNecessaryEnrolment()
+//            mockRetrieveUndertaking(eori1)(undertaking.copy(reference = None).some.toFuture)
+//          }
+//          assertThrows[Exception](await(performAction("cya" -> "true")(English.code)))
+//        }
 
         "call to get business entity fails" in {
           inSequence {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -28,9 +28,9 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   val mockEscService = mock[EscService]
 
-  def mockCreateUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
+  def mockCreateUndertaking(undertaking: WriteableUndertaking)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
-      .createUndertaking(_: Undertaking)(_: HeaderCarrier, _: EORI))
+      .createUndertaking(_: WriteableUndertaking)(_: HeaderCarrier, _: EORI))
       .expects(undertaking, *, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -28,9 +28,9 @@ trait EscServiceSupport { this: ControllerSpec =>
 
   val mockEscService = mock[EscService]
 
-  def mockCreateUndertaking(undertaking: WriteableUndertaking)(result: Either[ConnectorError, UndertakingRef]) =
+  def mockCreateUndertaking(undertaking: UndertakingCreate)(result: Either[ConnectorError, UndertakingRef]) =
     (mockEscService
-      .createUndertaking(_: WriteableUndertaking)(_: HeaderCarrier, _: EORI))
+      .createUndertaking(_: UndertakingCreate)(_: HeaderCarrier, _: EORI))
       .expects(undertaking, *, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
@@ -126,16 +126,6 @@ class SignOutControllerSpec
           assertThrows[Exception](await(performAction()))
         }
 
-        // TODO - is this a sensible test case?
-//        "call to retrieve Undertaking fetches Undertaking without UndertakingRef" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment(eori4)
-//            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
-//            mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.copy(reference = None).some))
-//          }
-//          assertThrows[Exception](await(performAction()))
-//        }
-
         "call to remove member fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment(eori4)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
@@ -126,14 +126,15 @@ class SignOutControllerSpec
           assertThrows[Exception](await(performAction()))
         }
 
-        "call to retrieve Undertaking fetches Undertaking without UndertakingRef" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment(eori4)
-            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
-            mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.copy(reference = None).some))
-          }
-          assertThrows[Exception](await(performAction()))
-        }
+        // TODO - is this a sensible test case?
+//        "call to retrieve Undertaking fetches Undertaking without UndertakingRef" in {
+//          inSequence {
+//            mockAuthWithNecessaryEnrolment(eori4)
+//            mockRetrieveEmail(eori4)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, validEmailAddress.some)))
+//            mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.copy(reference = None).some))
+//          }
+//          assertThrows[Exception](await(performAction()))
+//        }
 
         "call to remove member fails" in {
           inSequence {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1137,13 +1137,14 @@ class SubsidyControllerSpec
 
       "throw technical error" when {
 
-        "call to get undertaking passes but comes back with No reference" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking.copy(reference = None).some.toFuture)
-          }
-          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
-        }
+        // TODO - can this actually happen?
+//        "call to get undertaking passes but comes back with No reference" in {
+//          inSequence {
+//            mockAuthWithNecessaryEnrolment()
+//            mockRetrieveUndertaking(eori1)(undertaking.copy(reference = None).some.toFuture)
+//          }
+//          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
+//        }
 
         "call to retrieve subsidy fails" in {
           inSequence {
@@ -1300,14 +1301,14 @@ class SubsidyControllerSpec
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
 
-        "call to fetch undertaking come back with No reference" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
-            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
-          }
-          assertThrows[Exception](await(performAction("cya" -> "true")))
-        }
+//        "call to fetch undertaking come back with No reference" in {
+//          inSequence {
+//            mockAuthWithNecessaryEnrolment()
+//            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
+//            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
+//          }
+//          assertThrows[Exception](await(performAction("cya" -> "true")))
+//        }
 
         "call to create subsidy fails" in {
           inSequence {
@@ -1432,13 +1433,13 @@ class SubsidyControllerSpec
 
       "throw technical error" when {
 
-        "undertaking has no reference" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
-          }
-          assertThrows[Exception](await(performAction()))
-        }
+//        "undertaking has no reference" in {
+//          inSequence {
+//            mockAuthWithNecessaryEnrolment()
+//            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
+//          }
+//          assertThrows[Exception](await(performAction()))
+//        }
 
         "esc service returns an error retrieving subsidies" in {
           inSequence {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1137,15 +1137,6 @@ class SubsidyControllerSpec
 
       "throw technical error" when {
 
-        // TODO - can this actually happen?
-//        "call to get undertaking passes but comes back with No reference" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment()
-//            mockRetrieveUndertaking(eori1)(undertaking.copy(reference = None).some.toFuture)
-//          }
-//          assertThrows[Exception](await(performAction("removeSubsidyClaim" -> "true")("TID1234")))
-//        }
-
         "call to retrieve subsidy fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -1301,14 +1292,6 @@ class SubsidyControllerSpec
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
 
-//        "call to fetch undertaking come back with No reference" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment()
-//            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
-//            mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
-//          }
-//          assertThrows[Exception](await(performAction("cya" -> "true")))
-//        }
 
         "call to create subsidy fails" in {
           inSequence {
@@ -1432,14 +1415,6 @@ class SubsidyControllerSpec
         )
 
       "throw technical error" when {
-
-//        "undertaking has no reference" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment()
-//            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
-//          }
-//          assertThrows[Exception](await(performAction()))
-//        }
 
         "esc service returns an error retrieving subsidies" in {
           inSequence {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingControllerSpec.ModifyUndertakingRow
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.Language.{English, Welsh}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.{UndertakingDisabled, UndertakingUpdated}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult.EmailSent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{Sector, UndertakingName}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, Language}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
@@ -708,7 +709,7 @@ class UndertakingControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
-            mockSendEmail(eori1, "createUndertaking", undertakingCreated.toUndertakingWithRef(undertakingRef))(Left(ConnectorError(exception)))
+            mockSendEmail(eori1, "createUndertaking", undertakingCreated.toUndertakingWithRef(undertakingRef))(Right(EmailSent))
             mockTimeProviderNow(timeNow)
             mockSendAuditEvent(createUndertakingAuditEvent)
           }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -984,19 +984,6 @@ class UndertakingControllerSpec
           assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
         }
 
-        // TODO - is this scenario valid?
-//        "call to retrieve undertaking passes but  undertaking was fetched with no undertaking ref" in {
-//          inSequence {
-//            mockAuthWithNecessaryEnrolment()
-//            mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
-//            mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
-//              Right(undertakingJourneyComplete.copy(name = UndertakingNameFormPage("true".some)))
-//            )
-//            mockRetrieveUndertaking(eori1)(undertaking1.copy(reference = None).some.toFuture)
-//          }
-//          assertThrows[Exception](await(performAction("amendUndertaking" -> "true")))
-//        }
-
         "call to update undertaking fails" in {
           val updatedUndertaking =
             undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailServiceSpec.scala
@@ -117,12 +117,6 @@ class EmailServiceSpec extends AnyWordSpec with Matchers with MockFactory with S
 
       "return an error" when {
 
-        // TODO - is this test case valid?
-//        "there is no reference on the undertaking" in {
-//          a[RuntimeException] shouldBe
-//            thrownBy(service.sendEmail(eori1, "createUndertaking", undertaking.copy(reference = None)))
-//        }
-
         "the email retrieval fails" in {
           mockRetrieveEmail(eori1)(Left(ConnectorError(new RuntimeException())))
           val result = service.sendEmail(eori1, "createUndertaking", undertaking)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailServiceSpec.scala
@@ -117,10 +117,11 @@ class EmailServiceSpec extends AnyWordSpec with Matchers with MockFactory with S
 
       "return an error" when {
 
-        "there is no reference on the undertaking" in {
-          a[RuntimeException] shouldBe
-            thrownBy(service.sendEmail(eori1, "createUndertaking", undertaking.copy(reference = None)))
-        }
+        // TODO - is this test case valid?
+//        "there is no reference on the undertaking" in {
+//          a[RuntimeException] shouldBe
+//            thrownBy(service.sendEmail(eori1, "createUndertaking", undertaking.copy(reference = None)))
+//        }
 
         "the email retrieval fails" in {
           mockRetrieveEmail(eori1)(Left(ConnectorError(new RuntimeException())))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -48,7 +48,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
   private val service: EscService = new EscService(mockEscConnector, mockUndertakingCache)
 
-  private def mockCreateUndertaking(undertaking: Undertaking)(
+  private def mockCreateUndertaking(undertaking: WriteableUndertaking)(
     result: Either[ConnectorError, HttpResponse]
   ) =
     when(mockEscConnector.createUndertaking(argEq(undertaking))(any()))
@@ -127,28 +127,28 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
       "return an error" when {
 
         "the http call fails" in {
-          mockCreateUndertaking(undertaking)(Left(ConnectorError("")))
-          val result = service.createUndertaking(undertaking)
+          mockCreateUndertaking(writeableUndertaking)(Left(ConnectorError("")))
+          val result = service.createUndertaking(writeableUndertaking)
           assertThrows[RuntimeException](await(result))
         }
 
         "the http response doesn't come back with status 201(created)" in {
-          mockCreateUndertaking(undertaking)(Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders)))
-          val result = service.createUndertaking(undertaking)
+          mockCreateUndertaking(writeableUndertaking)(Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders)))
+          val result = service.createUndertaking(writeableUndertaking)
           assertThrows[RuntimeException](await(result))
         }
 
         "there is no json in the response" in {
-          mockCreateUndertaking(undertaking)(Right(HttpResponse(OK, "hi")))
-          val result = service.createUndertaking(undertaking)
+          mockCreateUndertaking(writeableUndertaking)(Right(HttpResponse(OK, "hi")))
+          val result = service.createUndertaking(writeableUndertaking)
           assertThrows[RuntimeException](await(result))
         }
 
         "the json in the response can't be parsed" in {
           val json = Json.parse("""{ "a" : 1 }""")
 
-          mockCreateUndertaking(undertaking)(Right(HttpResponse(OK, json, emptyHeaders)))
-          val result = service.createUndertaking(undertaking)
+          mockCreateUndertaking(writeableUndertaking)(Right(HttpResponse(OK, json, emptyHeaders)))
+          val result = service.createUndertaking(writeableUndertaking)
           assertThrows[RuntimeException](await(result))
         }
 
@@ -157,9 +157,9 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
       "return successfully" when {
 
         "the http call succeeds and the body of the response can be parsed" in {
-          mockCreateUndertaking(undertakingWithoutRef)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
+          mockCreateUndertaking(writeableUndertaking)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
           mockCachePut(eori1, undertaking)(Right(undertaking))
-          val result = service.createUndertaking(undertakingWithoutRef)
+          val result = service.createUndertaking(writeableUndertaking)
           await(result) shouldBe undertakingRef
         }
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -158,7 +158,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
         "the http call succeeds and the body of the response can be parsed" in {
           mockCreateUndertaking(writeableUndertaking)(Right(HttpResponse(OK, undertakingRefJson, emptyHeaders)))
-          mockCachePut(eori1, undertaking)(Right(undertaking))
+          mockCachePut(eori1, writeableUndertaking.toUndertakingWithRef(undertakingRef))(Right(undertaking))
           val result = service.createUndertaking(writeableUndertaking)
           await(result) shouldBe undertakingRef
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -48,7 +48,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
   private val service: EscService = new EscService(mockEscConnector, mockUndertakingCache)
 
-  private def mockCreateUndertaking(undertaking: WriteableUndertaking)(
+  private def mockCreateUndertaking(undertaking: UndertakingCreate)(
     result: Either[ConnectorError, HttpResponse]
   ) =
     when(mockEscConnector.createUndertaking(argEq(undertaking))(any()))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -112,7 +112,7 @@ object CommonTestData {
   )
 
   val undertaking = Undertaking(
-    undertakingRef.some,
+    undertakingRef,
     UndertakingName("TestUndertaking"),
     transport,
     IndustrySectorLimit(12.34).some,
@@ -120,10 +120,14 @@ object CommonTestData {
     List(businessEntity1, businessEntity2)
   )
 
-  val undertakingWithoutRef = undertaking.copy(reference = None)
+  val writeableUndertaking = WriteableUndertaking(
+    UndertakingName("TestUndertaking"),
+    transport,
+    List(businessEntity1)
+  )
 
   val undertaking1 = Undertaking(
-    undertakingRef.some,
+    undertakingRef,
     UndertakingName("TestUndertaking"),
     transport,
     IndustrySectorLimit(12.34).some,
@@ -132,7 +136,7 @@ object CommonTestData {
   )
 
   val undertaking2 = Undertaking(
-    undertakingRef.some,
+    undertakingRef,
     UndertakingName("TestUndertaking"),
     transport,
     IndustrySectorLimit(12.34).some,
@@ -227,7 +231,7 @@ object CommonTestData {
   val inValidEmailResponse = EmailAddressResponse(inValidEmailAddress, None, Some(Undeliverable("foo")))
 
   val undertakingCreated =
-    Undertaking(None, UndertakingName("TestUndertaking"), transport, None, None, List(businessEntity5))
+    WriteableUndertaking(UndertakingName("TestUndertaking"), transport, List(businessEntity5))
 
   val singleEoriEmailParameters = EmailParameters(eori1, None, undertaking.name, undertakingRef, None)
   val singleEoriWithDateEmailParameters = EmailParameters(eori1, None, undertaking.name, undertakingRef, dateTime.toString.some)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -120,7 +120,7 @@ object CommonTestData {
     List(businessEntity1, businessEntity2)
   )
 
-  val writeableUndertaking = WriteableUndertaking(
+  val writeableUndertaking = UndertakingCreate(
     UndertakingName("TestUndertaking"),
     transport,
     List(businessEntity1)
@@ -231,7 +231,7 @@ object CommonTestData {
   val inValidEmailResponse = EmailAddressResponse(inValidEmailAddress, None, Some(Undeliverable("foo")))
 
   val undertakingCreated =
-    WriteableUndertaking(UndertakingName("TestUndertaking"), transport, List(businessEntity5))
+    UndertakingCreate(UndertakingName("TestUndertaking"), transport, List(businessEntity5))
 
   val singleEoriEmailParameters = EmailParameters(eori1, None, undertaking.name, undertakingRef, None)
   val singleEoriWithDateEmailParameters = EmailParameters(eori1, None, undertaking.name, undertakingRef, dateTime.toString.some)


### PR DESCRIPTION
Summary of changes
* created separate read and create models for Undertaking so that code using the old shared model with the optional reference can be cleaned up - the read model has a mandatory reference which simplifies code using this value
* updated tests and removed redundant test cases