### PR TITLE
ESC-621 allow entry of GBP amounts with new conversion confirmation page

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -224,7 +224,6 @@ class SubsidyController @Inject() (
     }
   }
 
-  // TODO - check nav - back loses memory of GBP? If so this will need to be handled
   def postConfirmClaimAmount: Action[AnyContent] = withCDSAuthenticatedUser.async { implicit request =>
     withLeadUndertaking { _ =>
       implicit val eori = request.eoriNumber

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -179,11 +179,8 @@ class SubsidyController @Inject() (
       claimAmountForm
         .bindFromRequest()
         .fold(
-          formWithErrors => {
-            println(s"Form has errors apparently - so returning bad request")
-            println(s"form with errors: $formWithErrors")
-            BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture
-          },
+          formWithErrors =>
+            BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture,
           claimAmountEntered => for {
             journey <- store.update[SubsidyJourney](_.setClaimAmount(claimAmountEntered))
             redirect <- journey.next

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -190,7 +190,7 @@ class SubsidyController @Inject() (
               journey <- store.update[SubsidyJourney](_.setClaimAmount(claimAmountEntered))
               // TODO - move this check into the SubsidyJourney
               // TODO - add in redirect to confirmation page
-              redirect <- if (claimAmountEntered.currencyCode == GBP) Redirect(routes.SubsidyController.getConfirmClaimAmount()).toFuture else journey.next
+              redirect <- journey.next
             } yield redirect
           }
         )
@@ -218,7 +218,7 @@ class SubsidyController @Inject() (
         euroAmount <- convertPoundsToEuros(claimDate.toLocalDate, claimAmount).toContext
         _ = println(s"getConfirmClaimAmount: got euroAmount: $euroAmount")
         // TODO - this should come from the journey
-        previous = routes.SubsidyController.getClaimAmount().url
+        previous = subsidyJourney.previous
         // TODO - confirm what rounding rules are needed on the converted amount
       } yield Ok(confirmConvertedAmountPage(previous, BigDecimal(claimAmount.amount).toPounds, euroAmount.toEuros))
 
@@ -236,7 +236,7 @@ class SubsidyController @Inject() (
         claimAmount <- subsidyJourney.claimAmount.value.toContext
         claimDate <- subsidyJourney.claimDate.value.toContext
         euroAmount <- convertPoundsToEuros(claimDate.toLocalDate, claimAmount).toContext
-        updatedSubsidyJourney = subsidyJourney.copy(claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, euroAmount.toEuros).some))
+        updatedSubsidyJourney = subsidyJourney.setConvertedClaimAmount(ClaimAmount(EUR, euroAmount.toEuros))
         _ <- store.put[SubsidyJourney](updatedSubsidyJourney).toContext
         // TODO - this should come from the journey
         previous = routes.SubsidyController.getConfirmClaimAmount().url

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -302,7 +302,7 @@ class SubsidyController @Inject() (
         case Some(journey) =>
           journeyTraverseService.getPrevious[SubsidyJourney].flatMap { previous =>
             if (!journey.isEligibleForStep) {
-              Redirect(routes.SubsidyController.getClaimDate()).toFuture
+              Redirect(previous).toFuture
             } else {
               val form = journey.addClaimEori.value.fold(claimEoriForm) { optionalEORI =>
                 claimEoriForm.fill(OptionalEORI(optionalEORI.setValue, optionalEORI.value))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -31,7 +31,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.{NonCustomsSubsidyAdded, NonCustomsSubsidyRemoved, NonCustomsSubsidyUpdated}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, EisSubsidyAmendmentType, SubsidyAmount, TraderRef, UndertakingRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms.ClaimAmountFormPage
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
@@ -307,6 +306,7 @@ class SubsidyController @Inject() (
               val form = journey.addClaimEori.value.fold(claimEoriForm) { optionalEORI =>
                 claimEoriForm.fill(OptionalEORI(optionalEORI.setValue, optionalEORI.value))
               }
+              println(s"Showing add claim EORI form with previous URI: $previous")
               Ok(addClaimEoriPage(form, previous)).toFuture
             }
           }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -175,8 +175,10 @@ class SubsidyController @Inject() (
       claimAmountForm
         .bindFromRequest()
         .fold(
-          formWithErrors =>
-            BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture,
+          formWithErrors => {
+            println(s"Form with errors: $formWithErrors")
+            BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture
+          },
           claimAmountEntered =>
             for {
               journey <- store.update[SubsidyJourney](_.setClaimAmount(claimAmountEntered))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -180,6 +180,8 @@ class SubsidyController @Inject() (
         .bindFromRequest()
         .fold(
           formWithErrors => {
+            println(s"Form has errors apparently - so returning bad request")
+            println(s"form with errors: $formWithErrors")
             BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture
           },
           claimAmountEntered => for {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -409,6 +409,7 @@ class SubsidyController @Inject() (
   def getCheckAnswers: Action[AnyContent] = withCDSAuthenticatedUser.async { implicit request =>
     def getEuroAmount(j: SubsidyJourney) =
       if (j.claimAmount.value.map(_.currencyCode).contains(GBP)) {
+        println(s"claim amount entered: ${j.claimAmount}")
         val res = j.convertedClaimAmountConfirmation.value
         println(s"User entered amount in GBP: Displaying $res")
         res

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -99,7 +99,6 @@ object ClaimAmountFormProvider {
     val ClaimAmountEUR = "claim-amount-eur"
   }
 
-  // TODO - share these across form providers?
   object Errors {
     val IncorrectFormat = "error.incorrectFormat"
     val Required = "error.required"

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -51,12 +51,10 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   private val allowedCurrencySymbols = CurrencyCode.values.map(_.symbol)
 
   private val claimAmountIsBelowMaximumLength = Constraint[String] { claimAmount: String =>
-    println(s"validating claim amount length: $claimAmount")
     if (cleanAmount(claimAmount).length < 17) Valid else Invalid(TooBig)
   }
 
   private val claimAmountFormatIsValid = Constraint[String] { claimAmount: String =>
-    println(s"validating claim amount format: $claimAmount")
     val amount = cleanAmount(claimAmount)
     Try(BigDecimal(amount)).fold(
       _ => Invalid(IncorrectFormat),
@@ -65,7 +63,6 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   }
 
   private val claimAmountAboveMinimumAllowedValue = Constraint[String] { claimAmount: String =>
-    println(s"validating claim amount above minimum: $claimAmount")
     val amount = cleanAmount(claimAmount)
     Try(BigDecimal(amount)).fold(
       _ => Invalid(IncorrectFormat),
@@ -75,7 +72,6 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
 
   // Verify that the user hasn't entered a currency symbol which doesn't match the currency they selected
   private val claimAmountCurrencyMatchesSelection = Constraint[ClaimAmount] { claimAmount: ClaimAmount =>
-    println(s"validating amount and currency code match: $claimAmount")
     claimAmount.amount.head match {
       case GBP.symbol if claimAmount.currencyCode != GBP => Invalid(IncorrectFormat)
       case EUR.symbol if claimAmount.currencyCode != EUR => Invalid(IncorrectFormat)
@@ -86,7 +82,6 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   }
 
   private val currencyCodeIsValid = Constraint[String] { currencyCode: String =>
-    println(s"validating currency code: $currencyCode")
     if (currencyCode.isEmpty || !CurrencyCode.namesToValuesMap.contains(currencyCode)) Invalid(IncorrectFormat)
     else Valid
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -33,7 +33,7 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
       text
         .verifying(radioButtonSelected),
     Fields.ClaimAmount ->
-      nonEmptyText
+      text
         .verifying(isClaimAmountTooBig)
         .verifying(isClaimAmountFormatCorrect)
         .verifying(isClaimAmountTooSmall)
@@ -45,32 +45,33 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
 
   private val isClaimAmountTooBig = Constraint[String] { claimAmount: String =>
     val amount = getValidClaimAmount(claimAmount)
-    if (amount.length < 17) Valid else Invalid("error.amount.tooBig")
+    if (amount.length < 17) Valid else Invalid("error.tooBig")
   }
 
   private val isClaimAmountFormatCorrect = Constraint[String] { claimAmount: String =>
     val amount = getValidClaimAmount(claimAmount)
     Try(BigDecimal(amount)).fold(
-      _ => Invalid("error.amount.incorrectFormat"),
-      amount => if (amount.scale == 2 || amount.scale == 0) Valid else Invalid("error.amount.incorrectFormat")
+      _ => Invalid("error.incorrectFormat"),
+      amount => if (amount.scale == 2 || amount.scale == 0) Valid else Invalid("error.incorrectFormat")
     )
   }
 
   private val isClaimAmountTooSmall = Constraint[String] { claimAmount: String =>
     val amount = getValidClaimAmount(claimAmount)
     Try(BigDecimal(amount)).fold(
-      _ => Invalid("error.amount.incorrectFormat"),
-      amount => if (amount > 0.01) Valid else Invalid("error.amount.tooSmall")
+      _ => Invalid("error.incorrectFormat"),
+      amount => if (amount > 0.01) Valid else Invalid("error.tooSmall")
     )
   }
 
   // TODO - can this be shared?
   // TODO - test coverage of this in provider spec?
   private val radioButtonSelected = Constraint[String] { r: String =>
+    println(s"Radio Button Selected: ${r.nonEmpty}")
 //    if (r.isEmpty) Invalid(s"error.$CurrencyCode.required")
 //    if (r.isEmpty) Invalid(s"error.currency-code.required")
 //    if (r.isEmpty) Invalid(s"claim-amount.error.currency-code.required")
-    if (r.isEmpty) Invalid(s"error.currency-code.required")
+    if (r.isEmpty) Invalid(s"currency-code.error.required")
     else Valid
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -29,7 +29,6 @@ import scala.util.Try
 
 case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
 
-  // TODO - clean this up if the apply/unapply stuff works
   override protected def mapping: Mapping[ClaimAmount] = Forms.mapping(
     Fields.CurrencyCode ->
       text
@@ -101,7 +100,6 @@ object ClaimAmountFormProvider {
 
   object Fields {
     val CurrencyCode = "currency-code"
-    val ClaimAmount = "claim-amount"
     val ClaimAmountGBP = "claim-amount-gbp"
     val ClaimAmountEUR = "claim-amount-eur"
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
-import play.api.data.Forms.{nonEmptyText, text}
+import play.api.data.Forms.text
 import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.data.{Form, Forms, Mapping}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
@@ -68,10 +68,8 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   // TODO - test coverage of this in provider spec?
   private val radioButtonSelected = Constraint[String] { r: String =>
     println(s"Radio Button Selected: ${r.nonEmpty}")
-//    if (r.isEmpty) Invalid(s"error.$CurrencyCode.required")
-//    if (r.isEmpty) Invalid(s"error.currency-code.required")
-//    if (r.isEmpty) Invalid(s"claim-amount.error.currency-code.required")
-    if (r.isEmpty) Invalid(s"currency-code.error.required")
+    // TODO - do we need to use the fieldname here?
+    if (r.isEmpty) Invalid(s"$CurrencyCode.error.required")
     else Valid
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -46,7 +46,7 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
     text
       .verifying(claimAmountIsBelowMaximumLength)
       .verifying(claimAmountFormatIsValid)
-      .verifying(claimAmountAboveMinimumAllowedValue)
+      .verifying(claimAmountAboveZero)
 
   private val allowedCurrencySymbols = CurrencyCode.values.map(_.symbol)
 
@@ -62,11 +62,11 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
     )
   }
 
-  private val claimAmountAboveMinimumAllowedValue = Constraint[String] { claimAmount: String =>
+  private val claimAmountAboveZero = Constraint[String] { claimAmount: String =>
     val amount = cleanAmount(claimAmount)
     Try(BigDecimal(amount)).fold(
       _ => Invalid(IncorrectFormat),
-      amount => if (amount > 0.01) Valid else Invalid(TooSmall)
+      amount => if (amount > 0.00) Valid else Invalid(TooSmall)
     )
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.forms
+
+import play.api.data.Forms.{bigDecimal, nonEmptyText, text}
+import play.api.data.validation.{Constraint, Invalid, Valid}
+import play.api.data.{Form, Forms, Mapping}
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimEoriFormProvider.Fields.YesNoRadioButton
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ClaimAmount
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.getValidClaimAmount
+
+import scala.util.Try
+
+class ClaimAmountFormProvider extends FormProvider[ClaimAmount] {
+
+  override protected def mapping: Mapping[ClaimAmount] = Forms.mapping(
+    Fields.CurrencyCode ->
+      text
+        .verifying(radioButtonSelected),
+    Fields.ClaimAmount ->
+      nonEmptyText
+        .verifying(isClaimAmountTooBig)
+        .verifying(isClaimAmountFormatCorrect)
+        .verifying(isClaimAmountTooSmall)
+        // TODO - temporary fudge until the code is moved out of the SubsidyJourney
+        .transform(getValidClaimAmount, identity[String])
+  )(ClaimAmount.apply)(ClaimAmount.unapply)
+
+  override def form: Form[ClaimAmount] = Form(mapping)
+
+  private val isClaimAmountTooBig = Constraint[String] { claimAmount: String =>
+    val amount = getValidClaimAmount(claimAmount)
+    if (amount.length < 17) Valid else Invalid("error.amount.tooBig")
+  }
+
+  private val isClaimAmountFormatCorrect = Constraint[String] { claimAmount: String =>
+    val amount = getValidClaimAmount(claimAmount)
+    Try(BigDecimal(amount)).fold(
+      _ => Invalid("error.amount.incorrectFormat"),
+      amount => if (amount.scale == 2 || amount.scale == 0) Valid else Invalid("error.amount.incorrectFormat")
+    )
+  }
+
+  private val isClaimAmountTooSmall = Constraint[String] { claimAmount: String =>
+    val amount = getValidClaimAmount(claimAmount)
+    Try(BigDecimal(amount)).fold(
+      _ => Invalid("error.amount.incorrectFormat"),
+      amount => if (amount > 0.01) Valid else Invalid("error.amount.tooSmall")
+    )
+  }
+
+  // TODO - can this be shared?
+  private val radioButtonSelected = Constraint[String] { r: String =>
+    if (r.isEmpty) Invalid(s"error.$YesNoRadioButton.required")
+    else Valid
+  }
+
+}
+
+object ClaimAmountFormProvider {
+  object Fields {
+    val CurrencyCode = "currency-code"
+    val ClaimAmount = "claim-amount"
+  }
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -30,7 +30,7 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   override protected def mapping: Mapping[ClaimAmount] = Forms.mapping(
     Fields.CurrencyCode ->
       text
-        .verifying(radioButtonSelected),
+        .verifying(radioButtonSelected(s"$CurrencyCode.error.required")),
     Fields.ClaimAmount ->
       // TODO - use clean amount to transform the input
       text
@@ -62,14 +62,6 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
       _ => Invalid("error.incorrectFormat"),
       amount => if (amount > 0.01) Valid else Invalid("error.tooSmall")
     )
-  }
-
-  // TODO - can this be shared?
-  // TODO - test coverage of this in provider spec?
-  private val radioButtonSelected = Constraint[String] { r: String =>
-    // TODO - do we need to use the fieldname here?
-    if (r.isEmpty) Invalid(s"$CurrencyCode.error.required")
-    else Valid
   }
 
   // Verify that the user hasn't entered a currency symbol which doesn't match the currency they selected

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.getValidC
 
 import scala.util.Try
 
-class ClaimAmountFormProvider extends FormProvider[ClaimAmount] {
+case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
 
   override protected def mapping: Mapping[ClaimAmount] = Forms.mapping(
     Fields.CurrencyCode ->

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -20,7 +20,7 @@ import play.api.data.Forms.{nonEmptyText, text}
 import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.data.{Form, Forms, Mapping}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
-import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimEoriFormProvider.Fields.YesNoRadioButton
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields.CurrencyCode
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ClaimAmount
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.getValidClaimAmount
 
@@ -65,8 +65,12 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   }
 
   // TODO - can this be shared?
+  // TODO - test coverage of this in provider spec?
   private val radioButtonSelected = Constraint[String] { r: String =>
-    if (r.isEmpty) Invalid(s"error.$YesNoRadioButton.required")
+//    if (r.isEmpty) Invalid(s"error.$CurrencyCode.required")
+//    if (r.isEmpty) Invalid(s"error.currency-code.required")
+//    if (r.isEmpty) Invalid(s"claim-amount.error.currency-code.required")
+    if (r.isEmpty) Invalid(s"error.currency-code.required")
     else Valid
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
-import play.api.data.Forms.{bigDecimal, nonEmptyText, text}
+import play.api.data.Forms.{nonEmptyText, text}
 import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.data.{Form, Forms, Mapping}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
@@ -46,7 +46,7 @@ case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[
 
   private val eoriIsPartOfUndertaking = Constraint[String] { eori: String =>
     undertaking.undertakingBusinessEntity
-      .find(_.businessEntityIdentifier.toString == getValidEori(eori))
+      .find(_.businessEntityIdentifier == getValidEori(eori))
       .map(_ => Valid)
       .getOrElse(Invalid(s"error.not-in-undertaking"))
   }
@@ -58,6 +58,7 @@ case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[
       .verifying(enteredEoriIsValid)
       .verifying(eoriIsPartOfUndertaking)
 
+  // TODO - can this be shared?
   private val radioButtonSelected = Constraint[String] { r: String =>
     if (r.isEmpty) Invalid(s"error.$YesNoRadioButton.required")
     else Valid

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
@@ -30,7 +30,7 @@ case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[
   override def form: Form[OptionalEORI] = Form(mapping)
 
   override protected def mapping: Mapping[OptionalEORI] = Forms.mapping(
-    YesNoRadioButton -> text.verifying(radioButtonSelected),
+    YesNoRadioButton -> text.verifying(radioButtonSelected(s"error.$YesNoRadioButton.required")),
     EoriNumber -> mandatoryIfEqual(YesNoRadioButton, "true", eoriNumberMapping)
   )(OptionalEORI.apply)(OptionalEORI.unapply)
 
@@ -57,11 +57,6 @@ case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[
       .transform(e => getValidEori(e), (s: String) => s.drop(2))
       .verifying(enteredEoriIsValid)
       .verifying(eoriIsPartOfUndertaking)
-
-  private val radioButtonSelected = Constraint[String] { r: String =>
-    if (r.isEmpty) Invalid(s"error.$YesNoRadioButton.required")
-    else Valid
-  }
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
@@ -58,7 +58,6 @@ case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[
       .verifying(enteredEoriIsValid)
       .verifying(eoriIsPartOfUndertaking)
 
-  // TODO - can this be shared?
   private val radioButtonSelected = Constraint[String] { r: String =>
     if (r.isEmpty) Invalid(s"error.$YesNoRadioButton.required")
     else Valid

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
@@ -16,9 +16,16 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
+import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.data.{Form, Mapping}
 
 trait FormProvider[T] {
   protected def mapping: Mapping[T]
   def form: Form[T]
+
+  def radioButtonSelected(errorMessage: String): Constraint[String] = Constraint[String] { r: String =>
+    if (r.isEmpty) Invalid(errorMessage)
+    else Valid
+  }
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
@@ -23,6 +23,7 @@ trait FormProvider[T] {
   protected def mapping: Mapping[T]
   def form: Form[T]
 
+  // TODO - is this ever triggered? (Looks like selection check is handled by the gov radio code)
   def radioButtonSelected(errorMessage: String): Constraint[String] = Constraint[String] { r: String =>
     if (r.isEmpty) Invalid(errorMessage)
     else Valid

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
@@ -23,7 +23,6 @@ trait FormProvider[T] {
   protected def mapping: Mapping[T]
   def form: Form[T]
 
-  // TODO - is this ever triggered? (Looks like selection check is handled by the gov radio code)
   def radioButtonSelected(errorMessage: String): Constraint[String] = Constraint[String] { r: String =>
     if (r.isEmpty) Invalid(errorMessage)
     else Valid

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -50,8 +50,8 @@ object ClaimAmount {
 
   def toForm(claimAmount: ClaimAmount): Option[(CurrencyCode, Option[String], Option[String])] =
     claimAmount match {
-      case ClaimAmount(GBP, amount) => Some(GBP, None, Some(amount))
-      case ClaimAmount(EUR, amount) => Some(EUR, Some(amount), None)
+      case ClaimAmount(GBP, amount) => Some((GBP, None, Some(amount)))
+      case ClaimAmount(EUR, amount) => Some((EUR, Some(amount), None))
     }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -26,6 +26,7 @@ sealed abstract class CurrencyCode(val symbol: Char) extends EnumEntry
 
 object CurrencyCode extends Enum[CurrencyCode] with PlayJsonEnum[CurrencyCode] {
 
+  // TODO - confirm that we really do need the symbols?
   case object GBP extends CurrencyCode('£')
   case object EUR extends CurrencyCode('€')
 
@@ -33,15 +34,11 @@ object CurrencyCode extends Enum[CurrencyCode] with PlayJsonEnum[CurrencyCode] {
 
 }
 
-// TODO - provide a toEuros method to do the conversion with a given exchange rate.
-// TODO - would potentially be nicer to have amount as a BigDecimal if form bindings work ok
 case class ClaimAmount(currencyCode: CurrencyCode, amount: String)
 
 object ClaimAmount {
   implicit val claimAmountFormat: OFormat[ClaimAmount] = Json.format[ClaimAmount]
 
-  // TODO - clean this up
-  //      - define as to/from form methods?
   def fromForm(currencyCode: CurrencyCode, amountEUR: Option[String], amountGBP: Option[String]): ClaimAmount =
     currencyCode match {
       case GBP => ClaimAmount(GBP, amountGBP.getOrElse(""))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.{EUR, GBP}
 
 import scala.collection.immutable
 
@@ -38,4 +39,19 @@ case class ClaimAmount(currencyCode: CurrencyCode, amount: String)
 
 object ClaimAmount {
   implicit val claimAmountFormat: OFormat[ClaimAmount] = Json.format[ClaimAmount]
+
+  // TODO - clean this up
+  //      - define as to/from form methods?
+  def fromForm(currencyCode: CurrencyCode, amountEUR: Option[String], amountGBP: Option[String]): ClaimAmount =
+    currencyCode match {
+      case GBP => ClaimAmount(GBP, amountGBP.getOrElse(""))
+      case EUR => ClaimAmount(EUR, amountEUR.getOrElse(""))
+    }
+
+  def toForm(claimAmount: ClaimAmount): Option[(CurrencyCode, Option[String], Option[String])] =
+    claimAmount match {
+      case ClaimAmount(GBP, amount) => Some(GBP, None, Some(amount))
+      case ClaimAmount(EUR, amount) => Some(EUR, Some(amount), None)
+    }
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.models
+
+// TODO - make currency code an enum
+// TODO - provide a toEuros method to do the conversion with a given exchange rate.
+// TODO - would potentially be nicer to have amount as a BigDecimal if form bindings work ok
+case class ClaimAmount(currencyCode: String, amount: String)
+

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -16,12 +16,25 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 import play.api.libs.json.{Json, OFormat}
 
-// TODO - make currency code an enum
+import scala.collection.immutable
+
+sealed abstract class CurrencyCode(val symbol: Char) extends EnumEntry
+
+object CurrencyCode extends Enum[CurrencyCode] with PlayJsonEnum[CurrencyCode] {
+
+  case object GBP extends CurrencyCode('£')
+  case object EUR extends CurrencyCode('€')
+
+  override def values: immutable.IndexedSeq[CurrencyCode] = findValues
+
+}
+
 // TODO - provide a toEuros method to do the conversion with a given exchange rate.
 // TODO - would potentially be nicer to have amount as a BigDecimal if form bindings work ok
-case class ClaimAmount(currencyCode: String, amount: String)
+case class ClaimAmount(currencyCode: CurrencyCode, amount: String)
 
 object ClaimAmount {
   implicit val claimAmountFormat: OFormat[ClaimAmount] = Json.format[ClaimAmount]

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -26,7 +26,6 @@ sealed abstract class CurrencyCode(val symbol: Char) extends EnumEntry
 
 object CurrencyCode extends Enum[CurrencyCode] with PlayJsonEnum[CurrencyCode] {
 
-  // TODO - confirm that we really do need the symbols?
   case object GBP extends CurrencyCode('£')
   case object EUR extends CurrencyCode('€')
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ClaimAmount.scala
@@ -16,8 +16,13 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
+import play.api.libs.json.{Json, OFormat}
+
 // TODO - make currency code an enum
 // TODO - provide a toEuros method to do the conversion with a given exchange rate.
 // TODO - would potentially be nicer to have amount as a BigDecimal if form bindings work ok
 case class ClaimAmount(currencyCode: String, amount: String)
 
+object ClaimAmount {
+  implicit val claimAmountFormat: OFormat[ClaimAmount] = Json.format[ClaimAmount]
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ExchangeRate.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
 import play.api.libs.json.{Json, OFormat}
 
+// TODO - introduce currency code enum here too?
 case class ExchangeRate(from: String, to: String, rate: BigDecimal)
 
 object ExchangeRate {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ExchangeRate.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/ExchangeRate.scala
@@ -18,8 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
 import play.api.libs.json.{Json, OFormat}
 
-// TODO - introduce currency code enum here too?
-case class ExchangeRate(from: String, to: String, rate: BigDecimal)
+case class ExchangeRate(from: CurrencyCode, to: CurrencyCode, rate: BigDecimal)
 
 object ExchangeRate {
   implicit val exchangeRateFormat: OFormat[ExchangeRate] = Json.format[ExchangeRate]

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -225,8 +225,7 @@ object AuditEvent {
         traderReference =
           subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
         nonHMRCSubsidyAmtEUR =
-          // TODO - amount should be big decimal
-          SubsidyAmount(subsidyJourney.claimAmount.value.map(a => BigDecimal(a.amount)).getOrElse(sys.error("claimAmount is missing"))),
+          SubsidyAmount(subsidyJourney.getClaimAmount.getOrElse(sys.error("claimAmount is missing"))),
         businessEntityIdentifier =
           subsidyJourney.addClaimEori.value.fold(sys.error("eori value missing"))(optionalEORI =>
             optionalEORI.value.map(EORI(_))
@@ -282,8 +281,7 @@ object AuditEvent {
         traderReference =
           subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
         nonHMRCSubsidyAmtEUR =
-        // TODO - amount should be big decimal
-          SubsidyAmount(subsidyJourney.claimAmount.value.map(a => BigDecimal(a.amount)).getOrElse(sys.error("claimAmount is missing"))),
+          SubsidyAmount(subsidyJourney.getClaimAmount.getOrElse(sys.error("claimAmount is missing"))),
         businessEntityIdentifier =
           subsidyJourney.addClaimEori.value.fold(sys.error("eori value missing"))(optionalEORI =>
             optionalEORI.value.map(EORI(_))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/audit/AuditEvent.scala
@@ -225,7 +225,8 @@ object AuditEvent {
         traderReference =
           subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
         nonHMRCSubsidyAmtEUR =
-          SubsidyAmount(subsidyJourney.claimAmount.value.getOrElse(sys.error("claimAmount is missing"))),
+          // TODO - amount should be big decimal
+          SubsidyAmount(subsidyJourney.claimAmount.value.map(a => BigDecimal(a.amount)).getOrElse(sys.error("claimAmount is missing"))),
         businessEntityIdentifier =
           subsidyJourney.addClaimEori.value.fold(sys.error("eori value missing"))(optionalEORI =>
             optionalEORI.value.map(EORI(_))
@@ -281,7 +282,8 @@ object AuditEvent {
         traderReference =
           subsidyJourney.traderRef.value.fold(sys.error("Trader ref missing"))(_.value.map(TraderRef(_))),
         nonHMRCSubsidyAmtEUR =
-          SubsidyAmount(subsidyJourney.claimAmount.value.getOrElse(sys.error("claimAmount is missing"))),
+        // TODO - amount should be big decimal
+          SubsidyAmount(subsidyJourney.claimAmount.value.map(a => BigDecimal(a.amount)).getOrElse(sys.error("claimAmount is missing"))),
         businessEntityIdentifier =
           subsidyJourney.addClaimEori.value.fold(sys.error("eori value missing"))(optionalEORI =>
             optionalEORI.value.map(EORI(_))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/types/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/types/package.scala
@@ -135,7 +135,7 @@ package object types extends SimpleJson {
 
   type EisSubsidyAmendmentType = String @@ EisSubsidyAmendmentType.Tag
   object EisSubsidyAmendmentType
-      extends RegexValidatedString( // TODO: consider enum
+      extends RegexValidatedString(
         regex = "1|2|3"
       )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -49,6 +49,11 @@ trait Journey {
       .find(_.value.isEmpty)
       .map(e => redirectWithSession(e.uri))
 
+  // TODO - review test coverage
+  def stepWithPath(path: String): Option[FormPage[_]] =
+    steps
+      .find(_.uri == path)
+
   def isEligibleForStep(implicit r: Request[_]): Boolean =
     if (previousIndex < 0) true
     else steps(previousIndex).value.nonEmpty

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -49,7 +49,7 @@ trait Journey {
       .find(_.value.isEmpty)
       .map(e => redirectWithSession(e.uri))
 
-  def isEligibleForStep(implicit r: Request[_]) =
+  def isEligibleForStep(implicit r: Request[_]): Boolean =
     if (previousIndex < 0) true
     else steps(previousIndex).value.nonEmpty
 
@@ -58,7 +58,7 @@ trait Journey {
   private def nextIndex(implicit r: Request[_]) = currentIndex + 1
   private def lastIndex = steps.length - 1
 
-  def redirectWithSession(u: String)(implicit r: Request[_]) = Redirect(u).withSession(r.session)
+  def redirectWithSession(u: String)(implicit r: Request[_]): Result = Redirect(u).withSession(r.session)
 }
 
 object Journey {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -26,6 +26,8 @@ import scala.concurrent.Future
 trait FormPage[+T] {
   val value: Journey.Form[T]
   def uri: Uri
+
+  def isCurrentPage(implicit r: Request[_]): Boolean = r.uri == uri
 }
 
 trait Journey {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -49,7 +49,6 @@ trait Journey {
       .find(_.value.isEmpty)
       .map(e => redirectWithSession(e.uri))
 
-  // TODO - review test coverage
   def getStepWithPath(path: String): Option[FormPage[_]] =
     steps
       .find(_.uri == path)

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/Journey.scala
@@ -50,7 +50,7 @@ trait Journey {
       .map(e => redirectWithSession(e.uri))
 
   // TODO - review test coverage
-  def stepWithPath(path: String): Option[FormPage[_]] =
+  def getStepWithPath(path: String): Option[FormPage[_]] =
     steps
       .find(_.uri == path)
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyTraverseService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyTraverseService.scala
@@ -28,15 +28,14 @@ import scala.reflect.ClassTag
 @Singleton
 class JourneyTraverseService @Inject() (store: Store)(implicit ec: ExecutionContext) {
 
-  // TODO - this just calls previous on the subsidy journey - is it really necessary?
-  def getPrevious[A <: Journey : ClassTag](implicit
-    eori: EORI,
+  def getPrevious[A <: Journey : ClassTag](
+    implicit eori: EORI,
     request: Request[_],
-    reads: Reads[A]
+    reads: Reads[A],
   ): Future[Uri] = {
     val journeyType: Uri = implicitly[ClassTag[A]].runtimeClass.getSimpleName
     store.get[A].map { opt =>
-      opt.fold(throw new IllegalStateException(s"$journeyType should be there")) { value =>
+      opt.fold(throw new IllegalStateException(s"$journeyType is not present")) { value =>
         value.previous
       }
     }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyTraverseService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/JourneyTraverseService.scala
@@ -28,6 +28,7 @@ import scala.reflect.ClassTag
 @Singleton
 class JourneyTraverseService @Inject() (store: Store)(implicit ec: ExecutionContext) {
 
+  // TODO - this just calls previous on the subsidy journey - is it really necessary?
   def getPrevious[A <: Journey : ClassTag](implicit
     eori: EORI,
     request: Request[_],

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -71,22 +71,9 @@ case class SubsidyJourney(
 
 }
 
-// TODO - move amount parsing and validation into form provider
 object SubsidyJourney {
 
   implicit val format: Format[SubsidyJourney] = Json.format[SubsidyJourney]
-
-  // TODO - move and refactor these checks - just getting things working first
-  def isClaimAmountPrefixEuros(amountEntered: String) = amountEntered.take(1) == "€"
-  def isClaimAmountPrefixPounds(amountEntered: String) = amountEntered.take(1) == "£"
-
-
-  def trimAmount(amount: String) = amount.trim.replaceAll(",", "").replaceAll("\\s", "")
-
-  def getValidClaimAmount(amountEntered: String) =
-    if (isClaimAmountPrefixEuros(amountEntered) || isClaimAmountPrefixPounds(amountEntered))
-      trimAmount(amountEntered.drop(1))
-    else trimAmount(amountEntered)
 
   def fromNonHmrcSubsidy(nonHmrcSubsidy: NonHmrcSubsidy): SubsidyJourney =
     SubsidyJourney(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -77,6 +77,11 @@ case class SubsidyJourney(
     else super.previous
   }
 
+  // TODO - explicit test coverage for this
+  override def isEligibleForStep(implicit r: Request[_]): Boolean =
+    if (addClaimEori.isCurrentPage && shouldSkipCurrencyConversion) claimAmount.value.isDefined
+    else super.isEligibleForStep
+
   // When navigating back or forward we should skip the currency conversion step if the user has already entered a
   // claim amount in Euros.
   private def shouldSkipCurrencyConversion(implicit r: Request[_]): Boolean =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 
 import scala.concurrent.Future
 
+// TODO - add in a page for the confirmation step
 case class SubsidyJourney(
   reportPayment: ReportPaymentFormPage = ReportPaymentFormPage(),
   claimDate: ClaimDateFormPage = ClaimDateFormPage(),
@@ -53,6 +54,7 @@ case class SubsidyJourney(
 
   def isAmend: Boolean = existingTransactionId.nonEmpty
 
+  // TODO - possible for this to handle the GBP confirmation step logic?
   override def next(implicit r: Request[_]): Future[Result] =
     if (isAmend) Redirect(routes.SubsidyController.getCheckAnswers()).toFuture
     else super.next

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -106,6 +106,11 @@ case class SubsidyJourney(
   def setTraderRef(o: OptionalTraderRef): SubsidyJourney = this.copy(traderRef = traderRef.copy(o.some))
   def setCya(v: Boolean): SubsidyJourney = this.copy(cya = cya.copy(v.some))
 
+  def getClaimAmount: Option[BigDecimal] =
+    claimAmount
+      .value
+      .map(a => BigDecimal(a.amount))
+
 }
 
 object SubsidyJourney {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -21,6 +21,7 @@ import play.api.libs.json._
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.EUR
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyRef, TraderRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ClaimAmount, DateFormValues, NonHmrcSubsidy, OptionalEORI, OptionalTraderRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
@@ -79,7 +80,7 @@ object SubsidyJourney {
     SubsidyJourney(
       reportPayment = ReportPaymentFormPage(true.some),
       claimDate = ClaimDateFormPage(DateFormValues.fromDate(nonHmrcSubsidy.allocationDate).some),
-      claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", nonHmrcSubsidy.nonHMRCSubsidyAmtEUR.toString()).some),
+      claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, nonHmrcSubsidy.nonHMRCSubsidyAmtEUR.toString()).some),
       addClaimEori = AddClaimEoriFormPage(getAddClaimEORI(nonHmrcSubsidy.businessEntityIdentifier).some),
       publicAuthority = PublicAuthorityFormPage(nonHmrcSubsidy.publicAuthority.orElse("".some)),
       traderRef = TraderRefFormPage(getAddTraderRef(nonHmrcSubsidy.traderReference).some),

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -71,18 +71,22 @@ case class SubsidyJourney(
 
 }
 
+// TODO - move amount parsing and validation into form provider
 object SubsidyJourney {
 
   implicit val format: Format[SubsidyJourney] = Json.format[SubsidyJourney]
 
-  val claimAmountPrefix = "€"
+  // TODO - move and refactor these checks - just getting things working first
+  def isClaimAmountPrefixEuros(amountEntered: String) = amountEntered.take(1) == "€"
+  def isClaimAmountPrefixPounds(amountEntered: String) = amountEntered.take(1) == "£"
 
-  def isClaimAmountPrefixEuros(amountEntered: String) = amountEntered.take(1) === claimAmountPrefix
 
   def trimAmount(amount: String) = amount.trim.replaceAll(",", "").replaceAll("\\s", "")
 
   def getValidClaimAmount(amountEntered: String) =
-    if (isClaimAmountPrefixEuros(amountEntered)) trimAmount(amountEntered.drop(1)) else trimAmount(amountEntered)
+    if (isClaimAmountPrefixEuros(amountEntered) || isClaimAmountPrefixPounds(amountEntered))
+      trimAmount(amountEntered.drop(1))
+    else trimAmount(amountEntered)
 
   def fromNonHmrcSubsidy(nonHmrcSubsidy: NonHmrcSubsidy): SubsidyJourney =
     SubsidyJourney(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -30,11 +30,11 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 
 import scala.concurrent.Future
 
-// TODO - add in a page for the confirmation step
 case class SubsidyJourney(
   reportPayment: ReportPaymentFormPage = ReportPaymentFormPage(),
   claimDate: ClaimDateFormPage = ClaimDateFormPage(),
   claimAmount: ClaimAmountFormPage = ClaimAmountFormPage(),
+  convertedClaimAmountConfirmation: ConvertedClaimAmountConfirmationPage = ConvertedClaimAmountConfirmationPage(),
   addClaimEori: AddClaimEoriFormPage = AddClaimEoriFormPage(),
   publicAuthority: PublicAuthorityFormPage = PublicAuthorityFormPage(),
   traderRef: TraderRefFormPage = TraderRefFormPage(),
@@ -46,6 +46,7 @@ case class SubsidyJourney(
     reportPayment,
     claimDate,
     claimAmount,
+    convertedClaimAmountConfirmation,
     addClaimEori,
     publicAuthority,
     traderRef,
@@ -54,7 +55,6 @@ case class SubsidyJourney(
 
   def isAmend: Boolean = existingTransactionId.nonEmpty
 
-  // TODO - possible for this to handle the GBP confirmation step logic?
   override def next(implicit r: Request[_]): Future[Result] =
     if (isAmend) Redirect(routes.SubsidyController.getCheckAnswers()).toFuture
     else super.next
@@ -66,6 +66,8 @@ case class SubsidyJourney(
 
   def setReportPayment(v: Boolean): SubsidyJourney = this.copy(reportPayment = reportPayment.copy(value = v.some))
   def setClaimAmount(c: ClaimAmount): SubsidyJourney = this.copy(claimAmount = claimAmount.copy(value = c.some))
+  def setConvertedClaimAmount(c: ClaimAmount): SubsidyJourney =
+    this.copy(convertedClaimAmountConfirmation = convertedClaimAmountConfirmation.copy(value = c.some))
   def setClaimDate(d: DateFormValues): SubsidyJourney = this.copy(claimDate = claimDate.copy(value = d.some))
   def setClaimEori(oe: OptionalEORI): SubsidyJourney = this.copy(addClaimEori = addClaimEori.copy(oe.some))
   def setPublicAuthority(a: String): SubsidyJourney = this.copy(publicAuthority = publicAuthority.copy(a.some))
@@ -108,6 +110,9 @@ object SubsidyJourney {
     case class ClaimAmountFormPage(value: Form[ClaimAmount] = None) extends FormPage[ClaimAmount] {
       def uri = controller.getClaimAmount().url
     }
+    case class ConvertedClaimAmountConfirmationPage(value: Form[ClaimAmount] = None) extends FormPage[ClaimAmount] {
+      def uri = controller.getConfirmClaimAmount().url
+    }
     case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPage[OptionalEORI] {
       def uri = controller.getAddClaimEori().url
     }
@@ -126,6 +131,7 @@ object SubsidyJourney {
     }
     object ClaimDateFormPage { implicit val claimDateFormPageFormat: OFormat[ClaimDateFormPage] = Json.format }
     object ClaimAmountFormPage { implicit val claimAmountFormPageFormat: OFormat[ClaimAmountFormPage] = Json.format }
+    object ConvertedClaimAmountConfirmationPage { implicit val convertedClaimAmountConfirmationPageFormat: OFormat[ConvertedClaimAmountConfirmationPage] = Json.format }
     object AddClaimEoriFormPage { implicit val claimAmountFormPageFormat: OFormat[AddClaimEoriFormPage] = Json.format }
     object PublicAuthorityFormPage {
       implicit val claimAmountFormPageFormat: OFormat[PublicAuthorityFormPage] = Json.format

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -53,11 +53,23 @@ case class SubsidyJourney(
     cya
   )
 
-  def isAmend: Boolean = existingTransactionId.nonEmpty
+  def isAmend: Boolean = {
+    println(s"isAmend: ${existingTransactionId.nonEmpty}")
+    existingTransactionId.nonEmpty
+  }
 
+  // TODO - review this and simplify where possible
   override def next(implicit r: Request[_]): Future[Result] =
-    if (isAmend) {
-      println(s"on amend joureny - redirecting to check answers page")
+    if (isAmend && shouldSkipCurrencyConversion) {
+      println(s"on amend journey - redirecting to check answers page")
+      Redirect(routes.SubsidyController.getCheckAnswers()).toFuture
+    }
+    else if (isAmend && claimAmount.isCurrentPage && !shouldSkipCurrencyConversion) {
+      println(s"SubsidyJourney: user has entered GBP amount on amend journey - redirecting to confirmation page")
+      Redirect(routes.SubsidyController.getConfirmClaimAmount()).toFuture
+    }
+    else if (isAmend && convertedClaimAmountConfirmation.isCurrentPage) {
+      println(s"SubsidyJourney - user has confirmed GBP-EUR conversion on amend - redirecting to check answers")
       Redirect(routes.SubsidyController.getCheckAnswers()).toFuture
     }
     else if (claimAmount.isCurrentPage && shouldSkipCurrencyConversion) {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
-import cats.implicits.{catsSyntaxEq, catsSyntaxOptionId}
+import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json._
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -22,7 +22,7 @@ import play.api.mvc.Results.Redirect
 import play.api.mvc.{Request, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, SubsidyRef, TraderRef}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{DateFormValues, NonHmrcSubsidy, OptionalEORI, OptionalTraderRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ClaimAmount, DateFormValues, NonHmrcSubsidy, OptionalEORI, OptionalTraderRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
@@ -62,7 +62,7 @@ case class SubsidyJourney(
   else super.previous
 
   def setReportPayment(v: Boolean): SubsidyJourney = this.copy(reportPayment = reportPayment.copy(value = v.some))
-  def setClaimAmount(b: BigDecimal): SubsidyJourney = this.copy(claimAmount = claimAmount.copy(value = b.some))
+  def setClaimAmount(c: ClaimAmount): SubsidyJourney = this.copy(claimAmount = claimAmount.copy(value = c.some))
   def setClaimDate(d: DateFormValues): SubsidyJourney = this.copy(claimDate = claimDate.copy(value = d.some))
   def setClaimEori(oe: OptionalEORI): SubsidyJourney = this.copy(addClaimEori = addClaimEori.copy(oe.some))
   def setPublicAuthority(a: String): SubsidyJourney = this.copy(publicAuthority = publicAuthority.copy(a.some))
@@ -92,7 +92,7 @@ object SubsidyJourney {
     SubsidyJourney(
       reportPayment = ReportPaymentFormPage(true.some),
       claimDate = ClaimDateFormPage(DateFormValues.fromDate(nonHmrcSubsidy.allocationDate).some),
-      claimAmount = ClaimAmountFormPage(nonHmrcSubsidy.nonHMRCSubsidyAmtEUR.some),
+      claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", nonHmrcSubsidy.nonHMRCSubsidyAmtEUR.toString()).some),
       addClaimEori = AddClaimEoriFormPage(getAddClaimEORI(nonHmrcSubsidy.businessEntityIdentifier).some),
       publicAuthority = PublicAuthorityFormPage(nonHmrcSubsidy.publicAuthority.orElse("".some)),
       traderRef = TraderRefFormPage(getAddTraderRef(nonHmrcSubsidy.traderReference).some),
@@ -115,7 +115,7 @@ object SubsidyJourney {
     case class ClaimDateFormPage(value: Form[DateFormValues] = None) extends FormPage[DateFormValues] {
       def uri = controller.getClaimDate().url
     }
-    case class ClaimAmountFormPage(value: Form[BigDecimal] = None) extends FormPage[BigDecimal] {
+    case class ClaimAmountFormPage(value: Form[ClaimAmount] = None) extends FormPage[ClaimAmount] {
       def uri = controller.getClaimAmount().url
     }
     case class AddClaimEoriFormPage(value: Form[OptionalEORI] = None) extends FormPage[OptionalEORI] {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -56,11 +56,18 @@ case class SubsidyJourney(
   def isAmend: Boolean = existingTransactionId.nonEmpty
 
   override def next(implicit r: Request[_]): Future[Result] =
-    if (isAmend)
+    if (isAmend) {
+      println(s"on amend joureny - redirecting to check answers page")
       Redirect(routes.SubsidyController.getCheckAnswers()).toFuture
-    else if (claimAmount.isCurrentPage && shouldSkipCurrencyConversion)
+    }
+    else if (claimAmount.isCurrentPage && shouldSkipCurrencyConversion) {
+      println(s"user submitted an EUR claim amount - skipping exchange rate")
       Redirect(routes.SubsidyController.getAddClaimEori()).toFuture
-    else super.next
+    }
+    else {
+      println(s"no special behaviour needed - deferring to standard next method")
+      super.next
+    }
 
   override def previous(implicit request: Request[_]): Journey.Uri = {
     if (reportPayment.isCurrentPage)
@@ -95,6 +102,7 @@ object SubsidyJourney {
     SubsidyJourney(
       reportPayment = ReportPaymentFormPage(true.some),
       claimDate = ClaimDateFormPage(DateFormValues.fromDate(nonHmrcSubsidy.allocationDate).some),
+      // TODO - review usage here - need to check claim amount is populated correctly for GBP and EUR cases
       claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, nonHmrcSubsidy.nonHMRCSubsidyAmtEUR.toString()).some),
       addClaimEori = AddClaimEoriFormPage(getAddClaimEORI(nonHmrcSubsidy.businessEntityIdentifier).some),
       publicAuthority = PublicAuthorityFormPage(nonHmrcSubsidy.publicAuthority.orElse("".some)),

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -121,7 +121,6 @@ object SubsidyJourney {
     SubsidyJourney(
       reportPayment = ReportPaymentFormPage(true.some),
       claimDate = ClaimDateFormPage(DateFormValues.fromDate(nonHmrcSubsidy.allocationDate).some),
-      // TODO - review usage here - need to check claim amount is populated correctly for GBP and EUR cases
       claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, nonHmrcSubsidy.nonHMRCSubsidyAmtEUR.toString()).some),
       addClaimEori = AddClaimEoriFormPage(getAddClaimEORI(nonHmrcSubsidy.businessEntityIdentifier).some),
       publicAuthority = PublicAuthorityFormPage(nonHmrcSubsidy.publicAuthority.orElse("".some)),

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourney.scala
@@ -93,8 +93,7 @@ case class SubsidyJourney(
 
   // When navigating back or forward we should skip the currency conversion step if the user has already entered a
   // claim amount in Euros.
-  private def shouldSkipCurrencyConversion: Boolean =
-    claimAmount.value.map(_.currencyCode).contains(EUR)
+  private def shouldSkipCurrencyConversion: Boolean = claimAmountInEuros
 
   def setReportPayment(v: Boolean): SubsidyJourney = this.copy(reportPayment = reportPayment.copy(value = v.some))
   def setClaimAmount(c: ClaimAmount): SubsidyJourney = this.copy(claimAmount = claimAmount.copy(value = c.some))
@@ -106,11 +105,12 @@ case class SubsidyJourney(
   def setTraderRef(o: OptionalTraderRef): SubsidyJourney = this.copy(traderRef = traderRef.copy(o.some))
   def setCya(v: Boolean): SubsidyJourney = this.copy(cya = cya.copy(v.some))
 
-  def getClaimAmount: Option[BigDecimal] =
-    claimAmount
-      .value
-      .map(a => BigDecimal(a.amount))
+  def getClaimAmount: Option[BigDecimal] = claimAmountToBigDecimal(claimAmount)
+  def getConvertedClaimAmount: Option[BigDecimal] = claimAmountToBigDecimal(convertedClaimAmountConfirmation)
 
+  def claimAmountInEuros: Boolean = claimAmount.value.map(_.currencyCode).contains(EUR)
+
+  private def claimAmountToBigDecimal(f: FormPage[ClaimAmount]) = f.value.map(a => BigDecimal(a.amount))
 }
 
 object SubsidyJourney {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -21,7 +21,7 @@
 
 
 @this(
-  layout: Layout,
+  layout: FullWidthLayout,
   formHelper: FormWithCSRF,
   button: components.Button,
   govukErrorSummary: GovukErrorSummary,
@@ -102,7 +102,6 @@
                 isPageHeading = true
             ))
         )),
-        hint = Some(Hint(content = Text(messages("add-claim-amount.hint")))),
         errorMessage = if (form.hasErrors && form.errors.head.key == radioIdentifier) {
             Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
         } else None,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -41,7 +41,7 @@
 @eurInputHtml = {
     @govukInput(Input(
         id = inputIdentifier,
-        name = inputIdentifier,
+        name = "claim-amount-eur",
         prefix = Some(PrefixOrSuffix(content = Text("€"))),
         errorMessage = if (form.data.get(radioIdentifier).contains("EUR") && form.hasErrors && form.errors.head.key == inputIdentifier) {
             Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
@@ -56,7 +56,7 @@
 @gbpInputHtml = {
     @govukInput(Input(
         id = inputIdentifier,
-        name = inputIdentifier,
+        name = "claim-amount-gbp",
         prefix = Some(PrefixOrSuffix(content = Text("£"))),
         errorMessage = if (form.data.get(radioIdentifier).contains("GBP") && form.hasErrors && form.errors.head.key == inputIdentifier) {
             Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -44,7 +44,7 @@
         name = inputIdentifier,
         prefix = Some(PrefixOrSuffix(content = Text("€"))),
         errorMessage = if (form.hasErrors && form.errors.head.key == inputIdentifier) {
-            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}")))
+            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.message}")}")))
         } else None,
         value = form.data.get(inputIdentifier),
         label = Label(content = Text(messages("add-claim-amount.input-label"))),
@@ -59,7 +59,7 @@
         name = inputIdentifier,
         prefix = Some(PrefixOrSuffix(content = Text("£"))),
         errorMessage = if (form.hasErrors && form.errors.head.key == inputIdentifier) {
-            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}")))
+            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.message}")}")))
         } else None,
         value = form.data.get(inputIdentifier),
         label = Label(content = Text(messages("add-claim-amount.input-label"))),
@@ -103,7 +103,7 @@
         )),
         hint = Some(Hint(content = Text(messages("add-claim-amount.hint")))),
         errorMessage = if (form.hasErrors && form.errors.head.key == radioIdentifier) {
-            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}")))
+            Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.message}")}")))
         } else None,
         name = radioIdentifier,
         items = Seq(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -36,7 +36,7 @@
 @title = @{messages(s"$key.title")}
 
 @radioIdentifier = @{"currency-code"}
-@inputIdentifier = @{"currency-amount"}
+@inputIdentifier = @{"claim-amount"}
 
 @eurInputHtml = {
     @govukInput(Input(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -36,17 +36,18 @@
 @title = @{messages(s"$key.title")}
 
 @radioIdentifier = @{"currency-code"}
-@inputIdentifier = @{"claim-amount"}
+@inputIdentifierEUR = @{"claim-amount-eur"}
+@inputIdentifierGBP = @{"claim-amount-gbp"}
 
 @eurInputHtml = {
     @govukInput(Input(
-        id = inputIdentifier,
-        name = "claim-amount-eur",
+        id = inputIdentifierEUR,
+        name = inputIdentifierEUR,
         prefix = Some(PrefixOrSuffix(content = Text("€"))),
-        errorMessage = if (form.data.get(radioIdentifier).contains("EUR") && form.hasErrors && form.errors.head.key == inputIdentifier) {
+        errorMessage = if (form.data.get(radioIdentifier).contains("EUR") && form.hasErrors && form.errors.head.key == inputIdentifierEUR) {
             Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
         } else None,
-        value = if (form.data.get(radioIdentifier).contains("EUR")) form.data.get(inputIdentifier) else None,
+        value = if (form.data.get(radioIdentifier).contains("EUR")) form.data.get(inputIdentifierEUR) else None,
         label = Label(content = Text(messages("add-claim-amount.input-label"))),
         hint = Some(Hint(content = Text(messages("add-claim-amount.input-hint")))),
         classes = "govuk-input govuk-input--width-20"
@@ -55,13 +56,13 @@
 
 @gbpInputHtml = {
     @govukInput(Input(
-        id = inputIdentifier,
-        name = "claim-amount-gbp",
+        id = inputIdentifierGBP,
+        name = inputIdentifierGBP,
         prefix = Some(PrefixOrSuffix(content = Text("£"))),
-        errorMessage = if (form.data.get(radioIdentifier).contains("GBP") && form.hasErrors && form.errors.head.key == inputIdentifier) {
+        errorMessage = if (form.data.get(radioIdentifier).contains("GBP") && form.hasErrors && form.errors.head.key == inputIdentifierGBP) {
             Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
         } else None,
-        value = if (form.data.get(radioIdentifier).contains("GBP")) form.data.get(inputIdentifier) else None,
+        value = if (form.data.get(radioIdentifier).contains("GBP")) form.data.get(inputIdentifierGBP) else None,
         label = Label(content = Text(messages("add-claim-amount.input-label"))),
         hint = Some(Hint(content = Text(messages("add-claim-amount.input-hint")))),
         classes = "govuk-input govuk-input--width-20"

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey
 @import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.{H1, P}
 
+
 @this(
   layout: Layout,
   formHelper: FormWithCSRF,
@@ -29,9 +30,44 @@
   govukInsetText : GovukInsetText
 )
 
+
 @(form: Form[_], previous: Journey.Uri, currentYear: String, currentMonth: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 @key = @{"add-claim-amount"}
 @title = @{messages(s"$key.title")}
+
+@radioIdentifier = @{"currency-code"}
+@inputIdentifier = @{"currency-amount"}
+
+@eurInputHtml = {
+    @govukInput(Input(
+        id = inputIdentifier,
+        name = inputIdentifier,
+        prefix = Some(PrefixOrSuffix(content = Text("€"))),
+        errorMessage = if (form.hasErrors && form.errors.head.key == inputIdentifier) {
+            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}")))
+        } else None,
+        value = form.data.get(inputIdentifier),
+        label = Label(content = Text(messages("add-claim-amount.input-label"))),
+        hint = Some(Hint(content = Text(messages("add-claim-amount.input-hint")))),
+        classes = "govuk-input govuk-input--width-20"
+    ))
+}
+
+@gbpInputHtml = {
+    @govukInput(Input(
+        id = inputIdentifier,
+        name = inputIdentifier,
+        prefix = Some(PrefixOrSuffix(content = Text("£"))),
+        errorMessage = if (form.hasErrors && form.errors.head.key == inputIdentifier) {
+            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}")))
+        } else None,
+        value = form.data.get(inputIdentifier),
+        label = Label(content = Text(messages("add-claim-amount.input-label"))),
+        hint = Some(Hint(content = Text(messages("add-claim-amount.input-hint")))),
+        classes = "govuk-input govuk-input--width-20"
+    ))
+}
+
 @layout(
   pageTitle = Some(title),
   backLinkEnabled = true,
@@ -54,40 +90,38 @@
     )
   }
 
+
   @formHelper(action = controllers.routes.SubsidyController.postAddClaimAmount()) {
 
-    @H1(messages("add-claim-amount.title"))
-      @P(messages("add-claim-amount.p1"))
-      @govukInsetText(InsetText(
-          content = Text(messages("add-claim-amount.inset"))))
-    @P(messages("add-claim-amount.p2"))
-      <ul class="govuk-list govuk-list--number">
-          <li>@Html(messages(s"$key.l1", appConfig.exchangeRateToolUrl))</li>
-          <li>@{messages(s"$key.l2",currentYear, currentMonth)}</li>
-          <li>@{messages(s"$key.l3")}</li>
-          <li>@{messages(s"$key.l4")}</li>
-          <li>@{messages(s"$key.l5")}</li>
-      </ul>
-
-    @govukInput(Input(
-      id = "claim-amount",
-      name = "claim-amount",
-      prefix = Some(PrefixOrSuffix(content = Text("€"))),
-      value = form.data.get("claim-amount"),
-      errorMessage = if (form.hasErrors) {
-          Some(ErrorMessage(content = Text(messages(s"$key.${form.errors.head.message}" ))))
-      } else None,
-      hint = Some(Hint(
-        content = Text(messages("add-claim-amount.hint"))
-      )),
-      label = Label(
-        classes = "govuk-visually-hidden",
-        isPageHeading = false,
-        content = Text(title)
-      ),
-      classes = "govuk-input--width-5"
-    ))
+    @govukRadios(Radios(
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(title),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            ))
+        )),
+        hint = Some(Hint(content = Text(messages("add-claim-amount.hint")))),
+        errorMessage = if (form.hasErrors && form.errors.head.key == radioIdentifier) {
+            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}")))
+        } else None,
+        name = radioIdentifier,
+        items = Seq(
+            RadioItem(
+                content = Text(messages("add-claim-amount.eur")),
+                value = Some("EUR"),
+                checked = form.data.get(radioIdentifier).contains("radioIdentifier"),
+                conditionalHtml = Some(eurInputHtml)
+            ),
+            RadioItem(
+                content = Text(messages("add-claim-amount.gbp")),
+                checked = form.data.get(radioIdentifier).contains("radioIdentifier"),
+                value = Some("GBP"),
+                conditionalHtml = Some(gbpInputHtml)
+            ))
+        ))
 
     @button("common.continue")
-  }
+
+    }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/AddClaimAmountPage.scala.html
@@ -43,10 +43,10 @@
         id = inputIdentifier,
         name = inputIdentifier,
         prefix = Some(PrefixOrSuffix(content = Text("€"))),
-        errorMessage = if (form.hasErrors && form.errors.head.key == inputIdentifier) {
-            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.message}")}")))
+        errorMessage = if (form.data.get(radioIdentifier).contains("EUR") && form.hasErrors && form.errors.head.key == inputIdentifier) {
+            Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
         } else None,
-        value = form.data.get(inputIdentifier),
+        value = if (form.data.get(radioIdentifier).contains("EUR")) form.data.get(inputIdentifier) else None,
         label = Label(content = Text(messages("add-claim-amount.input-label"))),
         hint = Some(Hint(content = Text(messages("add-claim-amount.input-hint")))),
         classes = "govuk-input govuk-input--width-20"
@@ -58,10 +58,10 @@
         id = inputIdentifier,
         name = inputIdentifier,
         prefix = Some(PrefixOrSuffix(content = Text("£"))),
-        errorMessage = if (form.hasErrors && form.errors.head.key == inputIdentifier) {
-            Some(ErrorMessage(content = Text(s"${messages(s"${form.errors.head.message}")}")))
+        errorMessage = if (form.data.get(radioIdentifier).contains("GBP") && form.hasErrors && form.errors.head.key == inputIdentifier) {
+            Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
         } else None,
-        value = form.data.get(inputIdentifier),
+        value = if (form.data.get(radioIdentifier).contains("GBP")) form.data.get(inputIdentifier) else None,
         label = Label(content = Text(messages("add-claim-amount.input-label"))),
         hint = Some(Hint(content = Text(messages("add-claim-amount.input-hint")))),
         classes = "govuk-input govuk-input--width-20"
@@ -81,7 +81,7 @@
           errorList = Seq(
               ErrorLink(
                   href = Some(s"#${form.errors.head.key}"),
-                  content = Text(s"${messages(s"$key.${form.errors.head.message}")}"),
+                  content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}"),
                   attributes = Map("class" ->"govuk-link")
               )
           ),
@@ -103,25 +103,25 @@
         )),
         hint = Some(Hint(content = Text(messages("add-claim-amount.hint")))),
         errorMessage = if (form.hasErrors && form.errors.head.key == radioIdentifier) {
-            Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.message}")}")))
+            Some(ErrorMessage(content = Text(s"${messages(s"$key.${form.errors.head.key}.${form.errors.head.message}")}")))
         } else None,
         name = radioIdentifier,
         items = Seq(
             RadioItem(
                 content = Text(messages("add-claim-amount.eur")),
                 value = Some("EUR"),
-                checked = form.data.get(radioIdentifier).contains("radioIdentifier"),
+                checked = form.data.get(radioIdentifier).contains("EUR"),
                 conditionalHtml = Some(eurInputHtml)
             ),
             RadioItem(
                 content = Text(messages("add-claim-amount.gbp")),
-                checked = form.data.get(radioIdentifier).contains("radioIdentifier"),
+                checked = form.data.get(radioIdentifier).contains("GBP"),
                 value = Some("GBP"),
                 conditionalHtml = Some(gbpInputHtml)
             ))
         ))
 
-    @button("common.continue")
+        @button("common.continue")
 
     }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
@@ -14,11 +14,16 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 @import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 @import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey
 @import uk.gov.hmrc.govukfrontend.views.html.components.Text
 
-@this(layout: Layout)
+@this(
+    layout: Layout,
+    formHelper: FormWithCSRF,
+    button: components.Button
+)
 
 @(previous: Journey.Uri, poundsAmount: String, eurosAmount: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
@@ -26,6 +31,11 @@
  pageTitle = Some(messages("confirm-converted-amount.title")),
  backLinkEnabled = true,
 ) {
+
     <h1 class="govuk-heading-xl">@messages("confirm-converted-amount.title")</h1>
     <p class="govuk-body">@messages("confirm-converted-amount.p1", poundsAmount, eurosAmount)</p>
+
+    @formHelper(action = controllers.routes.SubsidyController.postConfirmClaimAmount) {
+        @button("common.continue")
+    }
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
@@ -18,9 +18,10 @@
 @import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 @import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey
 @import uk.gov.hmrc.govukfrontend.views.html.components.Text
+@import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.{H1, P}
 
 @this(
-    layout: Layout,
+    layout: FullWidthLayout,
     formHelper: FormWithCSRF,
     button: components.Button
 )
@@ -33,10 +34,13 @@
     backLink = Some(previous)
 ) {
 
-    <h1 class="govuk-heading-xl">@messages("confirm-converted-amount.title")</h1>
-    <p class="govuk-body">@messages("confirm-converted-amount.p1", poundsAmount, eurosAmount)</p>
+    @H1(messages("confirm-converted-amount.title"))
+
+    @P(messages("confirm-converted-amount.p1", poundsAmount, eurosAmount))
+    @P(messages("confirm-converted-amount.p2"))
 
     @formHelper(action = controllers.routes.SubsidyController.postConfirmClaimAmount) {
         @button("common.continue")
     }
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
@@ -28,8 +28,9 @@
 @(previous: Journey.Uri, poundsAmount: String, eurosAmount: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @layout(
- pageTitle = Some(messages("confirm-converted-amount.title")),
- backLinkEnabled = true,
+    pageTitle = Some(messages("confirm-converted-amount.title")),
+    backLinkEnabled = true,
+    backLink = Some(previous)
 ) {
 
     <h1 class="govuk-heading-xl">@messages("confirm-converted-amount.title")</h1>

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
@@ -14,14 +14,18 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.Text
 @import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+@import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey
+@import uk.gov.hmrc.govukfrontend.views.html.components.Text
 
 @this(layout: Layout)
 
-@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(previous: Journey.Uri, poundsAmount: String, eurosAmount: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
-@layout(pageTitle = Some("title")) {
-    <h1 class="govuk-heading-xl">Temp Converted Amount Page</h1>
-    <p class="govuk-body">TODO - show the converted GBP -> EUR amount</p>
+@layout(
+ pageTitle = Some(messages("confirm-converted-amount.title")),
+ backLinkEnabled = true,
+) {
+    <h1 class="govuk-heading-xl">@messages("confirm-converted-amount.title")</h1>
+    <p class="govuk-body">@messages("confirm-converted-amount.p1", poundsAmount, eurosAmount)</p>
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmClaimAmountConversionToEuros.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.govukfrontend.views.html.components.Text
+@import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+
+@this(layout: Layout)
+
+@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@layout(pageTitle = Some("title")) {
+    <h1 class="govuk-heading-xl">Temp Converted Amount Page</h1>
+    <p class="govuk-body">TODO - show the converted GBP -> EUR amount</p>
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmationPage.scala.html
@@ -19,8 +19,6 @@
 @import uk.gov.hmrc.eusubsidycompliancefrontend.models.types._
 @import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.helpers.{H1, H2, P}
 
-
-
 @this(
     layout: Layout,
     formHelper: FormWithCSRF,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
@@ -38,7 +38,6 @@ object BigDecimalFormatter {
 
   private def roundingMode = RoundingMode.DOWN
 
-  // TODO - test coverage of the rounding mode
   def toEuros(amount: BigDecimal): String = eurFormatter.format(amount.setScale(2, roundingMode))
   def toPounds(amount: BigDecimal): String = gbpFormatter.format(amount.setScale(2, roundingMode))
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
@@ -38,11 +38,13 @@ object BigDecimalFormatter {
 
   private def roundingMode = RoundingMode.DOWN
 
-  def toEuros(amount: BigDecimal): String = eurFormatter.format(amount.setScale(2, roundingMode))
-  def toPounds(amount: BigDecimal): String = gbpFormatter.format(amount.setScale(2, roundingMode))
+  def toRoundedAmount(amount: BigDecimal): BigDecimal = amount.setScale(2, roundingMode)
+  def toEuros(amount: BigDecimal): String = eurFormatter.format(toRoundedAmount(amount))
+  def toPounds(amount: BigDecimal): String = gbpFormatter.format(toRoundedAmount(amount))
 
   object Syntax {
     implicit class BigDecimalOps(val b: BigDecimal) extends AnyVal {
+      def toRoundedAmount: BigDecimal = BigDecimalFormatter.toRoundedAmount(b)
       def toEuros: String = BigDecimalFormatter.toEuros(b)
       def toPounds: String = BigDecimalFormatter.toPounds(b)
     }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
@@ -22,19 +22,30 @@ import scala.math.BigDecimal.RoundingMode
 
 object BigDecimalFormatter {
 
-  val currencyFormatter: NumberFormat = {
+  private val eurFormatter: NumberFormat = {
     val cf = NumberFormat.getCurrencyInstance(new Locale("en", "GB"))
     cf.setCurrency(Currency.getInstance(new Locale("en", "GB")))
     cf.setCurrency(Currency.getInstance("EUR"))
     cf
   }
 
+  private val gbpFormatter: NumberFormat = {
+    val cf = NumberFormat.getCurrencyInstance(new Locale("en", "GB"))
+    cf.setCurrency(Currency.getInstance(new Locale("en", "GB")))
+    cf.setCurrency(Currency.getInstance("GBP"))
+    cf
+  }
+
+  private def roundingMode = RoundingMode.DOWN
+
   // TODO - test coverage of the rounding mode
-  def toEuros(amount: BigDecimal): String = currencyFormatter.format(amount.setScale(2, RoundingMode.HALF_DOWN))
+  def toEuros(amount: BigDecimal): String = eurFormatter.format(amount.setScale(2, roundingMode))
+  def toPounds(amount: BigDecimal): String = gbpFormatter.format(amount.setScale(2, roundingMode))
 
   object Syntax {
     implicit class BigDecimalOps(val b: BigDecimal) extends AnyVal {
       def toEuros: String = BigDecimalFormatter.toEuros(b)
+      def toPounds: String = BigDecimalFormatter.toPounds(b)
     }
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters
 
 import java.text.NumberFormat
 import java.util.{Currency, Locale}
+import scala.math.BigDecimal.RoundingMode
 
 object BigDecimalFormatter {
 
@@ -28,7 +29,8 @@ object BigDecimalFormatter {
     cf
   }
 
-  def toEuros(amount: BigDecimal): String = currencyFormatter.format(amount.setScale(2))
+  // TODO - test coverage of the rounding mode
+  def toEuros(amount: BigDecimal): String = currencyFormatter.format(amount.setScale(2, RoundingMode.HALF_DOWN))
 
   object Syntax {
     implicit class BigDecimalOps(val b: BigDecimal) extends AnyVal {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatter.scala
@@ -16,23 +16,21 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters
 
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.{EUR, GBP}
+
 import java.text.NumberFormat
 import java.util.{Currency, Locale}
 import scala.math.BigDecimal.RoundingMode
 
 object BigDecimalFormatter {
 
-  private val eurFormatter: NumberFormat = {
-    val cf = NumberFormat.getCurrencyInstance(new Locale("en", "GB"))
-    cf.setCurrency(Currency.getInstance(new Locale("en", "GB")))
-    cf.setCurrency(Currency.getInstance("EUR"))
-    cf
-  }
+  private val eurFormatter: NumberFormat = numberFormatForCurrency(EUR)
+  private val gbpFormatter: NumberFormat = numberFormatForCurrency(GBP)
 
-  private val gbpFormatter: NumberFormat = {
+  private def numberFormatForCurrency(c: CurrencyCode) = {
     val cf = NumberFormat.getCurrencyInstance(new Locale("en", "GB"))
-    cf.setCurrency(Currency.getInstance(new Locale("en", "GB")))
-    cf.setCurrency(Currency.getInstance("GBP"))
+    cf.setCurrency(Currency.getInstance(c.entryName))
     cf
   }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -79,7 +79,7 @@ GET        /lead-undertaking-add-payment-amount                                 
 POST       /lead-undertaking-add-payment-amount                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postAddClaimAmount
 
 GET        /lead-undertaking-check-converted-amount                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getConfirmClaimAmount
-GET        /lead-undertaking-check-converted-amount                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postConfirmClaimAmount
+POST       /lead-undertaking-check-converted-amount                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postConfirmClaimAmount
 
 GET        /lead-undertaking-add-claim-date                                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getClaimDate
 POST       /lead-undertaking-add-claim-date                                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postClaimDate

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -42,7 +42,7 @@ POST       /first-login-journey-what-sector                                     
 GET        /first-login-journey-check-your-answers                                       uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getCheckAnswers
 POST       /first-login-journey-check-your-answers                                       uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postCheckAnswers
 
-GET        /first-login-journey-registered-undertaking/:undertakingRef/name             uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getConfirmation(undertakingRef,name)
+GET        /first-login-journey-registered-undertaking/:undertakingRef/name              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getConfirmation(undertakingRef,name)
 POST       /first-login-journey-registered-undertaking                                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postConfirmation
 GET        /lead-undertaking-amend-undertaking                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getAmendUndertakingDetails
 POST       /lead-undertaking-amend-undertaking                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postAmendUndertaking
@@ -69,8 +69,8 @@ POST       /lead-undertaking-remove-business-entity/:eori                       
 GET        /business-enterprise-remove-yourself-from-undertaking                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BusinessEntityController.getRemoveYourselfBusinessEntity
 POST       /business-enterprise-remove-yourself-from-undertaking                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BusinessEntityController.postRemoveYourselfBusinessEntity
 
-GET        /lead-undertaking-report-de-minimis-aid-payment                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getReportPayment
-POST       /lead-undertaking-report-de-minimis-aid-payment                                             uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postReportPayment
+GET        /lead-undertaking-report-de-minimis-aid-payment                               uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getReportPayment
+POST       /lead-undertaking-report-de-minimis-aid-payment                               uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postReportPayment
 
 GET        /lead-undertaking-add-eori-business-claimed-payment                           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getAddClaimEori
 POST       /lead-undertaking-add-eori-business-claimed-payment                           uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postAddClaimEori

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -78,6 +78,9 @@ POST       /lead-undertaking-add-eori-business-claimed-payment                  
 GET        /lead-undertaking-add-payment-amount                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getClaimAmount
 POST       /lead-undertaking-add-payment-amount                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postAddClaimAmount
 
+GET        /lead-undertaking-check-converted-amount                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getConfirmClaimAmount
+GET        /lead-undertaking-check-converted-amount                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postConfirmClaimAmount
+
 GET        /lead-undertaking-add-claim-date                                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.getClaimDate
 POST       /lead-undertaking-add-claim-date                                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.postClaimDate
 

--- a/conf/messages
+++ b/conf/messages
@@ -286,7 +286,7 @@ add-claim-amount.l5 = Enter amount in the box below.
 #add-claim-amount.error.required = Required - Enter number value of subsidy allocated in Euros, like €248.56
 
 confirm-converted-amount.title = Your amount in euros
-confirm-converted-amount.p1 = Your pounds sterling amount of £{0}, converted to euros, is €{1}
+confirm-converted-amount.p1 = Your pounds sterling amount of {0}, converted to euros, is {1}
 
 add-claim-date.title=What date were you awarded the payment?
 add-claim-date.hint=For example, 27 07 2020

--- a/conf/messages
+++ b/conf/messages
@@ -246,10 +246,9 @@ reportPayment.error.required=Select yes if you have a de minimis aid payment (le
 reportPayment.payment-dated = payment, dated
 
 # Add Claim Amount Form
-add-claim-amount.title = What currency was the payment in?
-add-claim-amount.hint = Select one option.
-add-claim-amount.eur = Euros
-add-claim-amount.gbp = Pounds sterling
+add-claim-amount.title = What currency was the payment received in?
+add-claim-amount.eur = Euros (EUR)
+add-claim-amount.gbp = Pounds sterling (GBP)
 add-claim-amount.input-label = Enter amount
 add-claim-amount.input-hint = Figure should include two decimal places, like 248.56
 
@@ -278,7 +277,8 @@ add-claim-amount.l4 = Change the ‘From’ dropdown to ‘GBP’ and use the fi
 add-claim-amount.l5 = Enter amount in the box below.
 
 confirm-converted-amount.title = Your amount in euros
-confirm-converted-amount.p1 = Your pounds sterling amount of {0}, converted to euros, is {1}
+confirm-converted-amount.p1 = Your pounds sterling amount of {0}, converted to euros, is <strong>{1}</strong>.
+confirm-converted-amount.p2 = We've converted your amount from pounds sterling as we measure this type of aid in euros.
 
 add-claim-date.title=What date were you awarded the payment?
 add-claim-date.hint=For example, 27 07 2020

--- a/conf/messages
+++ b/conf/messages
@@ -245,7 +245,13 @@ reportPayment.button = Report a payment
 reportPayment.error.required=Select yes if you have a de minimis aid payment (less Customs Duty waiver) to report?
 reportPayment.payment-dated = payment, dated
 
-add-claim-amount.title=What was the amount of the payment?
+add-claim-amount.title = What currency was the payment in?
+add-claim-amount.hint = Select one option.
+add-claim-amount.eur = Euros
+add-claim-amount.gbp = Pounds sterling
+add-claim-amount.input-label = Enter amount
+add-claim-amount.input-hint = Figure should include two decimal places, like 248.56
+
 add-claim-amount.p1=This type of aid is measured in euros.
 add-claim-amount.inset=If your payment is already in euros, skip the steps below and enter the amount in the box.
 add-claim-amount.p2=if you need to convert sterling into euros, then follow steps 1 to 5:
@@ -254,7 +260,6 @@ add-claim-amount.l2 = Change the year to {0} and month to {1}.
 add-claim-amount.l3 = Enter the amount of aid you received in pounds sterling.
 add-claim-amount.l4 = Change the ‘From’ dropdown to ‘GBP’ and use the figure displayed below it.
 add-claim-amount.l5 = Enter amount in the box below.
-add-claim-amount.hint = You must enter the amount of aid in Euros, including two decimal places, like 248.56
 add-claim-amount.error.amount.tooSmall=Subsidy amount must be more than one cent, like €00.01
 add-claim-amount.error.amount.tooBig=Subsidy amount must be fewer than 17 characters
 add-claim-amount.error.required= Enter number value of subsidy allocated in Euros, like €248.56

--- a/conf/messages
+++ b/conf/messages
@@ -251,7 +251,14 @@ add-claim-amount.eur = Euros
 add-claim-amount.gbp = Pounds sterling
 add-claim-amount.input-label = Enter amount
 add-claim-amount.input-hint = Figure should include two decimal places, like 248.56
-add-claim-amount.error.currency-code.required = Select the currency that the payment was made in.
+
+# Form validation errors
+add-claim-amount.currency-code.error.required = Select the currency that the payment was made in.
+add-claim-amount.claim-amount.error.required = Enter number value of subsidy allocated, like 248.56
+add-claim-amount.claim-amount.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
+add-claim-amount.claim-amount.error.tooBig=Subsidy amount must be fewer than 17 characters
+# TODO - confirm logic here - is 0.01 an allowable amount?
+add-claim-amount.claim-amount.error.tooSmall=Subsidy amount must be more than one cent or penny e.g 0.02
 
 add-claim-amount.p1=This type of aid is measured in euros.
 add-claim-amount.inset=If your payment is already in euros, skip the steps below and enter the amount in the box.
@@ -261,12 +268,14 @@ add-claim-amount.l2 = Change the year to {0} and month to {1}.
 add-claim-amount.l3 = Enter the amount of aid you received in pounds sterling.
 add-claim-amount.l4 = Change the ‘From’ dropdown to ‘GBP’ and use the figure displayed below it.
 add-claim-amount.l5 = Enter amount in the box below.
-add-claim-amount.error.amount.tooSmall=Subsidy amount must be more than one cent, like €00.01
-add-claim-amount.error.amount.tooBig=Subsidy amount must be fewer than 17 characters
-add-claim-amount.error.required= Enter number value of subsidy allocated in Euros, like €248.56
-add-claim-amount.error.amount.incorrectFormat=Enter number value of subsidy allocated in Euros, like €248.56
-add-claim-amount.error.real = Enter number value of subsidy allocated in Euros, like €248.56
-add-claim-amount.error.required = Enter number value of subsidy allocated in Euros, like €248.56
+
+# Original error messages
+# TODO - remove when ids migrated
+#add-claim-amount.error.amount.tooSmall=Subsidy amount must be more than one cent, like €00.01
+#add-claim-amount.error.required= Enter number value of subsidy allocated in Euros, like €248.56
+#add-claim-amount.error.amount.incorrectFormat=Enter number value of subsidy allocated in Euros, like €248.56
+#add-claim-amount.error.real = Enter number value of subsidy allocated in Euros, like €248.56
+#add-claim-amount.error.required = Required - Enter number value of subsidy allocated in Euros, like €248.56
 
 add-claim-date.title=What date were you awarded the payment?
 add-claim-date.hint=For example, 27 07 2020

--- a/conf/messages
+++ b/conf/messages
@@ -266,7 +266,7 @@ add-claim-amount.claim-amount-eur.error.required = Enter number value of subsidy
 add-claim-amount.claim-amount-eur.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
 add-claim-amount.claim-amount-eur.error.tooBig=Subsidy amount must be fewer than 17 characters
 # TODO - confirm logic here - is 0.01 an allowable amount?
-add-claim-amount.claim-amount-eur.error.tooSmall=Subsidy amount must be more than one penny e.g 0.02
+add-claim-amount.claim-amount-eur.error.tooSmall=Subsidy amount must be more than one cent e.g 0.02
 
 add-claim-amount.p1=This type of aid is measured in euros.
 add-claim-amount.inset=If your payment is already in euros, skip the steps below and enter the amount in the box.

--- a/conf/messages
+++ b/conf/messages
@@ -253,7 +253,7 @@ add-claim-amount.input-label = Enter amount
 add-claim-amount.input-hint = Figure should include two decimal places, like 248.56
 
 # Form validation errors
-add-claim-amount.currency-code.error.required = Select the currency that the payment was made in.
+add-claim-amount.currency-code.error.required = Select the currency the payment was made in
 
 # GBP field validation errors
 add-claim-amount.claim-amount-gbp.error.required = Enter number value of subsidy allocated, like 248.56

--- a/conf/messages
+++ b/conf/messages
@@ -285,6 +285,9 @@ add-claim-amount.l5 = Enter amount in the box below.
 #add-claim-amount.error.real = Enter number value of subsidy allocated in Euros, like €248.56
 #add-claim-amount.error.required = Required - Enter number value of subsidy allocated in Euros, like €248.56
 
+confirm-converted-amount.title = Your amount in euros
+confirm-converted-amount.p1 = Your pounds sterling amount of £{0}, converted to euros, is €{1}
+
 add-claim-date.title=What date were you awarded the payment?
 add-claim-date.hint=For example, 27 07 2020
 add-claim-date.error.date.emptyfields=Enter the date you were awarded the payment

--- a/conf/messages
+++ b/conf/messages
@@ -245,6 +245,7 @@ reportPayment.button = Report a payment
 reportPayment.error.required=Select yes if you have a de minimis aid payment (less Customs Duty waiver) to report?
 reportPayment.payment-dated = payment, dated
 
+# Add Claim Amount Form
 add-claim-amount.title = What currency was the payment in?
 add-claim-amount.hint = Select one option.
 add-claim-amount.eur = Euros
@@ -254,19 +255,18 @@ add-claim-amount.input-hint = Figure should include two decimal places, like 248
 
 # Form validation errors
 add-claim-amount.currency-code.error.required = Select the currency that the payment was made in.
+
 # GBP field validation errors
 add-claim-amount.claim-amount-gbp.error.required = Enter number value of subsidy allocated, like 248.56
 add-claim-amount.claim-amount-gbp.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
 add-claim-amount.claim-amount-gbp.error.tooBig=Subsidy amount must be fewer than 17 characters
-# TODO - confirm logic here - is 0.01 an allowable amount?
-add-claim-amount.claim-amount-gbp.error.tooSmall=Subsidy amount must be more than one penny e.g 0.02
+add-claim-amount.claim-amount-gbp.error.tooSmall=Subsidy amount must be more than zero
 
 # EUR field validation errors
 add-claim-amount.claim-amount-eur.error.required = Enter number value of subsidy allocated, like 248.56
 add-claim-amount.claim-amount-eur.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
 add-claim-amount.claim-amount-eur.error.tooBig=Subsidy amount must be fewer than 17 characters
-# TODO - confirm logic here - is 0.01 an allowable amount?
-add-claim-amount.claim-amount-eur.error.tooSmall=Subsidy amount must be more than one cent e.g 0.02
+add-claim-amount.claim-amount-eur.error.tooSmall=Subsidy amount must be more than zero
 
 add-claim-amount.p1=This type of aid is measured in euros.
 add-claim-amount.inset=If your payment is already in euros, skip the steps below and enter the amount in the box.
@@ -276,14 +276,6 @@ add-claim-amount.l2 = Change the year to {0} and month to {1}.
 add-claim-amount.l3 = Enter the amount of aid you received in pounds sterling.
 add-claim-amount.l4 = Change the ‘From’ dropdown to ‘GBP’ and use the figure displayed below it.
 add-claim-amount.l5 = Enter amount in the box below.
-
-# Original error messages
-# TODO - remove when ids migrated
-#add-claim-amount.error.amount.tooSmall=Subsidy amount must be more than one cent, like €00.01
-#add-claim-amount.error.required= Enter number value of subsidy allocated in Euros, like €248.56
-#add-claim-amount.error.amount.incorrectFormat=Enter number value of subsidy allocated in Euros, like €248.56
-#add-claim-amount.error.real = Enter number value of subsidy allocated in Euros, like €248.56
-#add-claim-amount.error.required = Required - Enter number value of subsidy allocated in Euros, like €248.56
 
 confirm-converted-amount.title = Your amount in euros
 confirm-converted-amount.p1 = Your pounds sterling amount of {0}, converted to euros, is {1}

--- a/conf/messages
+++ b/conf/messages
@@ -254,11 +254,19 @@ add-claim-amount.input-hint = Figure should include two decimal places, like 248
 
 # Form validation errors
 add-claim-amount.currency-code.error.required = Select the currency that the payment was made in.
-add-claim-amount.claim-amount.error.required = Enter number value of subsidy allocated, like 248.56
-add-claim-amount.claim-amount.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
-add-claim-amount.claim-amount.error.tooBig=Subsidy amount must be fewer than 17 characters
+# GBP field validation errors
+add-claim-amount.claim-amount-gbp.error.required = Enter number value of subsidy allocated, like 248.56
+add-claim-amount.claim-amount-gbp.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
+add-claim-amount.claim-amount-gbp.error.tooBig=Subsidy amount must be fewer than 17 characters
 # TODO - confirm logic here - is 0.01 an allowable amount?
-add-claim-amount.claim-amount.error.tooSmall=Subsidy amount must be more than one cent or penny e.g 0.02
+add-claim-amount.claim-amount-gbp.error.tooSmall=Subsidy amount must be more than one penny e.g 0.02
+
+# EUR field validation errors
+add-claim-amount.claim-amount-eur.error.required = Enter number value of subsidy allocated, like 248.56
+add-claim-amount.claim-amount-eur.error.incorrectFormat = Enter number value of subsidy allocated, like 248.56
+add-claim-amount.claim-amount-eur.error.tooBig=Subsidy amount must be fewer than 17 characters
+# TODO - confirm logic here - is 0.01 an allowable amount?
+add-claim-amount.claim-amount-eur.error.tooSmall=Subsidy amount must be more than one penny e.g 0.02
 
 add-claim-amount.p1=This type of aid is measured in euros.
 add-claim-amount.inset=If your payment is already in euros, skip the steps below and enter the amount in the box.

--- a/conf/messages
+++ b/conf/messages
@@ -251,6 +251,7 @@ add-claim-amount.eur = Euros
 add-claim-amount.gbp = Pounds sterling
 add-claim-amount.input-label = Enter amount
 add-claim-amount.input-hint = Figure should include two decimal places, like 248.56
+add-claim-amount.error.currency-code.required = Select the currency that the payment was made in.
 
 add-claim-amount.p1=This type of aid is measured in euros.
 add-claim-amount.inset=If your payment is already in euros, skip the steps below and enter the amount in the box.

--- a/conf/messages
+++ b/conf/messages
@@ -278,7 +278,7 @@ add-claim-amount.l5 = Enter amount in the box below.
 
 confirm-converted-amount.title = Your amount in euros
 confirm-converted-amount.p1 = Your pounds sterling amount of {0}, converted to euros, is <strong>{1}</strong>.
-confirm-converted-amount.p2 = We've converted your amount from pounds sterling as we measure this type of aid in euros.
+confirm-converted-amount.p2 = We’ve converted your amount from pounds sterling as we measure this type of aid in euros.
 
 add-claim-date.title=What date were you awarded the payment?
 add-claim-date.hint=For example, 27 07 2020

--- a/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCacheSpec.scala
+++ b/it/uk/gov/hmrc/eusubsidycompliancefrontend/cache/ExchangeRateCacheSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.test.DefaultAwaitTimeout
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.{EUR, GBP}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ExchangeRate
 import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
@@ -38,8 +39,8 @@ class ExchangeRateCacheSpec
   private val yearMonth1 = YearAndMonth(2022, 1)
   private val yearMonth2 = YearAndMonth(2022, 6)
 
-  private val exchangeRate1 = ExchangeRate("EUR", "GBP", BigDecimal(0.867))
-  private val exchangeRate2 = ExchangeRate("EUR", "GBP", BigDecimal(0.807))
+  private val exchangeRate1 = ExchangeRate(EUR, GBP, BigDecimal(0.867))
+  private val exchangeRate2 = ExchangeRate(EUR, GBP, BigDecimal(0.807))
 
   "ExchangeRateCache" should {
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ import sbt._
 object AppDependencies {
 
   val bootStrapVersion = "5.23.0"
-  val hmrcMongoVersion = "0.63.0"
+  val hmrcMongoVersion = "0.68.0"
   val enumeratumVersion = "1.7.0"
 
   val compile = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,6 +7,7 @@ object AppDependencies {
 
   val bootStrapVersion = "5.23.0"
   val hmrcMongoVersion = "0.63.0"
+  val enumeratumVersion = "1.7.0"
 
   val compile = Seq(
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % bootStrapVersion,
@@ -16,7 +17,8 @@ object AppDependencies {
     "ai.x"              %% "play-json-extensions"          % "0.42.0",
     "com.chuusai"       %% "shapeless"                     % "2.3.9",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.11.0-play-28",
-    "com.beachape"      %% "enumeratum"                    % "1.7.0"
+    "com.beachape"      %% "enumeratum"                    % enumeratumVersion,
+    "com.beachape"      %% "enumeratum-play-json"          % enumeratumVersion
   )
 
   val test = Seq(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
@@ -40,8 +40,6 @@ trait ControllerSpec extends PlaySupport {
 
   def messageFromMessageKey(messageKey: String, args: Any*)(implicit messagesApi: MessagesApi): String = {
     val m = messagesApi(messageKey, args: _*)
-    println(s"messageFromMessageKey: looking for message '$messageKey''")
-    // TODO - why are we duplicating the logic further down the call chain?
     if (m === messageKey) sys.error(s"messageFromMessageKey: Could not find message for key `$messageKey`")
     else m
   }
@@ -79,14 +77,8 @@ trait ControllerSpec extends PlaySupport {
       result,
       expectedTitle,
       { doc =>
-        val errorSummary = doc.select(".govuk-error-summary")
-        val errorSummaryContent = errorSummary.select("a").text()
-        println(s"Error summary content: '$errorSummaryContent''")
-        errorSummaryContent shouldBe formError
-
-        val inputErrorMessage = doc.select(".govuk-error-message").text()
-        println(s"input error message content: '$inputErrorMessage''")
-        inputErrorMessage shouldBe s"Error: $formError"
+        doc.select(".govuk-error-summary").select("a").text() shouldBe formError
+        doc.select(".govuk-error-message").text() shouldBe s"Error: $formError"
       },
       expectedStatus
     )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
@@ -40,7 +40,9 @@ trait ControllerSpec extends PlaySupport {
 
   def messageFromMessageKey(messageKey: String, args: Any*)(implicit messagesApi: MessagesApi): String = {
     val m = messagesApi(messageKey, args: _*)
-    if (m === messageKey) sys.error(s"Could not find message for key `$messageKey`")
+    println(s"messageFromMessageKey: looking for message '$messageKey''")
+    // TODO - why are we duplicating the logic further down the call chain?
+    if (m === messageKey) sys.error(s"messageFromMessageKey: Could not find message for key `$messageKey`")
     else m
   }
 
@@ -78,9 +80,12 @@ trait ControllerSpec extends PlaySupport {
       expectedTitle,
       { doc =>
         val errorSummary = doc.select(".govuk-error-summary")
-        errorSummary.select("a").text() shouldBe formError
+        val errorSummaryContent = errorSummary.select("a").text()
+        println(s"Error summary content: '$errorSummaryContent''")
+        errorSummaryContent shouldBe formError
 
         val inputErrorMessage = doc.select(".govuk-error-message").text()
+        println(s"input error message content: '$inputErrorMessage''")
         inputErrorMessage shouldBe s"Error: $formError"
       },
       expectedStatus

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import com.google.inject.{Inject, Singleton}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import play.api.http.HttpConfiguration
 import play.api.i18n._
 import play.api.mvc.{Call, Result}
@@ -28,7 +29,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.test.util.PlaySupport
 
 import scala.concurrent.Future
 
-trait ControllerSpec extends PlaySupport {
+trait ControllerSpec extends PlaySupport with ScalaFutures with IntegrationPatience {
 
   def checkIsRedirect(result: Future[Result], expectedRedirectLocation: String): Unit = {
     status(result) shouldBe SEE_OTHER

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.time.LocalDate
 import scala.concurrent.Future
 
 trait EscServiceSupport { this: ControllerSpec =>
@@ -70,7 +71,7 @@ trait EscServiceSupport { this: ControllerSpec =>
       .expects(undertakingRef, businessEntity, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
 
-  def mockCreateSubsidy(reference: UndertakingRef, subsidyUpdate: SubsidyUpdate)(
+  def mockCreateSubsidy(subsidyUpdate: SubsidyUpdate)(
     result: Either[ConnectorError, UndertakingRef]
   ) =
     (mockEscService
@@ -97,5 +98,10 @@ trait EscServiceSupport { this: ControllerSpec =>
       .disableUndertaking(_: Undertaking)(_: HeaderCarrier))
       .expects(undertaking, *)
       .returning(result.fold(e => Future.failed(e), _.toFuture))
+
+  def mockRetrieveExchangeRate(date: LocalDate)(result: Future[ExchangeRate]) =
+    (mockEscService.retrieveExchangeRate(_: LocalDate)(_: HeaderCarrier))
+      .expects(date, *)
+      .returning(result)
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -127,7 +127,7 @@ class NoClaimNotificationControllerSpec
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDay)
             mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
-            mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay.plusDays(1))))(
+            mockCreateSubsidy(SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay.plusDays(1))))(
               Left(ConnectorError(exception))
             )
           }
@@ -159,7 +159,7 @@ class NoClaimNotificationControllerSpec
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockTimeToday(currentDay)
           mockUpdate[NilReturnJourney](_ => update(nilReturnJourney), eori1)(Right(updatedNilReturnJourney))
-          mockCreateSubsidy(undertakingRef, SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay.plusDays(1))))(
+          mockCreateSubsidy(SubsidyUpdate(undertakingRef, NilSubmissionDate(currentDay.plusDays(1))))(
             Right(undertakingRef)
           )
           mockSendAuditEvent(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -415,7 +415,7 @@ class SubsidyControllerSpec
             SubsidyJourney(
               reportPayment = ReportPaymentFormPage(true.some),
               claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some),
-              claimAmount = ClaimAmountFormPage(value = subsidyAmount.some)
+              claimAmount = ClaimAmountFormPage(value = claimAmount.some)
             )
           )
         }
@@ -486,7 +486,7 @@ class SubsidyControllerSpec
           )
 
           def update(subsidyJourney: SubsidyJourney) =
-            subsidyJourney.copy(claimAmount = ClaimAmountFormPage(value = subsidyAmount.some))
+            subsidyJourney.copy(claimAmount = ClaimAmountFormPage(value = claimAmount.some))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()
@@ -537,6 +537,7 @@ class SubsidyControllerSpec
 
       }
 
+      // TODO - ensure these inputs are covered in the form provider tests with £ prefix too
       "redirect to next page when claim amount is prefixed with euro sign or not and have commas and space" in {
 
         List("123.45", "€123.45", "12  3.4 5", "1,23.4,5", "€12  3.4 5").foreach { claimAmount =>
@@ -544,11 +545,11 @@ class SubsidyControllerSpec
             val subsidyJourney = SubsidyJourney(
               reportPayment = ReportPaymentFormPage(true.some),
               claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some),
-              claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some)
+              claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", "123.45").some)
             )
 
             def update(subsidyJourney: SubsidyJourney) =
-              subsidyJourney.copy(claimAmount = ClaimAmountFormPage(BigDecimal(123.45).some))
+              subsidyJourney.copy(claimAmount = ClaimAmountFormPage(ClaimAmount("EURO", "123.45").some))
 
             inSequence {
               mockAuthWithNecessaryEnrolment()
@@ -1406,7 +1407,7 @@ class SubsidyControllerSpec
       val subsidyJourneyWithReportPaymentForm =
         subsidyJourney.copy(
           reportPayment = ReportPaymentFormPage(Some(true)),
-          claimAmount = ClaimAmountFormPage(Some(nonHmrcSubsidyAmount)),
+          claimAmount = ClaimAmountFormPage(claimAmount.some),
           existingTransactionId = Some(SubsidyRef(transactionID))
         )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -524,7 +524,7 @@ class SubsidyControllerSpec
           }
           assertThrows[Exception](await(performAction(
             ClaimAmountFormProvider.Fields.ClaimAmountGBP -> "123.45",
-            ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP",
+            ClaimAmountFormProvider.Fields.CurrencyCode -> GBP.entryName,
           )))
         }
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -391,10 +391,6 @@ class SubsidyControllerSpec
             performAction(),
             messageFromMessageKey("add-claim-amount.title"),
             { doc =>
-              val text = doc.select(".govuk-list").text
-              text should include regex subsidyJourney.claimDate.value.map(_.year).getOrElse("")
-              text should include regex subsidyJourney.claimDate.value.map(_.month).getOrElse("")
-
               val input = doc.select(".govuk-input").attr("value")
               input shouldBe subsidyJourney.claimAmount.value.map(_.toString()).getOrElse("")
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1434,7 +1434,7 @@ class SubsidyControllerSpec
       val subsidyJourneyWithReportPaymentForm =
         subsidyJourney.copy(
           reportPayment = ReportPaymentFormPage(Some(true)),
-          claimAmount = ClaimAmountFormPage(claimAmount.some),
+          claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", nonHmrcSubsidyAmount.toString).some),
           existingTransactionId = Some(SubsidyRef(transactionID))
         )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -24,6 +24,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyControllerSpec.RemoveSubsidyRow
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.EUR
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.NonCustomsSubsidyRemoved
@@ -569,11 +570,11 @@ class SubsidyControllerSpec
             val subsidyJourney = SubsidyJourney(
               reportPayment = ReportPaymentFormPage(true.some),
               claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some),
-              claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", claimAmount).some)
+              claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, claimAmount).some)
             )
 
             def update(subsidyJourney: SubsidyJourney) =
-              subsidyJourney.copy(claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", claimAmount).some))
+              subsidyJourney.copy(claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, claimAmount).some))
 
             inSequence {
               mockAuthWithNecessaryEnrolment()
@@ -1434,7 +1435,7 @@ class SubsidyControllerSpec
       val subsidyJourneyWithReportPaymentForm =
         subsidyJourney.copy(
           reportPayment = ReportPaymentFormPage(Some(true)),
-          claimAmount = ClaimAmountFormPage(ClaimAmount("EUR", nonHmrcSubsidyAmount.toString).some),
+          claimAmount = ClaimAmountFormPage(ClaimAmount(EUR, nonHmrcSubsidyAmount.toString).some),
           existingTransactionId = Some(SubsidyRef(transactionID))
         )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -418,7 +418,7 @@ class SubsidyControllerSpec
             SubsidyJourney(
               reportPayment = ReportPaymentFormPage(true.some),
               claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some),
-              claimAmount = ClaimAmountFormPage(value = claimAmount.some)
+              claimAmount = ClaimAmountFormPage(value = claimAmountPounds.some)
             )
           )
         }
@@ -489,7 +489,7 @@ class SubsidyControllerSpec
           )
 
           def update(subsidyJourney: SubsidyJourney) =
-            subsidyJourney.copy(claimAmount = ClaimAmountFormPage(value = claimAmount.some))
+            subsidyJourney.copy(claimAmount = ClaimAmountFormPage(value = claimAmountPounds.some))
 
           inSequence {
             mockAuthWithNecessaryEnrolment()

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -520,9 +520,7 @@ class SubsidyControllerSpec
           }
 
           val titleMessage = messageFromMessageKey("add-claim-amount.title")
-          println(s"testcase: Looking for message: $errorMessageKey")
           val errorMessage = messageFromMessageKey(errorMessageKey)
-          println(s"testcase: Found message with key: '$errorMessageKey' content: '$errorMessage''")
 
           checkFormErrorIsDisplayed(
             performAction(data: _*),
@@ -567,7 +565,6 @@ class SubsidyControllerSpec
       "redirect to next page when claim amount is prefixed with euro sign or not and have commas and space" in {
 
         List("123.45", "€123.45", "12  3.4 5", "1,23.4,5", "€12  3.4 5").foreach { claimAmount =>
-          println(s"Processing claimAmount: $claimAmount")
           withClue(s" For amount :: $claimAmount") {
             val subsidyJourney = SubsidyJourney(
               reportPayment = ReportPaymentFormPage(true.some),
@@ -713,8 +710,6 @@ class SubsidyControllerSpec
             mockPut[SubsidyJourney](subsidyJourneyWithPoundsAmount, eori1)(Right(subsidyJourneyWithPoundsAmount))
           }
 
-          println(s"subsidyJourney fixture: $subsidyJourneyWithPoundsAmount")
-          println(s"eori1: $eori1")
           val result = performAction()
           status(result) shouldBe SEE_OTHER
           redirectLocation(result) should contain(routes.SubsidyController.getAddClaimEori().url)
@@ -791,7 +786,7 @@ class SubsidyControllerSpec
 
       }
 
-      "redirect " when {
+      "redirect" when {
         "user is not an undertaking lead, to the account home page" in {
           testLeadOnlyRedirect(performAction)
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -393,7 +393,8 @@ class SubsidyControllerSpec
             performAction(),
             messageFromMessageKey("add-claim-amount.title"),
             { doc =>
-              val input = doc.select(".govuk-input").attr("value")
+              // TODO - add a test case to verify that the EUR field is also correctly populated
+              val input = doc.getElementById("claim-amount-gbp").attributes().get("value")
               input shouldBe subsidyJourney.claimAmount.value.map(_.amount).getOrElse("")
 
               val button = doc.select("form")
@@ -497,7 +498,7 @@ class SubsidyControllerSpec
             mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction(
-            ClaimAmountFormProvider.Fields.ClaimAmount -> "123.45",
+            ClaimAmountFormProvider.Fields.ClaimAmountGBP -> "123.45",
             ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP",
           )))
         }
@@ -534,29 +535,29 @@ class SubsidyControllerSpec
         }
 
         "nothing is entered" in {
-          displayError(ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP")("add-claim-amount.claim-amount.error.required")
+          displayError(ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP")("add-claim-amount.claim-amount-gbp.error.required")
         }
 
         "claim amount entered in wrong format" in {
           displayError(
             ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP",
-            ClaimAmountFormProvider.Fields.ClaimAmount -> "123.4"
-          )("add-claim-amount.claim-amount.error.incorrectFormat")
+            ClaimAmountFormProvider.Fields.ClaimAmountGBP -> "123.4"
+          )("add-claim-amount.claim-amount-gbp.error.incorrectFormat")
         }
 
         "claim amount entered is more than 17 chars" in {
           displayError(
             ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP",
-            ClaimAmountFormProvider.Fields.ClaimAmount -> "1234567890.12345678",
-          )("add-claim-amount.claim-amount.error.tooBig")
+            ClaimAmountFormProvider.Fields.ClaimAmountGBP -> "1234567890.12345678",
+          )("add-claim-amount.claim-amount-gbp.error.tooBig")
         }
 
         // TODO - check the logic here - test suggests 0.01 is allowed :/
         "claim amount entered is too small < 0.01" in {
           displayError(
             ClaimAmountFormProvider.Fields.CurrencyCode -> "GBP",
-            ClaimAmountFormProvider.Fields.ClaimAmount -> "0.01"
-          )("add-claim-amount.claim-amount.error.tooSmall")
+            ClaimAmountFormProvider.Fields.ClaimAmountGBP -> "0.01"
+          )("add-claim-amount.claim-amount-gbp.error.tooSmall")
         }
 
       }
@@ -586,7 +587,7 @@ class SubsidyControllerSpec
             checkIsRedirect(
               performAction(
                 ClaimAmountFormProvider.Fields.CurrencyCode -> "EUR",
-                ClaimAmountFormProvider.Fields.ClaimAmount -> claimAmount
+                ClaimAmountFormProvider.Fields.ClaimAmountEUR -> claimAmount
               ),
               routes.SubsidyController.getAddClaimEori().url
             )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -100,6 +100,17 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
 
       }
 
+      "the currency prefix does not match the selected currency code" in {
+        val scenarios = Seq(
+          "GBP" -> "€100.00",
+          "EUR" -> "£100.00",
+        )
+
+        scenarios.foreach { params =>
+          validateAndCheckError(params._1, params._2)("", "error.incorrectFormat")
+        }
+      }
+
     }
 
     "return an amount too small error" when {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.AppendedClues.convertToClueful
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.data.FormError
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Errors.{IncorrectFormat, TooBig, TooSmall}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ClaimAmount
 
@@ -75,7 +76,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
         )
 
         amounts.foreach { amount =>
-          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, "error.tooBig")
+          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, TooBig)
         }
 
       }
@@ -93,9 +94,13 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
         )
 
         amounts.foreach { amount =>
-          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, "error.incorrectFormat")
+          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, IncorrectFormat)
         }
 
+      }
+      
+      "an invalid currency code is specified" in {
+        validateAndCheckError("THB", "100.00")(Fields.CurrencyCode, IncorrectFormat)
       }
 
       "the currency prefix does not match the selected currency code" in {
@@ -105,7 +110,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
         )
 
         scenarios.foreach { params =>
-          validateAndCheckError(params._1, params._2)("", "error.incorrectFormat")
+          validateAndCheckError(params._1, params._2)("", IncorrectFormat)
         }
       }
 
@@ -114,11 +119,11 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
     "return an amount too small error" when {
 
       "the amount is zero" in {
-        validateAndCheckError("GBP", "0")(Fields.ClaimAmount, "error.tooSmall")
+        validateAndCheckError("GBP", "0")(Fields.ClaimAmount, TooSmall)
       }
 
       "the amount is negative" in {
-        validateAndCheckError("GBP", "-2")(Fields.ClaimAmount, "error.tooSmall")
+        validateAndCheckError("GBP", "-2")(Fields.ClaimAmount, TooSmall)
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -76,7 +76,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
         )
 
         amounts.foreach { amount =>
-          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, "error.amount.tooBig")
+          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, "error.tooBig")
         }
 
       }
@@ -95,7 +95,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
         )
 
         amounts.foreach { amount =>
-          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, "error.amount.incorrectFormat")
+          validateAndCheckError("GBP", amount)(Fields.ClaimAmount, "error.incorrectFormat")
         }
 
       }
@@ -105,11 +105,11 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
     "return an amount too small error" when {
 
       "the amount is zero" in {
-        validateAndCheckError("GBP", "0")(Fields.ClaimAmount, "error.amount.tooSmall")
+        validateAndCheckError("GBP", "0")(Fields.ClaimAmount, "error.tooSmall")
       }
 
       "the amount is negative" in {
-        validateAndCheckError("GBP", "-2")(Fields.ClaimAmount, "error.amount.tooSmall")
+        validateAndCheckError("GBP", "-2")(Fields.ClaimAmount, "error.tooSmall")
       }
 
     }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -36,6 +36,8 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
       "handling valid GBP form submissions" in {
         val amounts = Seq(
           "100",
+          "0.01",
+          "£0.01",
           "100.00",
           "£100.00",
           "10  0.00",
@@ -53,6 +55,8 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
       "handling valid EUR form submissions" in {
         val amounts = Seq(
           "100",
+          "0.01",
+          "€0.01",
           "100.00",
           "€100.00",
           "10  0.00",

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.data.FormError
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Errors.{IncorrectFormat, TooBig, TooSmall}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.ClaimAmount
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ClaimAmount, CurrencyCode}
 
 class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
 
@@ -98,7 +98,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
         }
 
       }
-      
+
       "an invalid currency code is specified" in {
         validateAndCheckError("THB", "100.00")(Fields.CurrencyCode, IncorrectFormat)
       }
@@ -133,7 +133,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
   private def validateAndCheckSuccess(currencyCode: String, amount: String) = {
     val result = processForm(currencyCode, amount)
     val parsedAmount = amount.replaceAll("[^\\d.]*", "")
-    result mustBe  Right(ClaimAmount(currencyCode, parsedAmount))
+    result mustBe  Right(ClaimAmount(CurrencyCode.withName(currencyCode), parsedAmount))
   }
 
   private def validateAndCheckError(currencyCode: String, amount: String)(field: String, errorMessage: String) = {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -38,6 +38,8 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
           "100",
           "100.00",
           "£100.00",
+          "10  0.00",
+          "£10  0.00",
           "1,000,000.00",
           "£1,000,000.00",
         )
@@ -53,6 +55,8 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
           "100",
           "100.00",
           "€100.00",
+          "10  0.00",
+          "€10  0.00",
           "1,000,000.00",
           "€1,000,000.00",
         )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.forms
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.data.FormError
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.ClaimAmount
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.getValidClaimAmount
+
+class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
+
+  private val underTest = new ClaimAmountFormProvider()
+
+  "claim amount form validation" must {
+
+    "return no errors for valid GBP form submissions" in {
+      val validSubmissions = Seq(
+        "100.00",
+        "£100.00",
+        "1,000,000.00",
+        "£1,000,000.00",
+      )
+
+      validSubmissions.foreach { amount =>
+        validateAndCheckSuccess("GBP", amount)
+      }
+    }
+
+
+    "return no errors for valid EUR form submissions" in {
+      val validSubmissions = Seq(
+        "100.00",
+        "€100.00",
+        "1,000,000.00",
+        "€1,000,000.00",
+      )
+
+      validSubmissions.foreach { amount =>
+        validateAndCheckSuccess("EUR", amount)
+      }
+    }
+
+  }
+
+  private def validateAndCheckSuccess(currencyCode: String, amount: String) = {
+    val result = processForm(currencyCode, amount)
+    // TODO - this should be part of the form handling, not in the subs journey
+    val parsedAmount = getValidClaimAmount(amount)
+    result mustBe  Right(ClaimAmount(currencyCode, parsedAmount))
+  }
+
+  private def processForm(currencyCode: String, amount: String): Either[Seq[FormError], ClaimAmount] =
+    underTest.form.mapping.bind(
+      Map(
+        Fields.CurrencyCode -> currencyCode,
+        Fields.ClaimAmount -> amount
+      )
+    )
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProviderSpec.scala
@@ -22,7 +22,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.data.FormError
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.ClaimAmount
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.getValidClaimAmount
 
 class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
 
@@ -83,7 +82,6 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
 
     }
 
-    // TODO - format error if user entered prefix != currency code?
     "return an incorrect format error" when {
 
       "the amount does not confirm to the required format" in {
@@ -129,8 +127,7 @@ class ClaimAmountFormProviderSpec extends AnyWordSpecLike with Matchers {
 
   private def validateAndCheckSuccess(currencyCode: String, amount: String) = {
     val result = processForm(currencyCode, amount)
-    // TODO - this should be part of the form handling, not in the subs journey
-    val parsedAmount = getValidClaimAmount(amount)
+    val parsedAmount = amount.replaceAll("[^\\d.]*", "")
     result mustBe  Right(ClaimAmount(currencyCode, parsedAmount))
   }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProviderSpec.scala
@@ -32,15 +32,15 @@ class ClaimEoriFormProviderSpec extends AnyWordSpecLike with Matchers {
   "claim eori form validation" must {
 
     "return no errors for a submission where no EORI was entered" in {
-      validateAndCheckSucess("false", None)
+      validateAndCheckSuccess("false", None)
     }
 
     "return no errors for a submission where an EORI was entered" in {
-      validateAndCheckSucess("true", Some(eori1.drop(2)))
+      validateAndCheckSuccess("true", Some(eori1.drop(2)))
     }
 
     "return no errors for a submission where an EORI was entered with prefix GB" in {
-      validateAndCheckSucess("true", Some(eori1))
+      validateAndCheckSuccess("true", Some(eori1))
     }
 
     "return an error if no fields are selected" in {
@@ -61,7 +61,7 @@ class ClaimEoriFormProviderSpec extends AnyWordSpecLike with Matchers {
 
   }
 
-  private def validateAndCheckSucess(radioButton: String, eoriNumber: Option[String]) = {
+  private def validateAndCheckSuccess(radioButton: String, eoriNumber: Option[String]) = {
     val result = processForm(radioButton, eoriNumber)
     result mustBe Right(OptionalEORI(radioButton, eoriNumber.map(getValidEori)))
   }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
@@ -25,9 +25,10 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET, defaultAwaitTimeout, redirectLocation, status}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{SubsidyAmount, SubsidyRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{DateFormValues, OptionalEORI, OptionalTraderRef}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.SubsidyJourney.Forms._
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.claimAmount
 
 class SubsidyJourneySpec extends AnyWordSpecLike with Matchers with ScalaFutures {
 
@@ -41,7 +42,7 @@ class SubsidyJourneySpec extends AnyWordSpecLike with Matchers with ScalaFutures
     }
 
     "return an updated instance with the specified value when setClaimAmount is called" in {
-      val value = SubsidyAmount(BigDecimal("123.45"))
+      val value = claimAmount
       SubsidyJourney().setClaimAmount(value) shouldBe SubsidyJourney(claimAmount = ClaimAmountFormPage(value.some))
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
@@ -84,7 +84,10 @@ class SubsidyJourneySpec extends AnyWordSpecLike with Matchers with ScalaFutures
 
       "return a redirect to the check your answers page if on amend journey" in {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
-        val result = SubsidyJourney(existingTransactionId = SubsidyRef("SomeRef").some).next
+        val result = SubsidyJourney(
+          existingTransactionId = SubsidyRef("SomeRef").some,
+          claimAmount = ClaimAmountFormPage(claimAmountEuros.some),
+        ).next
         status(result) shouldBe SEE_OTHER
         redirectLocation(result) should contain(routes.SubsidyController.getCheckAnswers().url)
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
@@ -132,6 +132,24 @@ class SubsidyJourneySpec extends AnyWordSpecLike with Matchers with ScalaFutures
         result shouldBe routes.SubsidyController.getClaimAmount().url
       }
 
+      "return URI to the referring page if it is valid and matches a SubsidyJourney page on the amend journey" in {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] =
+          FakeRequest(GET, routes.SubsidyController.getCheckAnswers().url)
+            .withHeaders("Referer" -> routes.SubsidyController.getClaimDate().url)
+
+        val result = SubsidyJourney(existingTransactionId = SubsidyRef("foo").some).previous
+        result shouldBe routes.SubsidyController.getClaimDate().url
+      }
+
+      "return URI to check your answers page if request for any page that is not the CYA page" in {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] =
+          FakeRequest(GET, routes.SubsidyController.getCheckAnswers().url)
+            .withHeaders("Referer" -> routes.SubsidyController.getClaimDate().url)
+
+        val result = SubsidyJourney(existingTransactionId = SubsidyRef("foo").some).previous
+        result shouldBe routes.SubsidyController.getClaimDate().url
+      }
+
       "return to the previous page otherwise" in {
         implicit val request: FakeRequest[AnyContentAsEmpty.type] =
           FakeRequest(GET, routes.SubsidyController.getAddClaimReference().url)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/SubsidyJourneySpec.scala
@@ -73,19 +73,39 @@ class SubsidyJourneySpec extends AnyWordSpecLike with Matchers with ScalaFutures
       SubsidyJourney().setCya(value) shouldBe SubsidyJourney(cya = CyaFormPage(value.some))
     }
 
-    "return a redirect to the next page in the journey if not on amend journey" in {
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
-      val result = SubsidyJourney().next
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) should contain(routes.SubsidyController.getReportPayment().url)
+    "when next is called" should {
+
+      "return a redirect to the next page in the journey if not on amend journey" in {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
+        val result = SubsidyJourney().next
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(routes.SubsidyController.getReportPayment().url)
+      }
+
+      "return a redirect to the check your answers page if on amend journey" in {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
+        val result = SubsidyJourney(existingTransactionId = SubsidyRef("SomeRef").some).next
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(routes.SubsidyController.getCheckAnswers().url)
+      }
+
+      "skip the confirm converted amount page if an amount in Euros is entered" in {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
+        val result = SubsidyJourney().next
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(routes.SubsidyController.getAddClaimEori().url)
+      }
+
+      "return the confirm converted amount page if an amount in Pounds sterling is entered" in {
+        implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
+        val result = SubsidyJourney().next
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(routes.SubsidyController.getConfirmClaimAmount().url)
+      }
+
     }
 
-    "return a redirect to the check your answers page if on amend journey" in {
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, "/")
-      val result = SubsidyJourney(existingTransactionId = SubsidyRef("SomeRef").some).next
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) should contain(routes.SubsidyController.getCheckAnswers().url)
-    }
+    // TODO - are tests for previous needed too?
 
   }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -101,6 +101,8 @@ object CommonTestData {
   val claimAmountPounds = ClaimAmount(GBP, subsidyAmount.toString())
   val claimAmountEuros = ClaimAmount(EUR, subsidyAmount.toString())
 
+  val claimDate = LocalDate.of(2022, 1, 1)
+
   val subsidyJourney = SubsidyJourney(
     publicAuthority = PublicAuthorityFormPage("Local Authority".some),
     traderRef = TraderRefFormPage(optionalTraderRef.some),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.test
 
 import cats.implicits.catsSyntaxOptionId
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.GBP
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
@@ -98,12 +99,12 @@ object CommonTestData {
   )
 
   // TODO - do we also need an EUR fixture?
-  val claimAmount = ClaimAmount("GBP", subsidyAmount.toString())
+  val claimAmount = ClaimAmount(GBP, subsidyAmount.toString())
 
   val subsidyJourney = SubsidyJourney(
     publicAuthority = PublicAuthorityFormPage("Local Authority".some),
     traderRef = TraderRefFormPage(optionalTraderRef.some),
-    claimAmount = ClaimAmountFormPage(ClaimAmount("GBP", subsidyAmount.toString()).some),
+    claimAmount = ClaimAmountFormPage(ClaimAmount(GBP, subsidyAmount.toString()).some),
     addClaimEori = AddClaimEoriFormPage(optionalEORI.some),
     claimDate = ClaimDateFormPage(DateFormValues("1", "1", "2022").some),
     reportPayment = ReportPaymentFormPage(true.some)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -97,10 +97,13 @@ object CommonTestData {
     hmrcSubsidyUsage = List(hmrcSubsidy)
   )
 
+  // TODO - do we also need an EUR fixture?
+  val claimAmount = ClaimAmount("GBP", subsidyAmount.toString())
+
   val subsidyJourney = SubsidyJourney(
     publicAuthority = PublicAuthorityFormPage("Local Authority".some),
     traderRef = TraderRefFormPage(optionalTraderRef.some),
-    claimAmount = ClaimAmountFormPage(subsidyAmount.some),
+    claimAmount = ClaimAmountFormPage(ClaimAmount("GBP", subsidyAmount.toString()).some),
     addClaimEori = AddClaimEoriFormPage(optionalEORI.some),
     claimDate = ClaimDateFormPage(DateFormValues("1", "1", "2022").some),
     reportPayment = ReportPaymentFormPage(true.some)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.test
 
 import cats.implicits.catsSyntaxOptionId
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.GBP
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.{EUR, GBP}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.createUndertaking.{CreateUndertakingResponse, EISResponse, ResponseCommonUndertaking, ResponseDetail}
@@ -98,8 +98,8 @@ object CommonTestData {
     hmrcSubsidyUsage = List(hmrcSubsidy)
   )
 
-  // TODO - do we also need an EUR fixture?
-  val claimAmount = ClaimAmount(GBP, subsidyAmount.toString())
+  val claimAmountPounds = ClaimAmount(GBP, subsidyAmount.toString())
+  val claimAmountEuros = ClaimAmount(EUR, subsidyAmount.toString())
 
   val subsidyJourney = SubsidyJourney(
     publicAuthority = PublicAuthorityFormPage("Local Authority".some),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -274,5 +274,5 @@ object CommonTestData {
   val businessEntityAddedEvent = AuditEvent.BusinessEntityAdded(undertakingRef, "1123", eori1, eori2)
   val businessEntityUpdatedEvent = AuditEvent.BusinessEntityUpdated(undertakingRef, "1123", eori1, eori2)
 
-  val exchangeRate = ExchangeRate("EUR", "GBP", BigDecimal(0.891))
+  val exchangeRate = ExchangeRate(EUR, GBP, BigDecimal(0.891))
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/test/CommonTestData.scala
@@ -104,7 +104,7 @@ object CommonTestData {
   val subsidyJourney = SubsidyJourney(
     publicAuthority = PublicAuthorityFormPage("Local Authority".some),
     traderRef = TraderRefFormPage(optionalTraderRef.some),
-    claimAmount = ClaimAmountFormPage(ClaimAmount(GBP, subsidyAmount.toString()).some),
+    claimAmount = ClaimAmountFormPage(claimAmountEuros.some),
     addClaimEori = AddClaimEoriFormPage(optionalEORI.some),
     claimDate = ClaimDateFormPage(DateFormValues("1", "1", "2022").some),
     reportPayment = ReportPaymentFormPage(true.some)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatterSoec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatterSoec.scala
@@ -22,16 +22,43 @@ import org.scalatest.wordspec.AnyWordSpecLike
 class BigDecimalFormatterSoec extends AnyWordSpecLike with Matchers {
 
   "BigDecimalFormatter" when {
-    "toTwoDecimalPlaces is called" should {
+
+    "toEuros is called" should {
 
       "return a formatted string containing the value formatted to two decimal places" in {
         BigDecimalFormatter.toEuros(BigDecimal(1)) shouldBe "€1.00"
       }
 
-      "format numbers greater than 100 with comma separators" in {
+      "format numbers greater than 999.99 with comma separators" in {
         BigDecimalFormatter.toEuros(BigDecimal(1000)) shouldBe "€1,000.00"
+        BigDecimalFormatter.toEuros(BigDecimal(1000000)) shouldBe "€1,000,000.00"
       }
+
+      "round sub cent amounts down" in {
+        BigDecimalFormatter.toEuros(BigDecimal(1.457)) shouldBe "€1.45"
+        BigDecimalFormatter.toEuros(BigDecimal(1.452)) shouldBe "€1.45"
+      }
+
     }
+
+    "toPounds is called" should {
+
+      "return a formatted string containing the value formatted to two decimal places" in {
+        BigDecimalFormatter.toPounds(BigDecimal(1)) shouldBe "£1.00"
+      }
+
+      "format numbers greater than 100 with comma separators" in {
+        BigDecimalFormatter.toPounds(BigDecimal(1000)) shouldBe "£1,000.00"
+        BigDecimalFormatter.toPounds(BigDecimal(1000000)) shouldBe "£1,000,000.00"
+      }
+
+      "round sub cent amounts down" in {
+        BigDecimalFormatter.toPounds(BigDecimal(1.457)) shouldBe "£1.45"
+        BigDecimalFormatter.toPounds(BigDecimal(1.452)) shouldBe "£1.45"
+      }
+
+    }
+
   }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatterSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/views/formatters/BigDecimalFormatterSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.views.formatters
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
-class BigDecimalFormatterSoec extends AnyWordSpecLike with Matchers {
+class BigDecimalFormatterSpec extends AnyWordSpecLike with Matchers {
 
   "BigDecimalFormatter" when {
 
@@ -47,7 +47,7 @@ class BigDecimalFormatterSoec extends AnyWordSpecLike with Matchers {
         BigDecimalFormatter.toPounds(BigDecimal(1)) shouldBe "£1.00"
       }
 
-      "format numbers greater than 100 with comma separators" in {
+      "format numbers greater than 999.99 with comma separators" in {
         BigDecimalFormatter.toPounds(BigDecimal(1000)) shouldBe "£1,000.00"
         BigDecimalFormatter.toPounds(BigDecimal(1000000)) shouldBe "£1,000,000.00"
       }


### PR DESCRIPTION
Summary of changes
* revised the claim amount page to allow entry of GBP or EUR amounts
* if a GBP amount is entered the user is taken to a new page which converts the amount into Euros and confirms the Euro amount
* extracted claim amount form into a separate form provider class allowing the validation rules to be tested in isolation
* revised the next/previous logic fixing an existing bug and ensuring that the journey flows correctly on the create and amend journeys for both the EUR and GBP flows
* other minor tidy ups including introducing an enum for the currency code