### PR TITLE
Esc 638

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/Connector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/Connector.scala
@@ -34,8 +34,8 @@ trait Connector {
     request(http) map { r: HttpResponse =>
       if (r.status.isSuccess) Right(r)
       else Left(ConnectorError(UpstreamErrorResponse(s"Unexpected response - got HTTP ${r.status}", r.status)))
-    } recover {
-      case e: Exception => Left(ConnectorError(e))
+    } recover { case e: Exception =>
+      Left(ConnectorError(e))
     }
 
 }
@@ -44,7 +44,7 @@ object Connector {
 
   object ConnectorSyntax {
     implicit class ResponseStatusOps(val status: Int) extends AnyVal {
-      def isSuccess: Boolean = status >= 200 && status < 300
+      def isSuccess: Boolean = (status == 404) || (status >= 200 && status < 300)
     }
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EmailConnector.scala
@@ -16,19 +16,14 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 
+import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EmailConnector.ConnectorSyntax.ResponseStatusOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.http.{HttpClient, HttpResponse, UpstreamErrorResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
-import Connector.ConnectorSyntax._
 
-trait Connector {
-
-  type ConnectorResult = Future[Either[ConnectorError, HttpResponse]]
-
-  protected val http: HttpClient
-
-  protected def makeRequest(
+trait EmailConnector extends Connector {
+  override protected def makeRequest(
     request: HttpClient => Future[HttpResponse]
   )(implicit ec: ExecutionContext): ConnectorResult =
     request(http) map { r: HttpResponse =>
@@ -40,11 +35,11 @@ trait Connector {
 
 }
 
-object Connector {
+object EmailConnector {
 
   object ConnectorSyntax {
     implicit class ResponseStatusOps(val status: Int) extends AnyVal {
-      def isSuccess: Boolean = status >= 200 && status < 300
+      def isSuccess: Boolean = (status == 404) || (status >= 200 && status < 300)
     }
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -36,6 +36,6 @@ class RetrieveEmailConnector @Inject() (
   private def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/$eori/verified-email"
 
   def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): ConnectorResult =
-    makeRequest(_.GET[HttpResponse](getUri(eori)))
+    makeRequest(_.GET[HttpResponse](getUri(eori)), true)
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -28,11 +28,12 @@ import scala.concurrent.ExecutionContext
 class RetrieveEmailConnector @Inject() (
   override protected val http: HttpClient,
   servicesConfig: ServicesConfig
-)(implicit ec: ExecutionContext) extends Connector {
+)(implicit ec: ExecutionContext)
+    extends Connector {
 
   lazy private val cdsURL: String = servicesConfig.baseUrl("cds")
 
-  private def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/${eori}/verified-email"
+  private def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/$eori/verified-email"
 
   def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.GET[HttpResponse](getUri(eori)))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/RetrieveEmailConnector.scala
@@ -29,13 +29,13 @@ class RetrieveEmailConnector @Inject() (
   override protected val http: HttpClient,
   servicesConfig: ServicesConfig
 )(implicit ec: ExecutionContext)
-    extends Connector {
+    extends EmailConnector {
 
   lazy private val cdsURL: String = servicesConfig.baseUrl("cds")
 
   private def getUri(eori: EORI) = s"$cdsURL/customs-data-store/eori/$eori/verified-email"
 
   def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): ConnectorResult =
-    makeRequest(_.GET[HttpResponse](getUri(eori)), true)
+    makeRequest(_.GET[HttpResponse](getUri(eori)))
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/SendEmailConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/SendEmailConnector.scala
@@ -28,7 +28,8 @@ import scala.concurrent.ExecutionContext
 class SendEmailConnector @Inject() (
   override protected val http: HttpClient,
   servicesConfig: ServicesConfig
-)(implicit ec: ExecutionContext) extends Connector {
+)(implicit ec: ExecutionContext)
+    extends Connector {
 
   private lazy val baseUrl: String = servicesConfig.baseUrl("email-send")
   private lazy val sendEmailUrl: String = s"$baseUrl/hmrc/email"

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailService.scala
@@ -41,7 +41,7 @@ class EmailService @Inject() (
   def sendEmail(
     eori1: EORI,
     template: EmailTemplate,
-    undertaking: Undertaking,
+    undertaking: Undertaking
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[EmailSendResult] =
     sendEmail(eori1, None, template, undertaking, None)
 
@@ -49,7 +49,7 @@ class EmailService @Inject() (
     eori1: EORI,
     eori2: EORI,
     template: EmailTemplate,
-    undertaking: Undertaking,
+    undertaking: Undertaking
   )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[EmailSendResult] =
     sendEmail(eori1, eori2.some, template, undertaking, None)
 
@@ -78,7 +78,7 @@ class EmailService @Inject() (
     removeEffectiveDate: Option[String]
   )(implicit
     hc: HeaderCarrier,
-    executionContext: ExecutionContext,
+    executionContext: ExecutionContext
   ): Future[EmailSendResult] =
     retrieveEmailByEORI(eori1).flatMap { retrieveEmailResponse =>
       retrieveEmailResponse.emailType match {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/ConnectorSpec.scala
@@ -34,7 +34,7 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
     "do a get http call and return the result" in {
       List(
         HttpResponse(200, "{}"),
-        HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]]),
+        HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]])
       ).foreach { httpResponse =>
         withClue(s"For http response [${httpResponse.toString}]") {
           mockResponse(Some(httpResponse))
@@ -47,7 +47,7 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
       "the server returns a 4xx response" in {
         mockResponse(Some(HttpResponse(404, "")))
-        performCall().futureValue.isLeft shouldBe true
+        performCall().futureValue.isRight shouldBe true
       }
 
       "the server returns a 5xx response" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EmailConnectorSpec.scala
@@ -24,16 +24,17 @@ import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
 
-trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
+trait EmailConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
-  def connectorBehaviour[A](
+  def connectorBehaviourForRetrieveEmail[A](
     mockResponse: Option[HttpResponse] => Unit,
     performCall: () => Future[Either[A, HttpResponse]]
-  ) = {
+  ): Unit = {
 
     "do a get http call and return the result" in {
       List(
         HttpResponse(200, "{}"),
+        HttpResponse(404, "{}"),
         HttpResponse(200, JsString("hi"), Map.empty[String, Seq[String]])
       ).foreach { httpResponse =>
         withClue(s"For http response [${httpResponse.toString}]") {
@@ -45,8 +46,8 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
     "return an error" when {
 
-      "the server returns a 4xx response" in {
-        mockResponse(Some(HttpResponse(404, "")))
+      "the server returns a 4xx response except 404" in {
+        mockResponse(Some(HttpResponse(400, "")))
         performCall().futureValue.isLeft shouldBe true
       }
 
@@ -62,4 +63,5 @@ trait ConnectorSpec { this: Matchers with AnyWordSpecLike =>
 
     }
   }
+
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/RetrieveEmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/RetrieveEmailConnectorSpec.scala
@@ -55,7 +55,7 @@ class RetrieveEmailConnectorSpec
 
   "RetrieveEmailConnector" when {
     "handling request to retrieve email address by eori" must {
-      behave like connectorBehaviour(
+      behave like connectorBehaviourForRetrieveEmail(
         mockGet(expectedUrl)(_),
         () => connector.retrieveEmailByEORI(eori1)
       )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/RetrieveEmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/RetrieveEmailConnectorSpec.scala
@@ -23,9 +23,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.Configuration
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.RetrieveEmailConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.eori1
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
-import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -34,7 +33,7 @@ class RetrieveEmailConnectorSpec
     with Matchers
     with MockFactory
     with HttpSupport
-    with ConnectorSpec {
+    with EmailConnectorSpec {
 
   private val (protocol, host, port) = ("http", "host", "123")
 
@@ -61,12 +60,6 @@ class RetrieveEmailConnectorSpec
       )
     }
 
-    "handling request to retrieve email address by eori with response 404" in {
-      inSequence {
-        mockGet(expectedUrl)(Some(HttpResponse(404, "")))
-      }
-      connector.retrieveEmailByEORI(eori1).futureValue.isRight shouldBe true
-    }
   }
 
 }


### PR DESCRIPTION
ticket details -> https://jira.tools.tax.service.gov.uk/browse/ESC-638

I have added the flag (isRetrieveEmail: Boolean = false) in connector so that 404 is handled differently in case of retrieve email only. I think even if it returns success for others it will not break anything but to be on safe side I have put this flag. We can test in future if 404 as success is okay for other scenarios.
Similarly in Connector Spec added separate test cases for RetrieveEmail