### PR TITLE
ESC-619 fetch exchange rates from ESC backend

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCache.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.cache
+
+import uk.gov.hmrc.eusubsidycompliancefrontend.cache.ExchangeRateCache.DefaultCacheTtl
+import uk.gov.hmrc.mongo.{CurrentTimestampSupport, MongoComponent}
+import uk.gov.hmrc.mongo.cache.{CacheIdType, MongoCacheRepository}
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+
+case class YearAndMonth(year: Int, month: Int) {
+  override def toString: String = f"$year%04d$month%02d"
+}
+
+object YearAndMonth {
+  def fromDate(d: LocalDate): YearAndMonth = YearAndMonth(d.getYear, d.getMonthValue)
+}
+
+object YearAndMonthIdType extends CacheIdType[YearAndMonth] {
+  override def run: YearAndMonth => String = _.toString
+}
+
+@Singleton
+class ExchangeRateCache @Inject() (
+  mongoComponent: MongoComponent
+)(implicit ec: ExecutionContext)
+  extends MongoCacheRepository[YearAndMonth](
+    mongoComponent = mongoComponent,
+    collectionName = "exchangeRateCache",
+    ttl = DefaultCacheTtl,
+    timestampSupport = new CurrentTimestampSupport,
+    cacheIdType = YearAndMonthIdType
+  )
+    {
+
+
+}
+
+object ExchangeRateCache {
+  val DefaultCacheTtl: FiniteDuration = 30 days
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/Helpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/Helpers.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.cache
+
+import uk.gov.hmrc.mongo.cache.DataKey
+
+import scala.reflect.ClassTag
+
+object Helpers {
+
+  def dataKeyForType[A](implicit ct: ClassTag[A]): DataKey[A] = DataKey[A](ct.runtimeClass.getSimpleName)
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/cache/UndertakingCache.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.cache
 import org.mongodb.scala.MongoCollection
 import org.mongodb.scala.model.{Filters, IndexOptions, Indexes, Updates}
 import play.api.libs.json.{Reads, Writes}
+import uk.gov.hmrc.eusubsidycompliancefrontend.cache.Helpers.dataKeyForType
 import uk.gov.hmrc.eusubsidycompliancefrontend.cache.UndertakingCache.DefaultCacheTtl
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
 import uk.gov.hmrc.mongo.cache.{CacheIdType, CacheItem, DataKey, MongoCacheRepository}
@@ -104,8 +105,6 @@ class UndertakingCache @Inject() (
       ).toFuture()
         .map(_ => ())
     }
-
-  private def dataKeyForType[A](implicit ct: ClassTag[A]) = DataKey[A](ct.runtimeClass.getSimpleName)
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EscConnector.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext
 
 @Singleton
@@ -42,6 +43,7 @@ class EscConnector @Inject() (
   private lazy val removeMemberUrl = s"$escUrl/eu-subsidy-compliance/undertaking/member/remove"
   private lazy val updateSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/update"
   private lazy val retrieveSubsidyUrl = s"$escUrl/eu-subsidy-compliance/subsidy/retrieve"
+  private lazy val retrieveExchangeRateUrl = s"$escUrl/eu-subsidy-compliance/exchangerate"
 
   def createUndertaking(undertaking: UndertakingCreate)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[UndertakingCreate, HttpResponse](createUndertakingUrl, undertaking))
@@ -83,5 +85,8 @@ class EscConnector @Inject() (
 
   def retrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(implicit hc: HeaderCarrier): ConnectorResult =
     makeRequest(_.POST[SubsidyRetrieve, HttpResponse](retrieveSubsidyUrl, subsidyRetrieve))
+
+  def retrieveExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier): ConnectorResult =
+    makeRequest(_.GET[HttpResponse](s"$retrieveExchangeRateUrl/$date"))
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ExchangeRateTestController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ExchangeRateTestController.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.eusubsidycompliancefrontend.actions.EscCDSActionBuilders
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class ExchangeRateTestController @Inject() (
+  mcc: MessagesControllerComponents,
+  escCDSActionBuilders: EscCDSActionBuilders,
+  escService: EscService
+)(implicit val ec: ExecutionContext) extends BaseController(mcc) {
+
+  import escCDSActionBuilders._
+
+  def getExchangeRate(isoDate: String): Action[AnyContent] = withCDSAuthenticatedUser.async { implicit request =>
+    val parsedDate = LocalDate.parse(isoDate)
+
+    escService.retrieveExchangeRate(parsedDate)
+      .map(r => Ok(Json.toJson(r)))
+  }
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ExchangeRate.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ExchangeRate(from: String, to: String, rate: BigDecimal)
+
+object ExchangeRate {
+  implicit val exchangeRateFormat: OFormat[ExchangeRate] = Json.format[ExchangeRate]
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -31,6 +31,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax.FutureOption
 import uk.gov.hmrc.http.UpstreamErrorResponse.WithStatusCode
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
+import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -164,6 +165,13 @@ class EscService @Inject() (
           ref <- handleResponse[UndertakingRef](response, "remove subsidy").toFuture
           _ <- undertakingCache.deleteUndertakingSubsidies(ref)
         } yield ref
+      }
+
+  def retrieveExchangeRate(date: LocalDate)(implicit hc: HeaderCarrier): Future[ExchangeRate] =
+    escConnector
+      .retrieveExchangeRate(date)
+      .map { response =>
+        handleResponse[ExchangeRate](response, "exchange rate")
       }
 
   private def handleResponse[A](r: Either[ConnectorError, HttpResponse], action: String)(implicit reads: Reads[A]): A =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -21,7 +21,7 @@ import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
 import com.google.inject.{Inject, Singleton}
 import play.api.http.Status.{NOT_FOUND, OK}
 import play.api.libs.json.Reads
-import uk.gov.hmrc.eusubsidycompliancefrontend.cache.UndertakingCache
+import uk.gov.hmrc.eusubsidycompliancefrontend.cache.{ExchangeRateCache, UndertakingCache}
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
@@ -37,7 +37,8 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class EscService @Inject() (
   escConnector: EscConnector,
-  undertakingCache: UndertakingCache
+  undertakingCache: UndertakingCache,
+  exchangeRateCache: ExchangeRateCache
 )(implicit ec: ExecutionContext) {
 
   def createUndertaking(undertaking: UndertakingCreate)(implicit hc: HeaderCarrier, eori: EORI): Future[UndertakingRef] =

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -126,3 +126,5 @@ POST       /lead-undertaking-no-business-present                                
 
 GET        /financial-dashboard                                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.FinancialDashboardController.getFinancialDashboard
 GET        /lead-undertaking-promote-business-entity-email-unverified                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SelectNewLeadController.emailNotVerified
+
+GET        /test/exchangeRate/:isoDate                                                   uk.gov.hmrc.eusubsidycompliancefrontend.controllers.ExchangeRateTestController.getExchangeRate(isoDate)

--- a/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCacheSpec.scala
+++ b/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCacheSpec.scala
@@ -1,0 +1,47 @@
+package uk.gov.hmrc.eusubsidycompliancefrontend.cache
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.test.DefaultAwaitTimeout
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ExchangeRate
+import uk.gov.hmrc.mongo.cache.CacheItem
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ExchangeRateCacheSpec
+  extends AnyWordSpec
+    with DefaultPlayMongoRepositorySupport[CacheItem]
+    with ScalaFutures
+    with DefaultAwaitTimeout
+    with Matchers {
+
+  override protected def repository = new ExchangeRateCache(mongoComponent)
+
+  private val yearMonth1 = YearAndMonth(2022, 1)
+  private val yearMonth2 = YearAndMonth(2022, 6)
+
+  private val exchangeRate1 = ExchangeRate("EUR", "GBP", BigDecimal(0.867))
+  private val exchangeRate2 = ExchangeRate("EUR", "GBP", BigDecimal(0.807))
+
+  "ExchangeRateCache" should {
+
+    "return None when the cache is empty" in {
+      repository.get[YearAndMonth](yearMonth1).futureValue shouldBe None
+    }
+
+    "return None when there is no matching item in the cache" in {
+      repository.put(yearMonth1, exchangeRate1).futureValue shouldBe exchangeRate1
+      repository.get[YearAndMonth](yearMonth2).futureValue shouldBe None
+    }
+
+    "return the item when present in the cache" in {
+      repository.put(yearMonth2, exchangeRate2).futureValue shouldBe exchangeRate2
+      Thread.sleep(10000)
+      repository.get[YearAndMonth](yearMonth2).futureValue shouldBe exchangeRate2
+    }
+
+  }
+
+}

--- a/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCacheSpec.scala
+++ b/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCacheSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.eusubsidycompliancefrontend.cache
 
 import org.scalatest.concurrent.ScalaFutures
@@ -28,18 +44,17 @@ class ExchangeRateCacheSpec
   "ExchangeRateCache" should {
 
     "return None when the cache is empty" in {
-      repository.get[YearAndMonth](yearMonth1).futureValue shouldBe None
+      repository.get[ExchangeRate](yearMonth1).futureValue shouldBe None
     }
 
     "return None when there is no matching item in the cache" in {
       repository.put(yearMonth1, exchangeRate1).futureValue shouldBe exchangeRate1
-      repository.get[YearAndMonth](yearMonth2).futureValue shouldBe None
+      repository.get[ExchangeRate](yearMonth2).futureValue shouldBe None
     }
 
     "return the item when present in the cache" in {
       repository.put(yearMonth2, exchangeRate2).futureValue shouldBe exchangeRate2
-      Thread.sleep(10000)
-      repository.get[YearAndMonth](yearMonth2).futureValue shouldBe exchangeRate2
+      repository.get[ExchangeRate](yearMonth2).futureValue shouldBe Some(exchangeRate2)
     }
 
   }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/cache/YearAndMonthSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/cache/YearAndMonthSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.cache
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class YearAndMonthTest extends AnyWordSpec with Matchers {
+class YearAndMonthSpec extends AnyWordSpec with Matchers {
 
   "YearAndMonth" should {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/cache/YearAndMonthTest.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/cache/YearAndMonthTest.scala
@@ -25,12 +25,12 @@ class YearAndMonthTest extends AnyWordSpec with Matchers {
 
     "generate the expected string representation when toString is called" in {
       val underTest = YearAndMonth(2001, 12)
-      underTest.toString shouldBe "200112"
+      underTest.toString shouldBe "2001-12"
     }
 
     "pad the year and month values correctly" in {
       val underTest = YearAndMonth(1, 1)
-      underTest.toString shouldBe "000101"
+      underTest.toString shouldBe "0001-01"
     }
   }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/cache/YearAndMonthTest.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/cache/YearAndMonthTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.cache
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class YearAndMonthTest extends AnyWordSpec with Matchers {
+
+  "YearAndMonth" should {
+
+    "generate the expected string representation when toString is called" in {
+      val underTest = YearAndMonth(2001, 12)
+      underTest.toString shouldBe "200112"
+    }
+
+    "pad the year and month values correctly" in {
+      val underTest = YearAndMonth(1, 1)
+      underTest.toString shouldBe "000101"
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EscConnectorSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class EscConnectorSpec
@@ -113,6 +114,16 @@ class EscConnectorSpec
         () => connector.retrieveSubsidy(subsidyRetrieve)
       )
     }
+
+    "handling request to retrieve exchange rate" must {
+      val date = LocalDate.of(2020, 1, 1)
+
+      behave like connectorBehaviour(
+        mockGet(s"$baseUrl/exchangerate/$date")(_),
+        () => connector.retrieveExchangeRate(date)
+      )
+    }
+
   }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
-import uk.gov.hmrc.eusubsidycompliancefrontend.cache.UndertakingCache
+import uk.gov.hmrc.eusubsidycompliancefrontend.cache.{ExchangeRateCache, UndertakingCache}
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EscConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
@@ -47,7 +47,13 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
 
   private val mockUndertakingCache: UndertakingCache = mock[UndertakingCache]
 
-  private val service: EscService = new EscService(mockEscConnector, mockUndertakingCache)
+  private val mockExchangeRateCache: ExchangeRateCache = mock[ExchangeRateCache]
+
+  private val service: EscService = new EscService(
+    mockEscConnector,
+    mockUndertakingCache,
+    mockExchangeRateCache
+  )
 
   private def mockCreateUndertaking(undertaking: UndertakingCreate)(
     result: Either[ConnectorError, HttpResponse]

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -528,6 +528,11 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
           service.retrieveExchangeRate(fixedDate).futureValue shouldBe exchangeRate
         }
 
+        "an item is present in the cache" in {
+          mockExchangeRateCacheGet(YearAndMonth.fromDate(fixedDate))(Right(exchangeRate.some))
+          service.retrieveExchangeRate(fixedDate).futureValue shouldBe exchangeRate
+        }
+
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscServiceSpec.scala
@@ -82,9 +82,7 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
     when(mockEscConnector.createSubsidy(argEq(subsidyUpdate))(any()))
       .thenReturn(result.toFuture)
 
-  private def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(
-    result: Either[ConnectorError, HttpResponse]
-  ) =
+  private def mockRetrieveSubsidy(subsidyRetrieve: SubsidyRetrieve)(result: Either[ConnectorError, HttpResponse]) =
     when(mockEscConnector.retrieveSubsidy(argEq(subsidyRetrieve))(any()))
       .thenReturn(result.toFuture)
 
@@ -111,9 +109,14 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
     when(mockUndertakingCache.deleteUndertakingSubsidies(argEq(ref)))
       .thenReturn(result.fold(Future.failed, _.toFuture))
 
+  private def mockRetrieveExchangeRate(date: LocalDate)(result: Either[ConnectorError, HttpResponse]) =
+    when(mockEscConnector.retrieveExchangeRate(argEq(date))(any()))
+      .thenReturn(result.toFuture)
+
   private val undertakingRefJson = Json.toJson(undertakingRef)
   private val undertakingJson: JsValue = Json.toJson(undertaking)
   private val undertakingSubsidiesJson = Json.toJson(undertakingSubsidies)
+  private val exchangeRateJson = Json.toJson(exchangeRate)
 
   private val emptyHeaders = Map.empty[String, Seq[String]]
 
@@ -312,32 +315,32 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
       "return an error" when {
 
-        def isError(): Assertion = {
+        def isError: Assertion = {
           val result = service.removeMember(undertakingRef, businessEntity3)
           assertThrows[RuntimeException](await(result))
         }
 
         "the http call fails" in {
           mockRemoveMember(undertakingRef, businessEntity3)(Left(ConnectorError("")))
-          isError()
+          isError
         }
 
         "the http response doesn't come back with status 200(OK)" in {
           mockRemoveMember(undertakingRef, businessEntity3)(
             Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders))
           )
-          isError()
+          isError
         }
 
         "there is no json in the response" in {
           mockRemoveMember(undertakingRef, businessEntity3)(Right(HttpResponse(OK, "hi")))
-          isError()
+          isError
         }
 
         "the json in the response can't be parsed" in {
           val json = Json.parse("""{ "a" : 1 }""")
           mockRemoveMember(undertakingRef, businessEntity3)(Right(HttpResponse(OK, json, emptyHeaders)))
-          isError()
+          isError
         }
 
       }
@@ -360,32 +363,32 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
       "return an error" when {
 
-        def isError(): Assertion = {
+        def isError: Assertion = {
           val result = service.createSubsidy(subsidyUpdate)
           assertThrows[RuntimeException](await(result))
         }
 
         "the http call fails" in {
           mockCreateSubsidy(subsidyUpdate)(Left(ConnectorError("")))
-          isError()
+          isError
         }
 
         "the http response doesn't come back with status 200(OK)" in {
           mockCreateSubsidy(subsidyUpdate)(
             Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders))
           )
-          isError()
+          isError
         }
 
         "there is no json in the response" in {
           mockCreateSubsidy(subsidyUpdate)(Right(HttpResponse(OK, "hi")))
-          isError()
+          isError
         }
 
         "the json in the response can't be parsed" in {
           val json = Json.parse("""{ "a" : 1 }""")
           mockCreateSubsidy(subsidyUpdate)(Right(HttpResponse(OK, json, emptyHeaders)))
-          isError()
+          isError
         }
 
       }
@@ -405,30 +408,30 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
       "return an error" when {
 
-        def isError(): Assertion = {
+        def isError: Assertion = {
           val result = service.retrieveSubsidy(subsidyRetrieve)
           assertThrows[RuntimeException](await(result))
         }
 
         "the http call fails" in {
           mockRetrieveSubsidy(subsidyRetrieve)(Left(ConnectorError("")))
-          isError()
+          isError
         }
 
         "the http response doesn't come back with status 200(OK)" in {
           mockRetrieveSubsidy(subsidyRetrieve)(Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders)))
-          isError()
+          isError
         }
 
         "there is no json in the response" in {
           mockRetrieveSubsidy(subsidyRetrieve)(Right(HttpResponse(OK, "hi")))
-          isError()
+          isError
         }
 
         "the json in the response can't be parsed" in {
           val json = Json.parse("""{ "a" : 1 }""")
           mockRetrieveSubsidy(subsidyRetrieve)(Right(HttpResponse(OK, json, emptyHeaders)))
-          isError()
+          isError
         }
 
       }
@@ -456,32 +459,32 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
 
       "return an error" when {
 
-        def isError(): Assertion = {
+        def isError: Assertion = {
           val result = service.removeSubsidy(undertakingRef, nonHmrcSubsidy)
           assertThrows[RuntimeException](await(result))
         }
 
         "the http call fails" in {
           mockRemoveSubsidy(undertakingRef, nonHmrcSubsidy)(Left(ConnectorError("")))
-          isError()
+          isError
         }
 
         "the http response doesn't come back with status 200(OK)" in {
           mockRemoveSubsidy(undertakingRef, nonHmrcSubsidy)(
             Right(HttpResponse(BAD_REQUEST, undertakingRefJson, emptyHeaders))
           )
-          isError()
+          isError
         }
 
         "there is no json in the response" in {
           mockRemoveSubsidy(undertakingRef, nonHmrcSubsidy)(Right(HttpResponse(OK, "hi")))
-          isError()
+          isError
         }
 
         "the json in the response can't be parsed" in {
           val json = Json.parse("""{ "a" : 1 }""")
           mockRemoveSubsidy(undertakingRef, nonHmrcSubsidy)(Right(HttpResponse(OK, json, emptyHeaders)))
-          isError()
+          isError
         }
 
       }
@@ -495,6 +498,39 @@ class EscServiceSpec extends AnyWordSpec with Matchers with MockitoSugar {
           val result = service.removeSubsidy(undertakingRef, nonHmrcSubsidy)
           await(result) shouldBe undertakingRef
         }
+      }
+
+    }
+
+    "handling request to retrieve exchange rate" must {
+
+      "return an error" when {
+
+        "the http call fails" in {
+          mockRetrieveExchangeRate(fixedDate)(Left(ConnectorError("Error")))
+          assertThrows[RuntimeException](await(service.retrieveExchangeRate(fixedDate)))
+        }
+
+        "the http response is not successful" in {
+          mockRetrieveExchangeRate(fixedDate)(Right(HttpResponse(BAD_REQUEST, exchangeRateJson, emptyHeaders)))
+          assertThrows[RuntimeException](await(service.retrieveExchangeRate(fixedDate)))
+        }
+
+        "the response body could not be parsed" in {
+          mockRetrieveExchangeRate(fixedDate)(Right(HttpResponse(OK, "This is not valid json", emptyHeaders)))
+          assertThrows[RuntimeException](await(service.retrieveExchangeRate(fixedDate)))
+        }
+
+      }
+
+      "return successfully" when {
+
+        "the http call succeeds and the body of the response can be parsed" in {
+          mockRetrieveExchangeRate(fixedDate)(Right(HttpResponse(OK, exchangeRateJson, emptyHeaders)))
+          val result = service.retrieveExchangeRate(fixedDate)
+          await(result) shouldBe exchangeRate
+        }
+
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -267,4 +267,6 @@ object CommonTestData {
 
   val businessEntityAddedEvent = AuditEvent.BusinessEntityAdded(undertakingRef, "1123", eori1, eori2)
   val businessEntityUpdatedEvent = AuditEvent.BusinessEntityUpdated(undertakingRef, "1123", eori1, eori2)
+
+  val exchangeRate = ExchangeRate("EUR", "GBP", BigDecimal(0.891))
 }


### PR DESCRIPTION
Summary of changes
* added connector to fetch exchange rates from ESC backend (which fetches the data from the Europa API)
* added service with caching to handle caching of exchange rates transparently
* added test endpoint to allow testing of the end to end flow before the frontend is built