### PR TITLE
ESC-660 simplify form provider trait removing duplicate functionality

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
@@ -30,7 +30,7 @@ case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[
   override def form: Form[OptionalEORI] = Form(mapping)
 
   override protected def mapping: Mapping[OptionalEORI] = Forms.mapping(
-    YesNoRadioButton -> text.verifying(radioButtonSelected(s"error.$YesNoRadioButton.required")),
+    YesNoRadioButton -> text,
     EoriNumber -> mandatoryIfEqual(YesNoRadioButton, "true", eoriNumberMapping)
   )(OptionalEORI.apply)(OptionalEORI.unapply)
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
@@ -16,16 +16,9 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
-import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.data.{Form, Mapping}
 
 trait FormProvider[T] {
   protected def mapping: Mapping[T]
   def form: Form[T]
-
-  def radioButtonSelected(errorMessage: String): Constraint[String] = Constraint[String] { r: String =>
-    if (r.isEmpty) Invalid(errorMessage)
-    else Valid
-  }
-
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProviderSpec.scala
@@ -43,10 +43,6 @@ class ClaimEoriFormProviderSpec extends AnyWordSpecLike with Matchers {
       validateAndCheckSuccess("true", Some(eori1))
     }
 
-    "return an error if no fields are selected" in {
-      validateAndCheckError("", None)(YesNoRadioButton, "error.should-claim-eori.required")
-    }
-
     "return an error if the yes radio button is selected and no eori number is entered" in {
       validateAndCheckError("true", None)(EoriNumber, "error.required")
     }


### PR DESCRIPTION
Summary of changes
* the radio button code from the HMRC libraries already provides a check to ensure a value is selected so we don't need our own code to do this
*  removed the `radioButtonSelected` method from the `FormProvider` trait and updated the tests