### PR TITLE
ESC-734 redirect to account home if no subsidy data found on get cya page

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -337,7 +337,8 @@ class SubsidyController @Inject() (
         previous = journey.previous
       } yield Ok(cyaPage(claimDate, euroAmount, claimEori, authority, traderRef, previous))
 
-      result.getOrElse(Redirect(routes.SubsidyController.getAddClaimReference()))
+      result
+        .getOrElse(Redirect(routes.AccountController.getAccountPage()))
     }
   }
 
@@ -352,7 +353,7 @@ class SubsidyController @Inject() (
           ref <- undertaking.reference.toContext
           currentDate = timeProvider.today
           _ <- escService.createSubsidy(toSubsidyUpdate(journey, ref, currentDate)).toContext
-          _ <- store.put(SubsidyJourney()).toContext
+          _ <- store.delete[SubsidyJourney].toContext
           _ = auditService.sendEvent[NonCustomsSubsidyAdded](
             AuditEvent.NonCustomsSubsidyAdded(request.authorityId, eori, ref, journey, currentDate)
           )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -1360,6 +1360,19 @@ class SubsidyControllerSpec
 
       }
 
+      "redirect to account home if no subsidy journey data found" in {
+        inSequence {
+          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
+          mockGet[SubsidyJourney](eori1)(Right(Option.empty))
+        }
+
+        val result = performAction()
+
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
+      }
+
       "display the page" in {
         inSequence {
           mockAuthWithNecessaryEnrolmentWithValidEmail()
@@ -1410,7 +1423,7 @@ class SubsidyControllerSpec
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
 
-        "call to reset subsidy journey fails" in {
+        "call to delete subsidy journey fails" in {
           inSequence {
             mockAuthWithNecessaryEnrolmentWithValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
@@ -1419,7 +1432,7 @@ class SubsidyControllerSpec
             mockCreateSubsidy(
               SubsidyController.toSubsidyUpdate(subsidyJourney, undertakingRef, currentDate)
             )(Right(undertakingRef))
-            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Left(ConnectorError(exception)))
+            mockDelete[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
         }
@@ -1441,7 +1454,7 @@ class SubsidyControllerSpec
             mockCreateSubsidy(
               SubsidyController.toSubsidyUpdate(updatedSJ, undertakingRef, currentDate)
             )(Right(undertakingRef))
-            mockPut[SubsidyJourney](SubsidyJourney(), eori1)(Right(SubsidyJourney()))
+            mockDelete[SubsidyJourney](eori1)(Right(SubsidyJourney()))
             mockSendAuditEvent[AuditEvent.NonCustomsSubsidyAdded](
               AuditEvent.NonCustomsSubsidyAdded(
                 ggDetails = "1123",


### PR DESCRIPTION
Summary of changes
* when recording a subsidy we delete the subsidy journey state instead of replacing what's there with an empty instance
* if the user hits back from the payment confirmation page we redirect them to the account home page
* updated tests to cover this 