### PR TITLE
ESC-593 send emails when undertaking disabled

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailTemplate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailTemplate.scala
@@ -26,6 +26,8 @@ object EmailTemplate extends Enum[EmailTemplate] {
   case object AddMemberToBusinessEntity extends EmailTemplate
   case object AddMemberToLead extends EmailTemplate
   case object CreateUndertaking extends EmailTemplate
+  case object DisableUndertakingToLead extends EmailTemplate
+  case object DisableUndertakingToBusinessEntity extends EmailTemplate
   case object MemberRemoveSelfToBusinessEntity extends EmailTemplate
   case object MemberRemoveSelfToLead extends EmailTemplate
   case object PromotedOtherAsLeadToBusinessEntity extends EmailTemplate

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -186,6 +186,8 @@ email-send {
   addMemberToBusinessEntity = "undertaking_member_added_email_to_be"
   addMemberToLead = "undertaking_member_added_email_to_lead"
   createUndertaking = "create_undertaking_email_to_lead"
+  disableUndertakingToLead = "disabled_undertaking_email-to_lead"
+  disableUndertakingToBusinessEntity = "disabled_undertaking_email_to_be"
   memberRemoveSelfToBusinessEntity ="member_remove_themself_email_to_be"
   memberRemoveSelfToLead = "member_remove_themself_email_to_lead"
   promotedOtherAsLeadToBusinessEntity = "promoted_other_as_lead_email_to_be"

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingControllerSpec.ModifyUndertakingRow
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.{UndertakingDisabled, UndertakingUpdated}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult.EmailSent
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailTemplate.CreateUndertaking
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailTemplate.{CreateUndertaking, DisableUndertakingToBusinessEntity, DisableUndertakingToLead}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{Sector, UndertakingName}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ConnectorError
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.UndertakingJourney.Forms.{UndertakingConfirmationFormPage, UndertakingCyaFormPage, UndertakingNameFormPage, UndertakingSectorFormPage}
@@ -1069,6 +1069,8 @@ class UndertakingControllerSpec
         )
 
       val currentDate = LocalDate.of(2022, 10, 9)
+      val formattedDate = "9 October 2022"
+
       "throw technical error" when {
         "call to remove disable fails" in {
           inSequence {
@@ -1119,6 +1121,9 @@ class UndertakingControllerSpec
             mockDelete[SubsidyJourney](eori4)(Right(()))
             mockTimeToday(currentDate)
             mockSendAuditEvent[UndertakingDisabled](UndertakingDisabled("1123", undertakingRef, currentDate))
+            mockTimeToday(currentDate)
+            mockSendEmail(eori1, DisableUndertakingToLead, undertaking1, formattedDate)(Right(EmailSent))
+            mockSendEmail(eori1, DisableUndertakingToBusinessEntity, undertaking1, formattedDate)(Right(EmailSent))
           }
           checkIsRedirect(
             performAction("disableUndertakingConfirm" -> "true"),


### PR DESCRIPTION
Summary of changes
* added config for disable undertaking lead and business entity templates
* revised the disable undertaking handling to also send emails to the undertaking lead and any business entitites 
* updated tests