### PR TITLE
Esc revert disable changes

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -36,6 +36,7 @@ class EscConnector @Inject() (
 
   private lazy val createUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking"
   private lazy val updateUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking/update"
+  private lazy val disableUpdateUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking/disable"
   private lazy val retrieveUndertakingUrl = s"$escUrl/eu-subsidy-compliance/undertaking"
   private lazy val addMemberUrl = s"$escUrl/eu-subsidy-compliance/undertaking/member"
   private lazy val removeMemberUrl = s"$escUrl/eu-subsidy-compliance/undertaking/member/remove"
@@ -47,6 +48,9 @@ class EscConnector @Inject() (
 
   def updateUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[Undertaking, HttpResponse](updateUndertakingUrl, undertaking))
+
+  def disableUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): ConnectorResult =
+    makeRequest(_.POST[Undertaking, HttpResponse](disableUpdateUndertakingUrl, undertaking))
 
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.GET[HttpResponse](s"$retrieveUndertakingUrl/$eori"))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -318,7 +318,7 @@ class UndertakingController @Inject() (
   ): Future[Result] =
     if (form.value == "true") {
       for {
-        _ <- escService.removeMember(undertaking.reference, undertaking.getBusinessEntityByEORI(request.eoriNumber))
+        _ <- escService.disableUndertaking(undertaking)
         _ <- undertaking.undertakingBusinessEntity.traverse(be => resetAllJourneys(be.businessEntityIdentifier))
         _ = auditService.sendEvent[UndertakingDisabled](
           UndertakingDisabled(request.authorityId, undertaking.reference, timeProvider.today)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -298,7 +298,7 @@ class UndertakingController @Inject() (
   }
 
   def getUndertakingDisabled: Action[AnyContent] = withCDSAuthenticatedUser.async { implicit request =>
-    Ok(undertakingDisabledPage()).toFuture
+    Ok(undertakingDisabledPage()).withNewSession.toFuture
   }
 
   private def resetAllJourneys(implicit eori: EORI) =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -59,6 +59,17 @@ class EscService @Inject() (
         } yield ref
       }
 
+  def disableUndertaking(undertaking: Undertaking)(implicit hc: HeaderCarrier): Future[UndertakingRef] =
+    escConnector
+      .disableUndertaking(undertaking)
+      .flatMap { response =>
+        for {
+          ref <- handleResponse[UndertakingRef](response, "disable undertaking").toFuture
+          _ <- undertakingCache.deleteUndertaking(ref)
+          _ <- undertakingCache.deleteUndertakingSubsidies(ref)
+        } yield ref
+      }
+
   def retrieveUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Option[Undertaking]] =
     undertakingCache
       .get[Undertaking](eori)
@@ -114,7 +125,6 @@ class EscService @Inject() (
         for {
           ref <- handleResponse[UndertakingRef](response, "add member").toFuture
           _ <- undertakingCache.deleteUndertaking(ref)
-          _ <- undertakingCache.deleteUndertakingSubsidies(ref)
         } yield ref
       }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/UndertakingDisabledPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/UndertakingDisabledPage.scala.html
@@ -14,16 +14,18 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 @import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
-@import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.H2
+@import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.P
 
-@this(layout: Layout, govukPanel : GovukPanel)
-
+@this(layout: Layout, govukPanel : GovukPanel, govukInsetText : GovukInsetText)
 @()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 @key = @{"undertakingDisabled"}
 @title = @{messages(s"$key.title")}
 @heading = @{messages(s"$key.h2")}
+@html = {
+    @P(messages(s"$key.inset.p1"))
+   @P(messages(s"$key.inset.p2"))
+}
 
 @layout(pageTitle = Some(title)) {
 
@@ -32,10 +34,10 @@
         classes = "govuk-!-margin-bottom-7 govuk-panel--warning"
     ))
 
+
     <p class="govuk-body">@messages(s"$key.p1")</p>
+    @govukInsetText(InsetText(
+        content = HtmlContent(html)))
     <p class="govuk-body">@messages(s"$key.p2")</p>
-    @H2(heading)
-    <p class="govuk-body">@Html(messages(s"$key.p3", controllers.routes.AccountController.getAccountPage().url))</p>
-    <p class="govuk-body">@Html(messages(s"$key.p4", appConfig.signOutUrl(continueUrl = Some(appConfig.exitSurveyUrl))))</p>
 
 }

--- a/conf/messages
+++ b/conf/messages
@@ -439,8 +439,8 @@ disableUndertakingConfirm.error.required = Select Yes if you want to disable the
 #undertakingDisabled
 undertakingDisabled.title = You have disabled this single undertaking
 undertakingDisabled.p1 = We have sent all businesses that were part of this single undertaking a confirmation email.
-undertakingDisabled.p2= You have been logged out of the account.
-undertakingDisabled.h2= Actions
-undertakingDisabled.p3 = <a href="{0}" class="govuk-link">Create a new undertaking</a>
+undertakingDisabled.inset.p1= The change does not take effect immediately and may take up to 24 hours to go through.
+undertakingDisabled.inset.p2=During this 24-hour period, you will still be in the undertaking, until the update happens, but will not be able make any changes to the undertaking.
+undertakingDisabled.p2 = You have been logged out of the account.
 undertakingDisabled.p4 = <a href="{0}" class="govuk-link">What did you think of this service?</a>(takes 30 seconds)
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -92,4 +92,10 @@ trait EscServiceSupport { this: ControllerSpec =>
       .expects(reference, nonHmrcSubsidy, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 
+  def mockDisableUndertaking(undertaking: Undertaking)(result: Either[ConnectorError, UndertakingRef]) =
+    (mockEscService
+      .disableUndertaking(_: Undertaking)(_: HeaderCarrier))
+      .expects(undertaking, *)
+      .returning(result.fold(e => Future.failed(e), _.toFuture))
+
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -692,7 +692,9 @@ class UndertakingControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
-            mockSendEmail(eori1, "createUndertaking", undertakingCreated.toUndertakingWithRef(undertakingRef))(Left(ConnectorError(exception)))
+            mockSendEmail(eori1, "createUndertaking", undertakingCreated.toUndertakingWithRef(undertakingRef))(
+              Left(ConnectorError(exception))
+            )
           }
           assertThrows[Exception](await(performAction("cya" -> "true")(Language.English.code)))
 
@@ -709,7 +711,9 @@ class UndertakingControllerSpec
             mockAuthWithNecessaryEnrolment()
             mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
-            mockSendEmail(eori1, "createUndertaking", undertakingCreated.toUndertakingWithRef(undertakingRef))(Right(EmailSent))
+            mockSendEmail(eori1, "createUndertaking", undertakingCreated.toUndertakingWithRef(undertakingRef))(
+              Right(EmailSent)
+            )
             mockTimeProviderNow(timeNow)
             mockSendAuditEvent(createUndertakingAuditEvent)
           }
@@ -1071,11 +1075,11 @@ class UndertakingControllerSpec
 
       val currentDate = LocalDate.of(2022, 10, 9)
       "throw technical error" when {
-        "call to remove member fails" in {
+        "call to remove disable fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
-            mockRemoveMember(undertakingRef, businessEntity1)(Left(ConnectorError(exception)))
+            mockDisableUndertaking(undertaking1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("disableUndertakingConfirm" -> "true")))
         }
@@ -1103,7 +1107,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
-            mockRemoveMember(undertakingRef, businessEntity1)(Right(undertakingRef))
+            mockDisableUndertaking(undertaking1)(Right(undertakingRef))
             mockDelete[EligibilityJourney](eori1)(Right(()))
             mockDelete[UndertakingJourney](eori1)(Right(()))
             mockDelete[NewLeadJourney](eori1)(Right(()))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -1154,15 +1154,7 @@ class UndertakingControllerSpec
         }
         checkPageIsDisplayed(
           performAction(),
-          messageFromMessageKey("undertakingDisabled.title"),
-          { doc =>
-            val body = doc.select(".govuk-body").html()
-            body should include regex messageFromMessageKey(
-              "undertakingDisabled.p3",
-              routes.AccountController.getAccountPage().url
-            )
-
-          }
+          messageFromMessageKey("undertakingDisabled.title")
         )
       }
     }


### PR DESCRIPTION
This PR include:
- revert the disable undertaking code to call update undertaking API instead of amend undertaking member api 
- change test case for that
- Change the last page of disabled undertaking as per the ticket https://jira.tools.tax.service.gov.uk/browse/ESC-604