### PR TITLE
ESC-642 add new url prefix along side that currently live to avoid breakage

### DIFF
--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,8 @@
 # Add all the application routes to the app.routes file
-->         /report-or-check-de-minimis-aid-northern-ireland              app.Routes
-->         /                          health.Routes
+# TODO - remove this route when all references to it have been migrated to report-and-manage... SEE ESC-642.
+->         /report-or-check-de-minimis-aid-northern-ireland                 app.Routes
 
-GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics
+->         /report-and-manage-your-allowance-for-customs-duty-waiver-claims app.Routes
+->         /                                                                health.Routes
+
+GET        /admin/metrics                                                   com.kenshoo.play.metrics.MetricsController.metrics


### PR DESCRIPTION
Summary of changes
* add new prod routes entry for the new url prefix `report-and-manage-your-allowance-for-customs-duty-waiver-claims`
* retain existing route for compatibility - this can be removed once all references have been replaced with the new prefix