### PR TITLE
ESC-611 ensure EligibilityJourney is present if user redirected to eori check page from ECC

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -63,11 +63,8 @@ class AccountController @Inject() (
   private def handleUndertakingNotCreated(implicit e: EORI): Future[Result] = {
     val result = getOrCreateJourneys().map {
       case (ej, uj) if !ej.isComplete && uj.isEmpty =>
-        if (ej.eoriCheck.value.contains(true)) {
-          Redirect(routes.EligibilityController.firstEmptyPage())
-        } else {
-          Redirect(routes.EligibilityController.getCustomsWaivers())
-        }
+        if (ej.eoriCheck.value.contains(true)) Redirect(routes.EligibilityController.firstEmptyPage())
+        else Redirect(routes.EligibilityController.getCustomsWaivers())
       case (_, uj) if !uj.isComplete => Redirect(routes.UndertakingController.firstEmptyPage())
       case _ => Redirect(routes.BusinessEntityController.getAddBusinessEntity())
     }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailParameters.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailParameters.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
 
 import play.api.libs.json.Json
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingName, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingName}
 
 case class EmailParameters(
   eori: EORI,

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -303,18 +303,7 @@ class EligibilityControllerSpec
             mockRetrieveEmail(eori1)(
               Right(RetrieveEmailResponse(EmailType.VerifiedEmail, EmailAddress("some@test.com").some))
             )
-            mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
-          }
-          assertThrows[Exception](await(performAction()))
-        }
-
-        "call to get eligibility passes but fetches nothing" in {
-          inSequence {
-            mockAuthWithNecessaryEnrolment()
-            mockRetrieveEmail(eori1)(
-              Right(RetrieveEmailResponse(EmailType.VerifiedEmail, EmailAddress("some@test.com").some))
-            )
-            mockGet[EligibilityJourney](eori1)(Right(None))
+            mockGetOrCreate[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -329,7 +318,7 @@ class EligibilityControllerSpec
             mockRetrieveEmail(eori1)(
               Right(RetrieveEmailResponse(EmailType.VerifiedEmail, EmailAddress("some@test.com").some))
             )
-            mockGet[EligibilityJourney](eori1)(Right(eligibilityJourney.some))
+            mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourney))
           }
           checkPageIsDisplayed(
             performAction(),


### PR DESCRIPTION
Summary of changes
* if user navigates directly to the eori check page then ensure EligibilityJourney data is present to allow the user to continue with the first login journey
* minor tidy ups and test changes