### PR TITLE
ESC-710 add email verification journey to become lead flow

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EmailVerificationConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/EmailVerificationConnector.scala
@@ -26,29 +26,20 @@ import scala.concurrent.ExecutionContext
 
 @Singleton
 class EmailVerificationConnector @Inject()(
-override protected val http: HttpClient,
-  servicesConfig: ServicesConfig
-  )
-  extends Connector {
+    override protected val http: HttpClient,
+    servicesConfig: ServicesConfig
+  ) extends Connector {
 
   lazy private val emailVerificationBaseUrl: String = servicesConfig.baseUrl("email-verification")
-  lazy private val emailVerificationFrontendBaseUrl: String = servicesConfig.baseUrl("email-verification-frontend")
 
   lazy private val verifyEmailUrl = s"$emailVerificationBaseUrl/email-verification/verify-email"
 
-  def useAbsoluteUrls: Boolean = emailVerificationBaseUrl.contains("localhost")
-
-
-  def verifyEmail(request: EmailVerificationRequest)(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext): ConnectorResult = {
+  def verifyEmail(request: EmailVerificationRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): ConnectorResult =
     makeRequest(
       _.POST[EmailVerificationRequest, HttpResponse](
         verifyEmailUrl,
         request
       )
     )
-  }
 
-  def getVerificationJourney(redirectUri: String): String = if(useAbsoluteUrls) s"${emailVerificationFrontendBaseUrl}${redirectUri}" else redirectUri
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BaseController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BaseController.scala
@@ -16,30 +16,14 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
-import play.api.data.Forms.{mapping, text}
-import play.api.data.validation.{Constraint, Invalid, Valid}
-import play.api.data.{Form, Mapping}
 import play.api.i18n.I18nSupport
 import play.api.mvc._
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.Singleton
 
 @Singleton
 class BaseController(mcc: MessagesControllerComponents) extends FrontendController(mcc) with I18nSupport {
-
-  protected def mandatory(key: String): Mapping[String] =
-    text.transform[String](_.trim, s => s).verifying(required(key))
-
-  private def required(key: String): Constraint[String] = Constraint {
-    case "" => Invalid(s"error.$key.required")
-    case _ => Valid
-  }
-
-  protected def formWithSingleMandatoryField(fieldName: String): Form[FormValues] = Form(
-    mapping(fieldName -> mandatory(fieldName))(FormValues.apply)(FormValues.unapply)
-  )
 
   protected def handleMissingSessionData(dataLabel: String) =
     throw new IllegalStateException(s"$dataLabel data missing on session")

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -268,7 +268,7 @@ class BecomeLeadController @Inject() (
             // Demote former lead
             _ <- escService.addMember(ref, formerLead).toContext
             _ <- emailService.sendEmail(formerLead.businessEntityIdentifier, RemovedAsLeadToFormerLead, undertaking).toContext
-            // Flush any state state
+            // Flush any stale journey state
             _ <- store.delete[UndertakingJourney].toContext
             _ <- store.delete[BusinessEntityJourney].toContext
             // Send audit event

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -119,7 +119,7 @@ class BecomeLeadController @Inject() (
       else Redirect(routes.AccountController.getAccountPage()).toFuture
     }
 
-    def promoteBusinessEntity() = withJourney[BecomeLeadJourney] { _ =>
+    def promoteBusinessEntity() = withJourneyOrRedirect[BecomeLeadJourney](routes.AccountController.getAccountPage()) { _ =>
       val result = for {
         undertaking <- escService.getUndertaking(eori).toContext
         ref = undertaking.reference

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -86,7 +86,8 @@ class BecomeLeadController @Inject() (
     handleConfirmEmailPost[BecomeLeadJourney](
       previous = routes.BecomeLeadController.getConfirmEmail(),
       next = routes.BecomeLeadController.getBecomeLeadEori(),
-      formAction = routes.BecomeLeadController.postConfirmEmail()
+      formAction = routes.BecomeLeadController.postConfirmEmail(),
+      generateEmailVerificationUrl = (id: String) => routes.BecomeLeadController.getVerifyEmail(id).url
     )
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -102,8 +102,8 @@ class BecomeLeadController @Inject() (
     // TODO - review the logic here
     for {
       journey <- store.get[BecomeLeadJourney]
-      undertakingOpt <- escService.retrieveUndertaking(eori)
-      result <- handleRequest(journey, undertakingOpt)
+      undertaking <- escService.retrieveUndertaking(eori)
+      result <- handleRequest(journey, undertaking)
     } yield result
 
   }
@@ -247,12 +247,14 @@ class BecomeLeadController @Inject() (
   }
 
 
-  def postBecomeLeadEori: Action[AnyContent] = enrolled.async { implicit request =>
+  def postBecomeLeadEori: Action[AnyContent] = verifiedEmail.async { implicit request =>
     implicit val eori: EORI = request.eoriNumber
 
-    def handleFormSubmission(form: FormValues) =
+    def handleFormSubmission(form: FormValues) = {
+      println(s"handling form: $form")
       if (form.value.isTrue) promoteBusinessEntity()
       else Redirect(routes.AccountController.getAccountPage()).toFuture
+    }
 
     def promoteBusinessEntity() =
       store.get[BecomeLeadJourney].toContext

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -83,7 +83,7 @@ class BecomeLeadController @Inject() (
   }
 
   def postConfirmEmail: Action[AnyContent] = enrolled.async { implicit request =>
-    handleConfirmEmailPost(
+    handleConfirmEmailPost[BecomeLeadJourney](
       previous = routes.BecomeLeadController.getConfirmEmail(),
       next = routes.BecomeLeadController.getBecomeLeadEori(),
       formAction = routes.BecomeLeadController.postConfirmEmail()

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -295,7 +295,6 @@ class BecomeLeadController @Inject() (
 
 
   def getPromotionConfirmation: Action[AnyContent] = verifiedEmail.async { implicit request =>
-    implicit val eori: EORI = request.eoriNumber
     Ok(becomeAdminConfirmationPage()).toFuture
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -162,4 +162,7 @@ class BecomeLeadController @Inject() (
     Ok(becomeAdminConfirmationPage()).toFuture
   }
 
+  override protected def addVerifiedEmailToJourney(email: String)(implicit eori: EORI): Future[Unit] =
+    ().toFuture
+
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -206,17 +206,11 @@ class BecomeLeadController @Inject() (
             for {
               stored <- emailVerificationService.getEmailVerification(request.eoriNumber)
               _ <- store.update[UndertakingJourney](_.setVerifiedEmail(stored.get.email))
-              redirect <-
-                if (wasSuccessful) {
-                  println(s"Verification was successful - moving on to next step in journey")
-//                  journey.next
-                  Redirect(routes.BecomeLeadController.getBecomeLeadEori().url).toFuture
-                }
-                else Redirect(routes.BecomeLeadController.getConfirmEmail().url).toFuture
+              redirect <- Redirect(routes.BecomeLeadController.getBecomeLeadEori().url).toFuture
             } yield redirect
-          // TODO - check location here- where should we redirect if the request was not successful?
-          } else Redirect(routes.BecomeLeadController.getBecomeLeadEori().url).toFuture
+          } else Redirect(routes.BecomeLeadController.getConfirmEmail().url).toFuture
         } yield redirect
+      // TODO - we could just throw the user back to home or the first page of the journey?
       case None => handleMissingSessionData("Become Lead Journey")
     }
   }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -209,11 +209,12 @@ class BecomeLeadController @Inject() (
               redirect <-
                 if (wasSuccessful) {
                   println(s"Verification was successful - moving on to next step in journey")
-                  journey.next
+//                  journey.next
                   Redirect(routes.BecomeLeadController.getBecomeLeadEori().url).toFuture
                 }
                 else Redirect(routes.BecomeLeadController.getConfirmEmail().url).toFuture
             } yield redirect
+          // TODO - check location here- where should we redirect if the request was not successful?
           } else Redirect(routes.BecomeLeadController.getBecomeLeadEori().url).toFuture
         } yield redirect
       case None => handleMissingSessionData("Become Lead Journey")

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -87,7 +87,7 @@ class BecomeLeadController @Inject() (
       previous = routes.BecomeLeadController.getConfirmEmail(),
       next = routes.BecomeLeadController.getBecomeLeadEori(),
       formAction = routes.BecomeLeadController.postConfirmEmail(),
-      generateEmailVerificationUrl = (id: String) => routes.BecomeLeadController.getVerifyEmail(id).url
+      generateVerifyEmailUrl = (id: String) => routes.BecomeLeadController.getVerifyEmail(id).url
     )
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EmailVerificationSupport.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EmailVerificationSupport.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
+
+import cats.implicits.catsSyntaxOptionId
+import play.api.data.Form
+import play.api.data.Forms.{email, mapping}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{EmailType, RetrieveEmailResponse}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, OptionalEmailFormInput}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EmailService, EmailVerificationService}
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfEqual
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EmailVerificationSupport extends FormHelpers { this: FrontendController =>
+
+  protected val emailService: EmailService
+  protected val emailVerificationService: EmailVerificationService
+
+  protected implicit val executionContext: ExecutionContext
+
+  protected val optionalEmailForm: Form[OptionalEmailFormInput] = Form(
+    mapping(
+      "using-stored-email" -> mandatory("using-stored-email"),
+      "email" -> mandatoryIfEqual("using-stored-email", "false", email)
+    )(OptionalEmailFormInput.apply)(OptionalEmailFormInput.unapply)
+  )
+
+  protected val emailForm: Form[FormValues] = Form(
+    mapping(
+      "email" -> email
+    )(FormValues.apply)(FormValues.unapply)
+  )
+
+  protected def findVerifiedEmail(implicit eori: EORI, hc: HeaderCarrier): Future[Option[String]] = {
+    emailVerificationService
+      .getEmailVerification(eori)
+      .toContext
+      .foldF(retrieveCdsEmail)(_.email.some.toFuture)
+  }
+
+  private def retrieveCdsEmail(implicit eori: EORI, hc: HeaderCarrier): Future[Option[String]] =
+    emailService
+      .retrieveEmailByEORI(eori)
+      .map {
+        case RetrieveEmailResponse(EmailType.VerifiedEmail, email) => email.map(_.value)
+        case _ => Option.empty
+      }
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EmailVerificationSupport.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EmailVerificationSupport.scala
@@ -103,11 +103,7 @@ trait EmailVerificationSupport extends FormHelpers { this: FrontendController =>
     }
   }
 
-  // Default implementation is a no-op. Override as required if you need to store the email on the journey.
-  protected def addVerifiedEmailToJourney(email: String)(implicit eori: EORI): Future[Unit] = {
-    eori.length // TODO - cludge to silence warning on unused implicit here - review
-    ().toFuture
-  }
+  protected def addVerifiedEmailToJourney(email: String)(implicit eori: EORI): Future[Unit]
 
   protected def handleConfirmEmailPost[A: ClassTag](
     previous: Call,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -40,7 +40,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class NoClaimNotificationController @Inject() (
                                                 mcc: MessagesControllerComponents,
                                                 actionBuilders: ActionBuilders,
-                                                store: Store,
+                                                override val store: Store,
                                                 override val escService: EscService,
                                                 auditService: AuditService,
                                                 timeProvider: TimeProvider,
@@ -48,6 +48,7 @@ class NoClaimNotificationController @Inject() (
                                                 noClaimConfirmationPage: NoClaimConfirmationPage,
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc)
+    with FormHelpers
     with LeadOnlyUndertakingSupport {
   import actionBuilders._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -39,7 +39,7 @@ class SelectNewLeadController @Inject() (
                                           mcc: MessagesControllerComponents,
                                           actionBuilders: ActionBuilders,
                                           override val escService: EscService,
-                                          store: Store,
+                                          override val store: Store,
                                           emailService: EmailService,
                                           auditService: AuditService,
                                           selectNewLeadPage: SelectNewLeadPage,
@@ -47,6 +47,7 @@ class SelectNewLeadController @Inject() (
                                           emailNotVerifiedForLeadPromotionPage: EmailNotVerifiedForLeadPromotionPage
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc)
+    with FormHelpers
     with LeadOnlyUndertakingSupport {
 
   import actionBuilders._

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -162,13 +162,8 @@ class UndertakingController @Inject() (
   }
 
   override def addVerifiedEmailToJourney(email: String)(implicit eori: EORI): Future[Unit] = {
-    println(s"Storing verified email: $email in UndertakingJourney")
     store
       .update[UndertakingJourney](_.setVerifiedEmail(email))
-      .map { j =>
-        println(s"Updated undertaking journey: $j")
-        j
-      }
       .map(_ => ())
   }
 
@@ -177,7 +172,7 @@ class UndertakingController @Inject() (
       previous = routes.UndertakingController.getConfirmEmail(),
       next = routes.UndertakingController.getCheckAnswers(),
       formAction = routes.UndertakingController.postConfirmEmail(),
-      generateEmailVerificationUrl = (id: String) => routes.UndertakingController.getVerifyEmail(id).url
+      generateVerifyEmailUrl = (id: String) => routes.UndertakingController.getVerifyEmail(id).url
     )
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -161,16 +161,23 @@ class UndertakingController @Inject() (
     )
   }
 
-  override def addVerifiedEmailToJourney(email: String)(implicit eori: EORI): Future[Unit] =
+  override def addVerifiedEmailToJourney(email: String)(implicit eori: EORI): Future[Unit] = {
+    println(s"Storing verified email: $email in UndertakingJourney")
     store
       .update[UndertakingJourney](_.setVerifiedEmail(email))
+      .map { j =>
+        println(s"Updated undertaking journey: $j")
+        j
+      }
       .map(_ => ())
+  }
 
   def postConfirmEmail: Action[AnyContent] = enrolled.async { implicit request =>
     handleConfirmEmailPost[UndertakingJourney](
       previous = routes.UndertakingController.getConfirmEmail(),
       next = routes.UndertakingController.getCheckAnswers(),
       formAction = routes.UndertakingController.postConfirmEmail(),
+      generateEmailVerificationUrl = (id: String) => routes.UndertakingController.getVerifyEmail(id).url
     )
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -162,11 +162,11 @@ class UndertakingController @Inject() (
         if (journey.isEligibleForStep) {
           emailVerificationService.getEmailVerification(request.eoriNumber).flatMap {
             case Some(verifiedEmail) =>
-              Ok(confirmEmailPage(optionalEmailForm, EmailAddress(verifiedEmail.email), routes.UndertakingController.getSector().url)).toFuture
+              Ok(confirmEmailPage(optionalEmailForm, routes.UndertakingController.postConfirmEmail(), EmailAddress(verifiedEmail.email), routes.UndertakingController.getSector().url)).toFuture
             case None => emailService.retrieveEmailByEORI(request.eoriNumber) map { response =>
               response.emailType match {
                 case EmailType.VerifiedEmail =>
-                  Ok(confirmEmailPage(optionalEmailForm, response.emailAddress.get, routes.UndertakingController.getSector().url))
+                  Ok(confirmEmailPage(optionalEmailForm, routes.UndertakingController.postConfirmEmail(), response.emailAddress.get, routes.UndertakingController.getSector().url))
                 case _ =>
                   Ok(inputEmailPage(emailForm, routes.UndertakingController.getSector().url))
               }
@@ -195,7 +195,7 @@ class UndertakingController @Inject() (
         optionalEmailForm
           .bindFromRequest()
           .fold(
-            errors => BadRequest(confirmEmailPage(errors, EmailAddress(email), routes.EligibilityController.getDoYouClaim().url)).toFuture,
+            errors => BadRequest(confirmEmailPage(errors, routes.UndertakingController.postConfirmEmail(), EmailAddress(email), routes.EligibilityController.getDoYouClaim().url)).toFuture,
             {
               case OptionalEmailFormInput("true", None) =>
                 for {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/OptionalEmailFormInput.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/OptionalEmailFormInput.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.models
 import play.api.libs.json.{Format, Json}
 
 case class OptionalEmailFormInput(
-  setValue: String,
+  usingStoredEmail: String,
   value: Option[String]
 )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/Undertaking.scala
@@ -42,16 +42,18 @@ case class Undertaking(
   def getBusinessEntityByEORI(eori: EORI): BusinessEntity =
     undertakingBusinessEntity
       .find(be => be.businessEntityIdentifier == eori)
-      .getOrElse(throw new IllegalStateException(s"BE with eori $eori is missing"))
+      .getOrElse(throw new IllegalStateException(s"No business entity found for given eori"))
 
   def getAllNonLeadEORIs: List[EORI] =
     undertakingBusinessEntity.filter(!_.leadEORI).map(_.businessEntityIdentifier)
 
-  def getLeadEORI = undertakingBusinessEntity
+  def getLeadEORI: EORI = undertakingBusinessEntity
     .filter(_.leadEORI)
     .map(_.businessEntityIdentifier)
     .headOption
     .getOrElse(throw new IllegalStateException(s"Lead EORI is missing"))
+
+  def getLeadBusinessEntity: BusinessEntity = getBusinessEntityByEORI(getLeadEORI)
 }
 
 object Undertaking {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
@@ -23,14 +23,14 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.services.Journey.Form
 
 case class BecomeLeadJourney(
   becomeLeadEori: BecomeLeadEoriFormPage = BecomeLeadEoriFormPage(),
-  acceptTerms: TermsAndConditionsFormPage = TermsAndConditionsFormPage(),
+  acceptResponsibilities: AcceptResponsibilitiesFormPage = AcceptResponsibilitiesFormPage(),
   confirmation: ConfirmationFormPage = ConfirmationFormPage()
 ) extends Journey {
 
   override def steps: Array[FormPage[_]] =
     Array(
+      acceptResponsibilities,
       becomeLeadEori,
-      acceptTerms,
       confirmation
     )
 
@@ -47,8 +47,8 @@ object BecomeLeadJourney {
     case class BecomeLeadEoriFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] {
       def uri = controller.getBecomeLeadEori().url
     }
-    case class TermsAndConditionsFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] {
-      def uri = controller.getAcceptPromotionTerms().url
+    case class AcceptResponsibilitiesFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] {
+      def uri = controller.getAcceptResponsibilities().url
     }
     case class ConfirmationFormPage(value: Form[Boolean] = None) extends FormPage[Boolean] {
       def uri = controller.getPromotionConfirmation().url
@@ -57,8 +57,8 @@ object BecomeLeadJourney {
     object BecomeLeadEoriFormPage {
       implicit val becomeLeadEoriFormPageFormat: OFormat[BecomeLeadEoriFormPage] = Json.format
     }
-    object TermsAndConditionsFormPage {
-      implicit val termsAndConditionsFormPageFormat: OFormat[TermsAndConditionsFormPage] = Json.format
+    object AcceptResponsibilitiesFormPage {
+      implicit val acceptResponsibilitiesFormPageFormat: OFormat[AcceptResponsibilitiesFormPage] = Json.format
     }
     object ConfirmationFormPage { implicit val confirmationFormPageFormat: OFormat[ConfirmationFormPage] = Json.format }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourney.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
+import cats.implicits.catsSyntaxOptionId
 import play.api.libs.json.{Format, Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormPages._
@@ -33,6 +34,10 @@ case class BecomeLeadJourney(
       becomeLeadEori,
       confirmation
     )
+
+  def setAcceptResponsibilities(value: Boolean): BecomeLeadJourney = this.copy(
+    acceptResponsibilities = acceptResponsibilities.copy(value = value.some)
+  )
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 import com.google.inject.Inject
 import play.api.Logging
 import play.api.http.Status.CREATED
+import play.api.mvc.Call
 import play.api.mvc.Results.Redirect
-import play.api.mvc.{Call, RequestHeader}
 import uk.gov.hmrc.eusubsidycompliancefrontend.cache.EoriEmailDatastore
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EmailVerificationConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -44,7 +44,7 @@ class EmailVerificationService @Inject() (
 
   def useAbsoluteUrls: Boolean = emailVerificationBaseUrl.contains("localhost")
 
-  def verifyEmail(verifyEmailUrl: String, confirmEmailUrl: String)(credId: String, email: String)(implicit hc: HeaderCarrier, ec: ExecutionContext, h: RequestHeader): Future[Option[EmailVerificationResponse]] = {
+  def verifyEmail(verifyEmailUrl: String, confirmEmailUrl: String)(credId: String, email: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[EmailVerificationResponse]] = {
     emailVerificationConnector
       .verifyEmail(
         EmailVerificationRequest(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EmailVerificationConne
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.util.UUID
@@ -84,9 +85,9 @@ class EmailVerificationService @Inject() (
     case None => Redirect(confirmEmailCall)
   }
 
-  def getEmailVerification(eori: EORI) = eoriEmailDatastore.getEmailVerification(eori)
+  def getEmailVerification(eori: EORI): Future[Option[VerifiedEmail]] = eoriEmailDatastore.getEmailVerification(eori)
 
-  def verifyEori(eori: EORI) = eoriEmailDatastore.verifyEmail(eori)
+  def verifyEori(eori: EORI): Future[CacheItem] = eoriEmailDatastore.verifyEmail(eori)
 
   def approveVerificationRequest(key: EORI, verificationId: String) = eoriEmailDatastore.approveVerificationRequest(key, verificationId)
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -35,7 +35,6 @@ import java.util.UUID
 import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
 
-// TODO - fix relative/abs url handling
 @Singleton
 class EmailVerificationService @Inject() (
    emailVerificationConnector: EmailVerificationConnector,
@@ -45,9 +44,10 @@ class EmailVerificationService @Inject() (
 
   def getEmailVerification(eori: EORI): Future[Option[VerifiedEmail]] = eoriEmailDatastore.getEmailVerification(eori)
 
-  // TODO - this exposes mongo internals - return a boolean instead?
-  def approveVerificationRequest(key: EORI, verificationId: String): Future[UpdateResult] =
-    eoriEmailDatastore.approveVerificationRequest(key, verificationId)
+  def approveVerificationRequest(key: EORI, verificationId: String)(implicit ec: ExecutionContext): Future[Boolean] =
+    eoriEmailDatastore
+      .approveVerificationRequest(key, verificationId)
+      .map(_.getMatchedCount > 0)
 
   // Add an email address that's already approved
   def addVerifiedEmail(eori: EORI, emailAddress: String)(implicit ec: ExecutionContext): Future[Unit] =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -33,6 +33,7 @@ import java.util.UUID
 import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
 
+// TODO - this needs to support both BusinessEntity promote and Undertaking create flows
 @Singleton
 class EmailVerificationService @Inject() (
    emailVerificationConnector: EmailVerificationConnector,
@@ -49,7 +50,10 @@ class EmailVerificationService @Inject() (
       .verifyEmail(
         EmailVerificationRequest(
           credId = credId,
-          continueUrl = if(useAbsoluteUrls) routes.UndertakingController.getVerifyEmail(verificationId).absoluteURL() else routes.UndertakingController.getVerifyEmail(verificationId).url,
+          // TODO - this needs to take a parameter - also provide syntax to get the URL?
+          continueUrl =
+            if(useAbsoluteUrls) routes.UndertakingController.getVerifyEmail(verificationId).absoluteURL()
+            else routes.UndertakingController.getVerifyEmail(verificationId).url,
           origin = "EU Subsidy Compliance",
           deskproServiceName = None,
           accessibilityStatementUrl = "",
@@ -58,7 +62,10 @@ class EmailVerificationService @Inject() (
             enterUrl = ""
           )),
           lang = None,
-          backUrl = if(useAbsoluteUrls) Some(routes.UndertakingController.getConfirmEmail().absoluteURL()) else Some(routes.UndertakingController.getConfirmEmail().url),
+          // TODO - this needs to take a parameter - also provide syntax to get the URL?
+          backUrl =
+            if(useAbsoluteUrls) Some(routes.UndertakingController.getConfirmEmail().absoluteURL())
+            else Some(routes.UndertakingController.getConfirmEmail().url),
           pageTitle = None
         )
       ).map {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -35,7 +35,8 @@ import java.util.UUID
 import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
 
-// TODO - this needs to support both BusinessEntity promote and Undertaking create flows
+// TODO - review public apis here
+// TODO - fix relative/abs url handling
 @Singleton
 class EmailVerificationService @Inject() (
    emailVerificationConnector: EmailVerificationConnector,
@@ -52,8 +53,6 @@ class EmailVerificationService @Inject() (
       .verifyEmail(
         EmailVerificationRequest(
           credId = credId,
-          // TODO - this needs to take a parameter - also provide syntax to get the URL?
-          // TODO - fix handling of abs vs relative urls
           continueUrl =
             if(useAbsoluteUrls) verifyEmailUrl
             else verifyEmailUrl,
@@ -65,9 +64,7 @@ class EmailVerificationService @Inject() (
             enterUrl = ""
           )),
           lang = None,
-          // TODO - this needs to take a parameter - also provide syntax to get the URL?
           backUrl =
-            // TODO - fix handling of abs vs rel urls
             if(useAbsoluteUrls) Some(confirmEmailUrl)
             else Some(confirmEmailUrl),
           pageTitle = None

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -66,7 +66,6 @@ class EmailVerificationService @Inject() (
     hc: HeaderCarrier
   ): Future[Result] = for {
     verificationId <- addVerificationRequest(request.eoriNumber, email)
-    _ = println(s"Added verification request for email: $email")
     verificationResponse <- verifyEmail(nextPageUrl(verificationId), previousPage.url)(request.authorityId, email)
   } yield verificationResponse.fold(Redirect(previousPage))(value => Redirect(value.redirectUri))
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -20,14 +20,13 @@ import com.google.inject.Inject
 import org.mongodb.scala.result.UpdateResult
 import play.api.Logging
 import play.api.http.Status.CREATED
-import play.api.mvc.{AnyContent, Call}
 import play.api.mvc.Results.Redirect
+import play.api.mvc.{AnyContent, Call, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.cache.EoriEmailDatastore
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EmailVerificationConnector
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -36,7 +35,6 @@ import java.util.UUID
 import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
 
-// TODO - review public apis here
 // TODO - fix relative/abs url handling
 @Singleton
 class EmailVerificationService @Inject() (
@@ -45,18 +43,45 @@ class EmailVerificationService @Inject() (
    servicesConfig: ServicesConfig
 ) extends Logging {
 
-  lazy private val emailVerificationBaseUrl: String = servicesConfig.baseUrl("email-verification")
+  def getEmailVerification(eori: EORI): Future[Option[VerifiedEmail]] = eoriEmailDatastore.getEmailVerification(eori)
 
-  lazy val useAbsoluteUrls: Boolean = emailVerificationBaseUrl.contains("localhost")
+  // TODO - this exposes mongo internals - return a boolean instead?
+  def approveVerificationRequest(key: EORI, verificationId: String): Future[UpdateResult] =
+    eoriEmailDatastore.approveVerificationRequest(key, verificationId)
 
-  private def verifyEmail(verifyEmailUrl: String, confirmEmailUrl: String)(credId: String, email: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[EmailVerificationResponse]] = {
+  // Add an email address that's already approved
+  def addVerifiedEmail(eori: EORI, emailAddress: String)(implicit ec: ExecutionContext): Future[Unit] =
+    for {
+      _ <- addVerificationRequest(eori, emailAddress)
+      _ <- verifyEmailForEori(eori)
+    } yield ()
+
+
+  def makeVerificationRequestAndRedirect(
+    email: String,
+    previousPage: Call,
+    nextPageUrl: String => String,
+  )(implicit request: AuthenticatedEnrolledRequest[AnyContent],
+    ec: ExecutionContext,
+    hc: HeaderCarrier
+  ): Future[Result] = for {
+    verificationId <- addVerificationRequest(request.eoriNumber, email)
+    _ = println(s"Added verification request for email: $email")
+    verificationResponse <- verifyEmail(nextPageUrl(verificationId), previousPage.url)(request.authorityId, email)
+  } yield verificationResponse.fold(Redirect(previousPage))(value => Redirect(value.redirectUri))
+
+  private def verifyEmail(
+    verifyEmailUrl: String,
+    confirmEmailUrl: String
+  )(credId: String,
+    email: String
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[EmailVerificationResponse]] = {
+    // TODO - TECH DEBT TICKET - the connector can construct the request so we just pass in the params we care about here.
     emailVerificationConnector
       .verifyEmail(
         EmailVerificationRequest(
           credId = credId,
-          continueUrl =
-            if(useAbsoluteUrls) verifyEmailUrl
-            else verifyEmailUrl,
+          continueUrl = verifyEmailUrl,
           origin = "EU Subsidy Compliance",
           deskproServiceName = None,
           accessibilityStatementUrl = "",
@@ -65,13 +90,12 @@ class EmailVerificationService @Inject() (
             enterUrl = ""
           )),
           lang = None,
-          backUrl =
-            if(useAbsoluteUrls) Some(confirmEmailUrl)
-            else Some(confirmEmailUrl),
+          backUrl = Some(confirmEmailUrl),
           pageTitle = None
         )
       ).map {
-      case Left(error) => throw ConnectorError(s"Error sending email:Id", error)
+      case Left(error) =>
+        throw ConnectorError(s"Error sending email:Id", error)
       case Right(value) =>
         value.status match {
           case CREATED => Some(value.json.as[EmailVerificationResponse])
@@ -80,19 +104,7 @@ class EmailVerificationService @Inject() (
     }
   }
 
-  // TODO - fold?
-  private def emailVerificationRedirect(confirmEmailCall: Call)(verifyEmailResponse: Option[EmailVerificationResponse]) = verifyEmailResponse match {
-    case Some(value) => Redirect(emailVerificationConnector.getVerificationJourney(value.redirectUri))
-    case None => Redirect(confirmEmailCall)
-  }
-
-  def getEmailVerification(eori: EORI): Future[Option[VerifiedEmail]] = eoriEmailDatastore.getEmailVerification(eori)
-
-  private def verifyEori(eori: EORI): Future[CacheItem] = eoriEmailDatastore.verifyEmail(eori)
-
-  // TODO - this exposes mongo internals - return a boolean instead?
-  def approveVerificationRequest(key: EORI, verificationId: String): Future[UpdateResult] =
-    eoriEmailDatastore.approveVerificationRequest(key, verificationId)
+  private def verifyEmailForEori(eori: EORI): Future[CacheItem] = eoriEmailDatastore.verifyEmail(eori)
 
   private def addVerificationRequest(key: EORI, email: String)(implicit ec: ExecutionContext): Future[String] = {
     val verificationId = UUID.randomUUID().toString
@@ -103,19 +115,5 @@ class EmailVerificationService @Inject() (
         _.fold(throw new IllegalArgumentException("Error storing email verification request"))(_.verificationId)
       }
   }
-
-  // Add an email address that's already approved
-  def addVerifiedEmail(eori: EORI, emailAddress: String)(implicit ec: ExecutionContext): Future[Unit] =
-    for {
-      _ <- addVerificationRequest(eori, emailAddress)
-      _ <- verifyEori(eori)
-    } yield ()
-
-
-  def makeVerificationRequestAndRedirect(email: String, previousPage: Call, nextPageUrl: String => String,
-  )(implicit request: AuthenticatedEnrolledRequest[AnyContent], ec: ExecutionContext, hc: HeaderCarrier) = for {
-    verificationId <- addVerificationRequest(request.eoriNumber, email)
-    verificationResponse <- verifyEmail(nextPageUrl(verificationId), previousPage.url)(request.authorityId, email)
-  } yield emailVerificationRedirect(previousPage)(verificationResponse)
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationService.scala
@@ -89,6 +89,7 @@ class EmailVerificationService @Inject() (
 
   def verifyEori(eori: EORI): Future[CacheItem] = eoriEmailDatastore.verifyEmail(eori)
 
+  // TODO - this exposes mongo internals - return a boolean instead?
   def approveVerificationRequest(key: EORI, verificationId: String) = eoriEmailDatastore.approveVerificationRequest(key, verificationId)
 
   def addVerificationRequest(key: EORI, email: String)(implicit ec: ExecutionContext): Future[String] = {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EscService.scala
@@ -106,6 +106,10 @@ class EscService @Inject() (
       .value
   }
 
+  def getUndertaking(eori: EORI)(implicit hc: HeaderCarrier): Future[Undertaking] =
+    retrieveUndertaking(eori).toContext
+      .getOrElse(throw new IllegalStateException("Expected undertaking not found"))
+
   def addMember(undertakingRef: UndertakingRef, businessEntity: BusinessEntity)(implicit
     hc: HeaderCarrier
   ): Future[UndertakingRef] =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -59,8 +59,13 @@ case class UndertakingJourney(
 
   override def next(implicit request: Request[_]): Future[Result] =
     if (isAmend) Redirect(routes.UndertakingController.getAmendUndertakingDetails()).toFuture
-    else if (requiredDetailsProvided) Redirect(routes.UndertakingController.getCheckAnswers()).toFuture
-    else super.next
+    else if (requiredDetailsProvided) {
+      println(s"all data provided - redirecting to check your answers")
+      Redirect(routes.UndertakingController.getCheckAnswers()).toFuture
+    } else {
+      println(s"Not on amend journey and not all data has been provided - delegating to super.next")
+      super.next
+    }
 
   def isEmpty: Boolean = steps.flatMap(_.value).isEmpty
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -77,7 +77,12 @@ case class UndertakingJourney(
 
   def setUndertakingCYA(b: Boolean): UndertakingJourney = this.copy(cya = cya.copy(value = Some(b)))
 
-  def setVerifiedEmail(e: String): UndertakingJourney = this.copy(verifiedEmail = verifiedEmail.copy(value = Some(e)))
+  def setVerifiedEmail(e: String): UndertakingJourney = {
+    println(s"setVerifiedEmail: setting email $e on UndertakingJourney")
+    val result = this.copy(verifiedEmail = verifiedEmail.copy(value = Some(e)))
+    println(s"setVerifiedEmail: returning updated journey: $result")
+    result
+  }
 
   def setAddBusiness(b: Boolean): UndertakingJourney = this.copy(addBusiness = addBusiness.copy(value = b.some))
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/UndertakingJourney.scala
@@ -59,13 +59,8 @@ case class UndertakingJourney(
 
   override def next(implicit request: Request[_]): Future[Result] =
     if (isAmend) Redirect(routes.UndertakingController.getAmendUndertakingDetails()).toFuture
-    else if (requiredDetailsProvided) {
-      println(s"all data provided - redirecting to check your answers")
-      Redirect(routes.UndertakingController.getCheckAnswers()).toFuture
-    } else {
-      println(s"Not on amend journey and not all data has been provided - delegating to super.next")
-      super.next
-    }
+    else if (requiredDetailsProvided) Redirect(routes.UndertakingController.getCheckAnswers()).toFuture
+    else super.next
 
   def isEmpty: Boolean = steps.flatMap(_.value).isEmpty
 
@@ -77,12 +72,7 @@ case class UndertakingJourney(
 
   def setUndertakingCYA(b: Boolean): UndertakingJourney = this.copy(cya = cya.copy(value = Some(b)))
 
-  def setVerifiedEmail(e: String): UndertakingJourney = {
-    println(s"setVerifiedEmail: setting email $e on UndertakingJourney")
-    val result = this.copy(verifiedEmail = verifiedEmail.copy(value = Some(e)))
-    println(s"setVerifiedEmail: returning updated journey: $result")
-    result
-  }
+  def setVerifiedEmail(e: String): UndertakingJourney = this.copy(verifiedEmail = verifiedEmail.copy(value = Some(e)))
 
   def setAddBusiness(b: Boolean): UndertakingJourney = this.copy(addBusiness = addBusiness.copy(value = b.some))
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminAcceptResponsibilitiesPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminAcceptResponsibilitiesPage.scala.html
@@ -46,7 +46,7 @@
   @H2(messages("become-admin-tandc.h2-3"))
   @P(messages("become-admin-tandc.p5"))
 
-  @formHelper(action = controllers.routes.BecomeLeadController.postAcceptPromotionTerms()) {
+  @formHelper(action = controllers.routes.BecomeLeadController.postAcceptResponsibilities()) {
     @button("common.accept")
   }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminAcceptResponsibilitiesPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminAcceptResponsibilitiesPage.scala.html
@@ -32,19 +32,25 @@
 
 @(eori: EORI)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
+@key = @{"become-admin-responsibilities"}
+
 @layout(
-  pageTitle = Some(messages("become-admin-tandc.title"))
+  pageTitle = Some(messages(s"$key.title"))
 ) {
 
-  @H1(messages("become-admin-tandc.title"))
-  @H2(messages("become-admin-tandc.h2"))
-  @P(messages("become-admin-tandc.p1"))
-  @H2(messages("become-admin-tandc.h2-2"))
-  @P(messages("become-admin-tandc.p2"))
-  @P(messages("become-admin-tandc.p3"))
-  @P(messages("become-admin-tandc.p4", eori))
-  @H2(messages("become-admin-tandc.h2-3"))
-  @P(messages("become-admin-tandc.p5"))
+  @H1(messages(s"$key.title"))
+
+  @P(messages(s"$key.p1"))
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>@messages(s"$key.li1")</li>
+    <li>@messages(s"$key.li2")</li>
+    <li>@messages(s"$key.li3")</li>
+    <li>@messages(s"$key.li4")</li>
+    <li>@messages(s"$key.li5")</li>
+  </ul>
+
+  @P(messages(s"$key.p2"))
 
   @formHelper(action = controllers.routes.BecomeLeadController.postAcceptResponsibilities()) {
     @button("common.accept")

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminAcceptResponsibilitiesPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminAcceptResponsibilitiesPage.scala.html
@@ -53,7 +53,7 @@
   @P(messages(s"$key.p2"))
 
   @formHelper(action = controllers.routes.BecomeLeadController.postAcceptResponsibilities()) {
-    @button("common.accept")
+    @button("common.continue.only")
   }
 
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminConfirmationPage.scala.html
@@ -41,7 +41,7 @@
   @P(messages("become-admin-confirmation.p1"))
   @P(messages("become-admin-confirmation.p2"))
   <div>
-    <a class="govuk-link" href=@routes.BecomeLeadController.getPromotionCleanup()>@messages("common.go-account-home")</a>
+    <a class="govuk-link" href=@routes.AccountController.getAccountPage()>@messages("common.go-account-home")</a>
   </div>
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminConfirmationPage.scala.html
@@ -28,7 +28,7 @@
   govukSummaryList: GovukSummaryList
 )
 
-@(eori: EORI)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @layout(
   pageTitle = Some(messages("become-admin-confirmation.title"))
@@ -39,7 +39,7 @@
   </div>
   @H2(messages("become-admin-confirmation.h2"))
   @P(messages("become-admin-confirmation.p1"))
-  @P(messages("become-admin-confirmation.p2", eori))
+  @P(messages("become-admin-confirmation.p2"))
   <div>
     <a class="govuk-link" href=@routes.BecomeLeadController.getPromotionCleanup()>@messages("common.go-account-home")</a>
   </div>

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/BecomeAdminPage.scala.html
@@ -30,7 +30,7 @@
   govukSummaryList: GovukSummaryList
 )
 
-@(form: Form[_], eori: EORI)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(form: Form[_])(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @layout(
   pageTitle = Some(messages("become-admin.title")),
@@ -65,7 +65,7 @@
               ))
           )),
           hint = Some(Hint(
-            content = Text(messages("become-admin.hint", eori))
+            content = Text(messages("become-admin.hint"))
           )),
           idPrefix = Some("becomeAdmin"),
           name = "becomeAdmin",

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmEmailPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmEmailPage.scala.html
@@ -59,7 +59,7 @@
 }
 
 @layout(
-    pageTitle = Some(messages("add-claim-trader-reference.title")),
+    pageTitle = Some(messages("confirmEmail.title")),
     backLinkEnabled = true,
     backLink = Some(previous),
     hasErrors = form.hasErrors

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmEmailPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmEmailPage.scala.html
@@ -30,7 +30,12 @@
   govukInput : GovukInput,
   govukInsetText: GovukInsetText
 )
-@(form: Form[_], email: EmailAddress, previous: Journey.Uri)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(
+    form: Form[_],
+    action: Call,
+    email: EmailAddress,
+    previous: Journey.Uri
+)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @radioIdentifier = @{"using-stored-email"}
 @inputIdentifier = @{"email"}
@@ -60,8 +65,7 @@
     hasErrors = form.hasErrors
 ) {
 
-
-    @formHelper(action = controllers.routes.UndertakingController.postConfirmEmail()) {
+    @formHelper(action) {
       @if(form.hasErrors) {
           @govukErrorSummary(
               ErrorSummary(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/NonLeadAccountPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/NonLeadAccountPage.scala.html
@@ -78,7 +78,7 @@
 
   @H2(messages(s"$key.h2-4"))
   <ul class="govuk-list govuk-list--spaced">
-    <li><a href="@routes.BecomeLeadController.getBecomeLeadEori()" class="govuk-link">@messages(s"$key.ul2-li1")</a></li>
+    <li><a href="@routes.BecomeLeadController.getAcceptResponsibilities()" class="govuk-link">@messages(s"$key.ul2-li1")</a></li>
     <li><a href="@routes.BusinessEntityController.getRemoveYourselfBusinessEntity()" class="govuk-link">@messages(s"$key.ul2-li2")</a></li>
   </ul>
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -107,6 +107,9 @@ POST       /business-enterprise-become-lead-eori                                
 GET        /business-enterprise-accept-responsibilities                                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getAcceptResponsibilities()
 POST       /business-enterprise-accept-responsibilities                                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postAcceptResponsibilities()
 
+GET        /business-enterprise-confirm-email                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getConfirmEmail
+POST       /business-enterprise-confirm-email                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postConfirmEmail
+
 GET        /business-enterprise-admin-request                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionConfirmation()
 
 GET        /lead-undertaking-non-customs-subsidy-nil-return                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimNotification

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -104,8 +104,8 @@ GET        /lead-undertaking-lead-eori-changed                                  
 GET        /business-enterprise-become-lead-eori                                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getBecomeLeadEori()
 POST       /business-enterprise-become-lead-eori                                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postBecomeLeadEori()
 
-GET        /business-enterprise-terms-conditions                                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getAcceptPromotionTerms()
-POST       /business-enterprise-terms-conditions                                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postAcceptPromotionTerms()
+GET        /business-enterprise-accept-responsibilities                                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getAcceptResponsibilities()
+POST       /business-enterprise-accept-responsibilities                                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postAcceptResponsibilities()
 
 GET        /business-enterprise-admin-request                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionConfirmation()
 GET        /lead-promotion-confirmation-cleanup                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionCleanup()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -35,7 +35,7 @@ POST       /first-login-confirm-email                                           
 GET        /first-login-add-business                                                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getAddBusiness
 POST       /first-login-add-business                                                    uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postAddBusiness
 
-GET        /verify-email                                                                uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getVerifyEmail(UndertakingControllerpendingVerificationId)
+GET        /verify-email/:pendingVerificationId                                         uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getVerifyEmail(pendingVerificationId)
 
 GET        /first-login-journey-check-your-answers                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.getCheckAnswers
 POST       /first-login-journey-check-your-answers                                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.UndertakingController.postCheckAnswers
@@ -110,7 +110,7 @@ POST       /business-enterprise-accept-responsibilities                         
 GET        /business-enterprise-confirm-email                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getConfirmEmail
 POST       /business-enterprise-confirm-email                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postConfirmEmail
 
-GET        /business-enterprise-verify-email                                             uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getVerifyEmail(UndertakingControllerpendingVerificationId)
+GET        /business-enterprise-verify-email/:pendingVerificationId                      uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getVerifyEmail(pendingVerificationId)
 
 GET        /business-enterprise-admin-request                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionConfirmation()
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -108,7 +108,6 @@ GET        /business-enterprise-accept-responsibilities                         
 POST       /business-enterprise-accept-responsibilities                                  uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postAcceptResponsibilities()
 
 GET        /business-enterprise-admin-request                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionConfirmation()
-GET        /lead-promotion-confirmation-cleanup                                          uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionCleanup()
 
 GET        /lead-undertaking-non-customs-subsidy-nil-return                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimNotification
 POST       /lead-undertaking-non-customs-subsidy-nil-return                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.postNoClaimNotification

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -110,6 +110,8 @@ POST       /business-enterprise-accept-responsibilities                         
 GET        /business-enterprise-confirm-email                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getConfirmEmail
 POST       /business-enterprise-confirm-email                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.postConfirmEmail
 
+GET        /business-enterprise-verify-email                                             uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getVerifyEmail(UndertakingControllerpendingVerificationId)
+
 GET        /business-enterprise-admin-request                                            uk.gov.hmrc.eusubsidycompliancefrontend.controllers.BecomeLeadController.getPromotionConfirmation()
 
 GET        /lead-undertaking-non-customs-subsidy-nil-return                              uk.gov.hmrc.eusubsidycompliancefrontend.controllers.NoClaimNotificationController.getNoClaimNotification

--- a/conf/messages
+++ b/conf/messages
@@ -458,15 +458,14 @@ become-admin.title=Do you want to become the administrator for the undertaking
 become-admin.hint=As undertaking administrator, the business EORI number {0} will be responsible for reporting de minimis aid (less Customs Duty waivers) payments received by all businesses which are part of this single undertaking.
 becomeAdmin.error.required = Select yes if you want to become administrator for this undertaking 
 
-become-admin-tandc.title=You must accept the terms and conditions
-become-admin-tandc.h2=Reporting de minimis aid payments (less Customs Duty waivers) as a single undertaking
-become-admin-tandc.p1=De minimis aid payments (less Customs Duty waivers) could include subsidised contracts, loans or grants, from organisations like Invest NI and NI Direct. If you are unsure if an aid you claim is counted as de minimis aid payments (less Customs Duty waivers) you should contact the provider.
-become-admin-tandc.h2-2=What is a single undertaking?
-become-admin-tandc.p2=HMRC needs to group together related businesses within a company or organisation into a ‘single undertaking’. Businesses within an undertaking are identified by their EORI number.
-become-admin-tandc.p3=Every company may be structured differently. You may be a sole trader, a limited company or partnership. You may be a larger business, with subsidiary companies within the organisation. However a business is structured, we need to group all subsidiary or parent companies together. This is referred to as a single undertaking.
-become-admin-tandc.p4=EORI number {0} will be the administrator for this single undertaking. The administrator is a business, not a person.
-become-admin-tandc.h2-3=Declaration
-become-admin-tandc.p5=I agree to the terms and conditions.
+become-admin-responsibilities.title = Become the administrator for this undertaking
+become-admin-responsibilities.p1 = By taking on the role of undertaking administrator it is your role to:
+become-admin-responsibilities.li1 = report all non-customs subsidy payments received by any member of the undertaking. You must do this every 90 days
+become-admin-responsibilities.li2 = report if the undertaking has not received any non-customs subsidy payments. You must do this every 90 days
+become-admin-responsibilities.li3 = check you do not go over the combined customs and non-customs subsidy allowance for your sector
+become-admin-responsibilities.li4 = inform us about any changes to the businesses in your undertaking
+become-admin-responsibilities.li5 = keep your undertaking details up-to-date
+become-admin-responsibilities.p2 = By accepting, you will take on the above responsibilities with immediate effect.
 
 become-admin-confirmation.title=You have asked to become the administrator for this single undertaking
 become-admin-confirmation.h2=What happens next

--- a/conf/messages
+++ b/conf/messages
@@ -148,7 +148,7 @@ addBusinessIntent.hint=Are there other businesses in your undertaking
 addBusinessIntent.error.required=Select yes if you need to add a business to your undertaking?
 
 confirmEmail.no.label=Enter new email address
-confirmEmail.title=Is this the email address you want to use for your undertaking?
+confirmEmail.title=Is this the email address you want to use to receive notifications?
 
 inputEmail.title=What is your email address?
 inputEmail.label=Enter an email

--- a/conf/messages
+++ b/conf/messages
@@ -454,8 +454,8 @@ dashboard.sector.name.2 = Agriculture
 dashboard.sector.name.3 = Aquaculture
 dashboard.allowance.remaining.heading = Allowance remaining
 
-become-admin.title=Do you want to become the administrator for the undertaking
-become-admin.hint=As undertaking administrator, the business EORI number {0} will be responsible for reporting de minimis aid (less Customs Duty waivers) payments received by all businesses which are part of this single undertaking.
+become-admin.title=Do you want to become the administrator for this undertaking?
+become-admin.hint=As undertaking administrator, you will be responsible for reporting de minimis aid (less Customs Duty waivers) payments received by all businesses which are part of this single undertaking.
 becomeAdmin.error.required = Select yes if you want to become administrator for this undertaking 
 
 become-admin-responsibilities.title = Become the administrator for this undertaking

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/actions/builders/EnrolledActionBuilderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/actions/builders/EnrolledActionBuilderSpec.scala
@@ -79,7 +79,7 @@ class EnrolledActionBuilderSpec
 
     "redirect to the first page of the first login journey" when {
       "handling a request that is authenticated but not enrolled" in {
-        mockAuthWithNoEnrolmentNoCheck()
+        mockAuthWithoutEnrolment()
 
         val request = FakeRequest()
         val result = underTest.invokeBlock(request, block)
@@ -91,7 +91,7 @@ class EnrolledActionBuilderSpec
 
     "throw an illegal state exception" when {
       "handling a request that has an enrolment but no eori" in {
-        mockAuthWithEccEnrolmentWithoutEori()
+        mockAuthWithEnrolmentWithoutEori()
 
         val request = FakeRequest()
         val result = underTest.invokeBlock(request, block)
@@ -102,7 +102,7 @@ class EnrolledActionBuilderSpec
 
     "invoke the supplied block" when {
       "handling a request that is authenticated and enrolled" in {
-        mockAuthWithNecessaryEnrolment(eori1)
+        mockAuthWithEnrolment(eori1)
 
         val request = FakeRequest()
         val result = underTest.invokeBlock(request, block)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/actions/builders/NotEnrolledActionBuilderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/actions/builders/NotEnrolledActionBuilderSpec.scala
@@ -76,7 +76,7 @@ class NotEnrolledActionBuilderSpec extends AnyWordSpec
 
     "redirect to the account page" when {
       "handling a request that is authenticated and enrolled" in {
-        mockAuthWithNecessaryEnrolment(eori1)
+        mockAuthWithEnrolment(eori1)
 
         val request = FakeRequest()
         val result = underTest.invokeBlock(request, block)
@@ -88,7 +88,7 @@ class NotEnrolledActionBuilderSpec extends AnyWordSpec
 
     "invoke the supplied block" when {
       "handling a request that is authenticated but not enrolled" in {
-        mockAuthWithNoEnrolmentNoCheck()
+        mockAuthWithoutEnrolment()
 
         val request = FakeRequest()
         val result = underTest.invokeBlock(request, block)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EmailVerificationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/connector/EmailVerificationConnectorSpec.scala
@@ -56,64 +56,6 @@ class EmailVerificationConnectorSpec
 
   "EmailVerificationConnector" when {
 
-    "Get verification redirect" in {
-      connector.getVerificationJourney("/redirect") shouldBe "/redirect"
-    }
-
-    "Use absolute urls" in {
-      connector.useAbsoluteUrls shouldBe false
-    }
-
-    "verify email" when {
-      behave like connectorBehaviour(
-        mockPost(s"$baseUrl/verify-email", Seq.empty, emailVerificationRequest)(_),
-        () => connector.verifyEmail(emailVerificationRequest)
-      )
-    }
-  }
-}
-
-class LocallyConfiguredEmailVerificationConnectorSpec
-  extends AnyWordSpec
-    with Matchers
-    with MockFactory
-    with HttpSupport
-    with ConnectorSpec
-    with ScalaFutures {
-
-  private val (protocol, host, port) = ("http", "localhost", "123")
-  private val baseUrl = s"$protocol://$host:$port/email-verification"
-
-  private val config = Configuration(
-    ConfigFactory.parseString(s"""
-                                 | microservice.services.email-verification {
-                                 |    protocol = "$protocol"
-                                 |    host     = "$host"
-                                 |    port     = $port
-                                 |  }
-                                 | microservice.services.email-verification-frontend {
-                                 |    protocol = "$protocol"
-                                 |    host     = "$host"
-                                 |    port     = $port
-                                 |  }
-                                 |
-                                 |""".stripMargin)
-  )
-
-  private val connector = new EmailVerificationConnector(mockHttp, new ServicesConfig(config))
-
-  private implicit val hc: HeaderCarrier = HeaderCarrier()
-
-  "Locally configured EmailVerificationConnector" when {
-
-    "Get verification redirect" in {
-      connector.getVerificationJourney("/redirect") shouldBe "http://localhost:123/redirect"
-    }
-
-    "Use absolute urls" in {
-      connector.useAbsoluteUrls shouldBe true
-    }
-
     "verify email" when {
       behave like connectorBehaviour(
         mockPost(s"$baseUrl/verify-email", Seq.empty, emailVerificationRequest)(_),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -69,7 +69,7 @@ class AccountControllerSpec
 
       def performAction() = controller.getAccountPage(FakeRequest())
 
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       "display the lead account home page" when {
 
@@ -77,7 +77,7 @@ class AccountControllerSpec
 
           val nilJourneyCreate = NilReturnJourney(NilReturnFormPage(None))
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
@@ -123,7 +123,7 @@ class AccountControllerSpec
         ): Unit = {
           val nilJourneyCreate = NilReturnJourney(NilReturnFormPage(None))
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
@@ -190,7 +190,7 @@ class AccountControllerSpec
 
           "Only ECC enrolment is present" in {
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+              mockAuthWithEnrolmentAndNoEmailVerification(eori4)
               mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
               mockGetOrCreate[EligibilityJourney](eori4)(Right(eligibilityJourneyComplete))
               mockGetOrCreate[UndertakingJourney](eori4)(Right(UndertakingJourney()))
@@ -219,7 +219,7 @@ class AccountControllerSpec
 
         "there is error in retrieving the undertaking" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockRetrieveUndertaking(eori1)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction()))
@@ -228,7 +228,7 @@ class AccountControllerSpec
 
         "there is an error in fetching eligibility journey data" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -238,7 +238,7 @@ class AccountControllerSpec
 
         "there is an error in retrieving undertaking journey data" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
@@ -249,7 +249,7 @@ class AccountControllerSpec
 
         "there is an error in fetching Business entity journey data" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
@@ -266,7 +266,7 @@ class AccountControllerSpec
 
           "retrieve undertaking journey is not there" in {
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification(eori1)
+              mockAuthWithEnrolmentAndNoEmailVerification(eori1)
               mockRetrieveUndertaking(eori1)(None.toFuture)
               mockGetOrCreate[EligibilityJourney](eori1)(Right(EligibilityJourney()))
               mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
@@ -280,7 +280,7 @@ class AccountControllerSpec
 
           "eligibility Journey is not complete and undertaking Journey is blank" in {
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification()
+              mockAuthWithEnrolmentAndNoEmailVerification()
               mockRetrieveUndertaking(eori1)(None.toFuture)
               mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyNotComplete))
               mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
@@ -290,7 +290,7 @@ class AccountControllerSpec
 
           "eligibility Journey  is complete and undertaking Journey is not complete" in {
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification()
+              mockAuthWithEnrolmentAndNoEmailVerification()
               mockRetrieveUndertaking(eori1)(None.toFuture)
               mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
               mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
@@ -300,7 +300,7 @@ class AccountControllerSpec
 
           "eligibility Journey  and undertaking Journey are  complete" in {
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification()
+              mockAuthWithEnrolmentAndNoEmailVerification()
               mockRetrieveUndertaking(eori1)(None.toFuture)
               mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourneyComplete))
               mockGetOrCreate[UndertakingJourney](eori1)(Right(undertakingJourneyComplete1))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -204,7 +204,7 @@ class AccountControllerSpec
               messageFromMessageKey("non-lead-account-homepage.title"),
               { doc =>
                 val htmlBody = doc.select(".govuk-list").html
-                htmlBody should include regex routes.BecomeLeadController.getBecomeLeadEori().url
+                htmlBody should include regex routes.BecomeLeadController.getAcceptResponsibilities().url
                 htmlBody should include regex routes.FinancialDashboardController.getFinancialDashboard().url
                 htmlBody should include regex routes.BusinessEntityController.getRemoveYourselfBusinessEntity().url
               }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthAndSessionDataBehaviour.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthAndSessionDataBehaviour.scala
@@ -75,9 +75,11 @@ trait AuthAndSessionDataBehaviour { this: ControllerSpec with AuthSupport with J
   def mockNoPredicateAuthWithNecessaryEnrolment(eori: EORI = eori1): Unit =
     mockAuthWithAuthRetrievalsNoPredicate(Enrolments(enrolmentSets(eori)), "1123", Some("groupIdentifier"))
 
+  // TODO - review naming here
   def mockAuthWithNecessaryEnrolmentWithValidEmail(eori: EORI = eori1): Unit =
     mockAuthWithEccAuthRetrievalsWithEmailCheck(Enrolments(enrolmentSets(eori)), "1123", Some("groupIdentifier"))
 
+  // TODO - do we need these necessary enrolment methods?
   def mockAuthWithNecessaryEnrolment(eori: EORI = eori1): Unit =
     mockAuthWithEccAuthRetrievals(Enrolments(enrolmentSets(eori)), "1123", Some("groupIdentifier"))
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
@@ -102,11 +102,11 @@ trait AuthSupport { this: ControllerSpec =>
   // TODO - review this
   //  - should EmailServiceSpec be using this?
   //  - add params for false, other values?
-  def mockGetEmailVerification() =
+  def mockGetEmailVerification(email: String = "foo@example.com") =
     (mockEmailVerificationService
       .getEmailVerification(_: EORI))
       .expects(*)
-      .returning(VerifiedEmail("", "", verified = true).some.toFuture)
+      .returning(VerifiedEmail(email, "", verified = true).some.toFuture)
 
   def mockGetEmailVerification(result: Option[VerifiedEmail]) =
     (mockEmailVerificationService

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
@@ -99,11 +99,20 @@ trait AuthSupport { this: ControllerSpec =>
   val authRetrievalsNoEnrolment: Retrieval[Option[Credentials] ~ Option[String]] =
     Retrievals.credentials and Retrievals.groupIdentifier
 
+  // TODO - review this
+  //  - should EmailServiceSpec be using this?
+  //  - add params for false, other values?
   def mockGetEmailVerification() =
     (mockEmailVerificationService
       .getEmailVerification(_: EORI))
       .expects(*)
       .returning(VerifiedEmail("", "", verified = true).some.toFuture)
+
+  def mockGetEmailVerification(result: Option[VerifiedEmail]) =
+    (mockEmailVerificationService
+      .getEmailVerification(_: EORI))
+      .expects(*)
+      .returning(result.toFuture)
 }
 
 object AuthSupport {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
@@ -21,7 +21,8 @@ import org.scalamock.handlers.CallHandler1
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, EmptyRetrieval, Retrieval, ~}
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.VerifiedEmail
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.services.EmailVerificationService
@@ -32,11 +33,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait AuthSupport { this: ControllerSpec =>
 
-  import AuthSupport._
-
   protected val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
   protected val mockEmailVerificationService: EmailVerificationService = mock[EmailVerificationService]
+
+  protected val authRetrievals: Retrieval[Option[Credentials] ~ Option[String] ~ Enrolments] =
+    Retrievals.credentials and Retrievals.groupIdentifier and Retrievals.allEnrolments
 
   def mockAuth[R](predicate: Predicate, retrieval: Retrieval[R])(
     result: Future[R]
@@ -49,51 +51,25 @@ trait AuthSupport { this: ControllerSpec =>
       .expects(predicate, retrieval, *, *)
       .returning(result)
 
-  def mockAuthWithNoRetrievals(): Unit =
-    mockAuth(EmptyPredicate, EmptyRetrieval)(().toFuture)
-
-  def mockAuthWithAuthRetrievalsNoPredicate(
-    enrolments: Enrolments,
-    providerId: String,
-    groupIdentifier: Option[String]
-  ) = {
+  def mockAuthWithEccRetrievals(enrolments: Enrolments, providerId: String, groupIdentifier: Option[String]): Unit = {
     mockAuth(EmptyPredicate, authRetrievals)(
       (new ~(Credentials(providerId, "type").some, groupIdentifier) and enrolments).toFuture
     )
   }
 
-
-  def mockAuthNoEnrolmentsRetrievals(
-    providerId: String,
-    groupIdentifier: Option[String]
-  ) =
-    mockAuth(EmptyPredicate, authRetrievalsNoEnrolment)(
-      (new ~(Credentials(providerId, "type").some, groupIdentifier)).toFuture
-    )
-
-  def mockAuthWithEccAuthRetrievalsWithEmailCheck(enrolments: Enrolments, providerId: String, groupIdentifier: Option[String]) = {
+  def mockAuthWithEccAuthRetrievalsWithEmailCheck(enrolments: Enrolments, providerId: String, groupIdentifier: Option[String]): CallHandler1[EORI, Future[Option[VerifiedEmail]]] = {
     mockAuth(EmptyPredicate, authRetrievals)(
       (new ~(Credentials(providerId, "type").some, groupIdentifier) and enrolments).toFuture
     )
     mockGetEmailVerification()
   }
 
-  def mockAuthWithEccAuthRetrievals(enrolments: Enrolments, providerId: String, groupIdentifier: Option[String]) = {
-    mockAuth(EmptyPredicate, authRetrievals)(
-      (new ~(Credentials(providerId, "type").some, groupIdentifier) and enrolments).toFuture
-    )
-  }
 
-  def mockAuthWithEccAuthRetrievalsNoEmailVerification(enrolments: Enrolments, providerId: String, groupIdentifier: Option[String]) =
+  def mockAuthWithEccAuthRetrievalsNoEmailVerification(enrolments: Enrolments, providerId: String, groupIdentifier: Option[String]): Unit =
     mockAuth(EmptyPredicate, authRetrievals)(
       (new ~(Credentials(providerId, "type").some, groupIdentifier) and enrolments).toFuture
     )
 
-  val authRetrievals: Retrieval[Option[Credentials] ~ Option[String] ~ Enrolments] =
-    Retrievals.credentials and Retrievals.groupIdentifier and Retrievals.allEnrolments
-
-  val authRetrievalsNoEnrolment: Retrieval[Option[Credentials] ~ Option[String]] =
-    Retrievals.credentials and Retrievals.groupIdentifier
 
   def mockGetEmailVerification(result: Option[VerifiedEmail]): CallHandler1[EORI, Future[Option[VerifiedEmail]]] =
     (mockEmailVerificationService
@@ -103,13 +79,5 @@ trait AuthSupport { this: ControllerSpec =>
 
   def mockGetEmailVerification(email: String = "foo@example.com"): CallHandler1[EORI, Future[Option[VerifiedEmail]]] =
     mockGetEmailVerification(VerifiedEmail(email, "", verified = true).some)
-
-}
-
-object AuthSupport {
-
-  implicit class RetrievalOps[A, B](val r: ~[A, B]) {
-    def and[C](c: C): ~[~[A, B], C] = new ~(r, c)
-  }
 
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AuthSupport.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
+import org.scalamock.handlers.CallHandler1
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
@@ -36,11 +37,6 @@ trait AuthSupport { this: ControllerSpec =>
   protected val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
   protected val mockEmailVerificationService: EmailVerificationService = mock[EmailVerificationService]
-
-  // TODO - review these and perhaps use common values
-  val EccEnrolmentKey = "HMRC-ESC-ORG"
-  val CdsEnrolmentKey = "HMRC-CUS-ORG"
-
 
   def mockAuth[R](predicate: Predicate, retrieval: Retrieval[R])(
     result: Future[R]
@@ -99,20 +95,15 @@ trait AuthSupport { this: ControllerSpec =>
   val authRetrievalsNoEnrolment: Retrieval[Option[Credentials] ~ Option[String]] =
     Retrievals.credentials and Retrievals.groupIdentifier
 
-  // TODO - review this
-  //  - should EmailServiceSpec be using this?
-  //  - add params for false, other values?
-  def mockGetEmailVerification(email: String = "foo@example.com") =
-    (mockEmailVerificationService
-      .getEmailVerification(_: EORI))
-      .expects(*)
-      .returning(VerifiedEmail(email, "", verified = true).some.toFuture)
-
-  def mockGetEmailVerification(result: Option[VerifiedEmail]) =
+  def mockGetEmailVerification(result: Option[VerifiedEmail]): CallHandler1[EORI, Future[Option[VerifiedEmail]]] =
     (mockEmailVerificationService
       .getEmailVerification(_: EORI))
       .expects(*)
       .returning(result.toFuture)
+
+  def mockGetEmailVerification(email: String = "foo@example.com"): CallHandler1[EORI, Future[Option[VerifiedEmail]]] =
+    mockGetEmailVerification(VerifiedEmail(email, "", verified = true).some)
+
 }
 
 object AuthSupport {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -163,9 +163,6 @@ class BecomeLeadControllerSpec
       "throw technical error" when {
 
         "call to get become lead journey fails" in {
-
-          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
-
           inSequence {
             mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
             mockGet[BecomeLeadJourney](eori4)(Left(ConnectorError("Error")))
@@ -209,8 +206,6 @@ class BecomeLeadControllerSpec
         "user submits Yes" in {
 
           def testRedirection(input: String, nextCall: String) = {
-            def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
-
             inSequence {
               mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
               mockGet[BecomeLeadJourney](eori4)(
@@ -236,8 +231,6 @@ class BecomeLeadControllerSpec
 
         "user submits No" in {
           def testRedirection(input: String, nextCall: String) = {
-            def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
-
             inSequence {
               mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
             }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -476,7 +476,7 @@ class BecomeLeadControllerSpec
         val result = performAction(verificationId)
 
         status(result) shouldBe SEE_OTHER
-        redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
+        redirectLocation(result) should contain(routes.BecomeLeadController.getConfirmEmail().url)
       }
 
       "the email verification record is not found" in {
@@ -490,7 +490,7 @@ class BecomeLeadControllerSpec
         val result = performAction(verificationId)
 
         status(result) shouldBe SEE_OTHER
-        redirectLocation(result) should contain(routes.AccountController.getAccountPage().url)
+        redirectLocation(result) should contain(routes.BecomeLeadController.getConfirmEmail().url)
       }
 
       "the verification request is successful" in {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -207,13 +207,10 @@ class BecomeLeadControllerSpec
         }
 
         "user submits Yes, redirect to accept terms" in {
-          testRedirection("true", routes.BecomeLeadController.getAcceptPromotionTerms().url)
-        }
-
-        "user submits No, redirect to account homepage" in {
-          testRedirection("false", routes.AccountController.getAccountPage().url)
+          testRedirection("true", routes.BecomeLeadController.getPromotionConfirmation().url)
         }
       }
+
     }
 
     "handling request to get accept Promotion Terms" must {
@@ -418,28 +415,10 @@ class BecomeLeadControllerSpec
           }
 
           checkIsRedirect(performAction(), routes.BecomeLeadController.getBecomeLeadEori())
-
         }
       }
 
     }
 
-    "handling request to getPromotionCleanup" must {
-
-      def performAction() = controller.getPromotionCleanup(FakeRequest())
-
-      "redirect" when {
-
-        "redirect to promotion confirmation on success" in {
-          def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
-
-          inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
-            mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori4)(Right(newBecomeLeadJourney))
-          }
-          redirectLocation(performAction()) shouldBe routes.AccountController.getAccountPage().url.some
-        }
-      }
-    }
   }
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -301,6 +301,7 @@ class BecomeLeadControllerSpec
           mockGetUndertaking(eori4)(undertaking.toFuture)
           mockGetOrCreate[BecomeLeadJourney](eori4)(Right(BecomeLeadJourney()))
         }
+
         checkPageIsDisplayed(
           performAction(),
           messageFromMessageKey("become-admin-responsibilities.title")
@@ -426,8 +427,6 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGetEmailVerification()
-          // TODO - add common fixtures for response and email address
-          mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, Some(EmailAddress("foo@example.com")))))
           mockAddEmailVerification(eori1)(Right("foo"))
           mockEmailVerification(eori1)(Right(cacheItem))
           mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourneyComplete))
@@ -444,8 +443,6 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGetEmailVerification()
-          mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, Some(EmailAddress("foo@example.com")))))
-          // TODO - fixtures for these responses
           mockAddEmailVerification(eori1)(Right("foo"))
           mockVerifyEmail("foo@example.com")(Right(Some(EmailVerificationResponse("/foo"))))
           mockEmailVerificationRedirect(Some(EmailVerificationResponse("/foo")))(Redirect(routes.BecomeLeadController.getBecomeLeadEori().url))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -17,9 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
-import com.mongodb.client.result.UpdateResult
 import com.typesafe.config.ConfigFactory
-import org.bson.BsonBoolean
 import play.api.Configuration
 import play.api.inject.bind
 import play.api.mvc.Results.Redirect
@@ -482,7 +480,7 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
-          mockApproveVerification(eori1, verificationId)(Right(UpdateResult.acknowledged(1, 1, BsonBoolean.TRUE)))
+          mockApproveVerification(eori1, verificationId)(Right(true))
           mockGetEmailVerification(Option.empty)
         }
 
@@ -496,8 +494,7 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
-          // TODO - get this into a fixture - also review API - this is leaking internal implementation
-          mockApproveVerification(eori1, verificationId)(Right(UpdateResult.acknowledged(1, 1, BsonBoolean.TRUE)))
+          mockApproveVerification(eori1, verificationId)(Right(true))
           mockGetEmailVerification()
         }
 
@@ -511,8 +508,7 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
-          // TODO - get this into a fixture - also review API - this is leaking internal implementation
-          mockApproveVerification(eori1, verificationId)(Right(UpdateResult.acknowledged(0, 1, BsonBoolean.TRUE)))
+          mockApproveVerification(eori1, verificationId)(Right(false))
         }
 
         val result = performAction(verificationId)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -78,6 +78,7 @@ class BecomeLeadControllerSpec
     "handling request to get Become Lead Eori" must {
 
       def performAction() = controller.getBecomeLeadEori(FakeRequest())
+
       behave like authBehaviourWithPredicate(() => performAction())
 
       "throw technical error" when {
@@ -191,56 +192,45 @@ class BecomeLeadControllerSpec
 
       }
 
-      // TODO - remove testRedirection function
       "Redirect to next page" when {
 
         "user submits Yes" in {
-
-          def testRedirection(input: String, nextCall: String) = {
-            inSequence {
-              mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
-              mockGet[BecomeLeadJourney](eori4)(
-                Right(newBecomeLeadJourney.copy(acceptResponsibilities = AcceptResponsibilitiesFormPage(true.some)).some)
-              )
-              mockGetUndertaking(eori4)(undertaking1.toFuture)
-              mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Right(undertakingRef))
-              mockSendEmail(eori4, PromotedSelfToNewLead, undertaking1)(Right(EmailSent))
-              mockAddMember(undertakingRef, businessEntity1.copy(leadEORI = false))(Right(undertakingRef))
-              mockSendEmail(eori1, RemovedAsLeadToFormerLead, undertaking1)(Right(EmailSent))
-              mockDelete[UndertakingJourney](eori4)(Right(()))
-              mockDelete[BecomeLeadJourney](eori4)(Right(()))
-              mockSendAuditEvent[BusinessEntityPromotedSelf](
-                AuditEvent.BusinessEntityPromotedSelf(undertakingRef, "1123", eori1, eori4)
-              )
-            }
-
-            checkIsRedirect(performAction("becomeAdmin" -> input), nextCall)
+          inSequence {
+            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockGet[BecomeLeadJourney](eori4)(
+              Right(newBecomeLeadJourney.copy(acceptResponsibilities = AcceptResponsibilitiesFormPage(true.some)).some)
+            )
+            mockGetUndertaking(eori4)(undertaking1.toFuture)
+            mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Right(undertakingRef))
+            mockSendEmail(eori4, PromotedSelfToNewLead, undertaking1)(Right(EmailSent))
+            mockAddMember(undertakingRef, businessEntity1.copy(leadEORI = false))(Right(undertakingRef))
+            mockSendEmail(eori1, RemovedAsLeadToFormerLead, undertaking1)(Right(EmailSent))
+            mockDelete[UndertakingJourney](eori4)(Right(()))
+            mockDelete[BecomeLeadJourney](eori4)(Right(()))
+            mockSendAuditEvent[BusinessEntityPromotedSelf](
+              AuditEvent.BusinessEntityPromotedSelf(undertakingRef, "1123", eori1, eori4)
+            )
           }
 
-          testRedirection("true", routes.BecomeLeadController.getPromotionConfirmation().url)
+          checkIsRedirect(performAction("becomeAdmin" -> "true"), routes.BecomeLeadController.getPromotionConfirmation().url)
         }
 
         "user submits No" in {
-          def testRedirection(input: String, nextCall: String) = {
-            inSequence {
-              mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
-            }
-
-            checkIsRedirect(performAction("becomeAdmin" -> input), nextCall)
+          inSequence {
+            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
           }
 
-          testRedirection("false", routes.AccountController.getAccountPage().url)
+          checkIsRedirect(performAction("becomeAdmin" -> "false"), routes.AccountController.getAccountPage().url)
         }
 
-        }
       }
 
     }
 
-    // TODO - reorder the test, this is the first page in the journey
     "handling request to get Accept Responsibilities" must {
 
       def performAction() = controller.getAcceptResponsibilities(FakeRequest())
+
       behave like authBehaviourWithPredicate(() => performAction())
 
       "throw technical error" when {
@@ -343,6 +333,8 @@ class BecomeLeadControllerSpec
       }
 
     }
+    
+  }
 
   "handling request to get Confirm Email page" must {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -388,7 +388,6 @@ class BecomeLeadControllerSpec
 
   }
 
-  // TODO - check error handling here - looks like we have a missing message key
   "handling request to post Confirm Email page" must {
 
     val verificationUrl = routes.BecomeLeadController.getVerifyEmail("SomeId").url

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -333,7 +333,7 @@ class BecomeLeadControllerSpec
       }
 
     }
-    
+
   }
 
   "handling request to get Confirm Email page" must {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -448,7 +448,8 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGetEmailVerification(None)
-          mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, Some(EmailAddress("foo@example.com")))))
+          // TODO - this mocks the retrieval from CDS
+          mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.UnVerifiedEmail, None)))
           // TODO - fixtures for these responses
           mockAddEmailVerification(eori1)(Right("foo"))
           mockVerifyEmail("foo@example.com")(Right(Some(EmailVerificationResponse("/foo"))))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessEntityPromotedSelf
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailSendResult.EmailSent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.EmailTemplate.{PromotedSelfToNewLead, RemovedAsLeadToFormerLead}
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormPages.{BecomeLeadEoriFormPage, TermsAndConditionsFormPage}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.BecomeLeadJourney.FormPages.{BecomeLeadEoriFormPage, AcceptResponsibilitiesFormPage}
 import uk.gov.hmrc.eusubsidycompliancefrontend.services._
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
@@ -218,7 +218,7 @@ class BecomeLeadControllerSpec
 
     "handling request to get accept Promotion Terms" must {
 
-      def performAction() = controller.getAcceptPromotionTerms(FakeRequest())
+      def performAction() = controller.getAcceptResponsibilities(FakeRequest())
       behave like authBehaviourWithPredicate(() => performAction())
 
       "throw technical error" when {
@@ -258,7 +258,7 @@ class BecomeLeadControllerSpec
 
     "handling request to post accept Promotion Terms" must {
 
-      def performAction() = controller.postAcceptPromotionTerms(FakeRequest())
+      def performAction() = controller.postAcceptResponsibilities(FakeRequest())
 
       "redirect" when {
 
@@ -375,7 +375,7 @@ class BecomeLeadControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
             mockGet[BecomeLeadJourney](eori4)(
-              Right(newBecomeLeadJourney.copy(acceptTerms = TermsAndConditionsFormPage(true.some)).some)
+              Right(newBecomeLeadJourney.copy(acceptResponsibilities = AcceptResponsibilitiesFormPage(true.some)).some)
             )
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
             mockAddMember(undertakingRef, businessEntity4.copy(leadEORI = true))(Right(undertakingRef))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -413,7 +413,6 @@ class BecomeLeadControllerSpec
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGetEmailVerification()
           mockAddVerifiedEmail(eori1, "foo@example.com")(Future.successful(()))
-          mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourneyComplete))
         }
 
         val result = performAction("using-stored-email" -> "true")
@@ -500,7 +499,6 @@ class BecomeLeadControllerSpec
           // TODO - get this into a fixture - also review API - this is leaking internal implementation
           mockApproveVerification(eori1, verificationId)(Right(UpdateResult.acknowledged(1, 1, BsonBoolean.TRUE)))
           mockGetEmailVerification()
-          mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourneyComplete))
         }
 
         val result = performAction(verificationId)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -79,13 +79,13 @@ class BecomeLeadControllerSpec
 
       def performAction() = controller.getBecomeLeadEori(FakeRequest())
 
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
         "call to fetch new lead journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockGetOrCreate[BecomeLeadJourney](eori4)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -93,7 +93,7 @@ class BecomeLeadControllerSpec
 
         "call to fetch undertaking returns None" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockGetOrCreate[BecomeLeadJourney](eori4)(Right(BecomeLeadJourney()))
             mockRetrieveUndertaking(eori4)(None.toFuture)
           }
@@ -105,7 +105,7 @@ class BecomeLeadControllerSpec
 
         "Become lead journey is blank " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockGetOrCreate[BecomeLeadJourney](eori4)(Right(BecomeLeadJourney()))
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
           }
@@ -125,7 +125,7 @@ class BecomeLeadControllerSpec
 
         "new lead journey already exists" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockGetOrCreate[BecomeLeadJourney](eori4)(Right(
               newBecomeLeadJourney.copy(becomeLeadEori = newBecomeLeadJourney.becomeLeadEori.copy(value = Some(true)))
             ))
@@ -156,7 +156,7 @@ class BecomeLeadControllerSpec
 
         "call to get become lead journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockGet[BecomeLeadJourney](eori4)(Left(ConnectorError("Error")))
           }
           assertThrows[Exception](await(performAction("becomeAdmin" -> "true")))
@@ -169,7 +169,7 @@ class BecomeLeadControllerSpec
         "Nothing is submitted" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
           }
           checkFormErrorIsDisplayed(
             performAction(),
@@ -180,7 +180,7 @@ class BecomeLeadControllerSpec
 
         "An invalid form is submitted" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
           }
           checkFormErrorIsDisplayed(
             performAction("invalidFieldName" -> "true"),
@@ -196,7 +196,7 @@ class BecomeLeadControllerSpec
 
         "user submits Yes" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockGet[BecomeLeadJourney](eori4)(
               Right(newBecomeLeadJourney.copy(acceptResponsibilities = AcceptResponsibilitiesFormPage(true.some)).some)
             )
@@ -217,7 +217,7 @@ class BecomeLeadControllerSpec
 
         "user submits No" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
           }
 
           checkIsRedirect(performAction("becomeAdmin" -> "false"), routes.AccountController.getAccountPage().url)
@@ -231,14 +231,14 @@ class BecomeLeadControllerSpec
 
       def performAction() = controller.getAcceptResponsibilities(FakeRequest())
 
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
 
         "call to get undertaking fails" in {
           inSequence {
-            mockAuthWithEccEnrolmentOnly(eori4)
+            mockAuthWithEnrolment(eori4)
             mockGetUndertaking(eori4)(Future.failed(new IllegalStateException()))
           }
           assertThrows[Exception](await(performAction()))
@@ -246,7 +246,7 @@ class BecomeLeadControllerSpec
 
         "call to fetch new become lead journey fails" in {
           inSequence {
-            mockAuthWithEccEnrolmentOnly(eori4)
+            mockAuthWithEnrolment(eori4)
             mockGetUndertaking(eori4)(undertaking.toFuture)
             mockGetOrCreate(eori4)(Left(ConnectorError(exception)))
           }
@@ -258,7 +258,7 @@ class BecomeLeadControllerSpec
       "display the page where the become lead journey exists" in {
 
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori4)
+          mockAuthWithEnrolment(eori4)
           mockGetUndertaking(eori4)(undertaking.toFuture)
           mockGetOrCreate(eori4)(
             Right(
@@ -277,7 +277,7 @@ class BecomeLeadControllerSpec
       "display the page where the become lead journey does not exist" in {
 
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori4)
+          mockAuthWithEnrolment(eori4)
           mockGetUndertaking(eori4)(undertaking.toFuture)
           mockGetOrCreate[BecomeLeadJourney](eori4)(Right(BecomeLeadJourney()))
         }
@@ -301,7 +301,7 @@ class BecomeLeadControllerSpec
           def update(j: BecomeLeadJourney) = j.copy(becomeLeadEori = BecomeLeadEoriFormPage())
 
           inSequence {
-            mockAuthWithEccEnrolmentOnly(eori4)
+            mockAuthWithEnrolment(eori4)
             mockUpdate[BecomeLeadJourney](_ => update(BecomeLeadJourney()), eori4)(Right(newBecomeLeadJourney))
           }
           redirectLocation(performAction()) shouldBe routes.BecomeLeadController.getConfirmEmail().url.some
@@ -317,7 +317,7 @@ class BecomeLeadControllerSpec
 
         def testDisplay(): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
           }
 
           checkPageIsDisplayed(
@@ -344,7 +344,7 @@ class BecomeLeadControllerSpec
 
       "user has a verified email address in our store" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
           mockGetEmailVerification()
         }
@@ -357,7 +357,7 @@ class BecomeLeadControllerSpec
 
       "user has no verified email address but they do have an email address in CDS" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
           mockGetEmailVerification(Option.empty)
           mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.VerifiedEmail, EmailAddress("foo@example.com").some)))
@@ -372,7 +372,7 @@ class BecomeLeadControllerSpec
 
       "user has no verified email nor do they have an email address in CDS" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
           mockGetEmailVerification(Option.empty)
           mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.UnVerifiedEmail, None)))
@@ -400,7 +400,7 @@ class BecomeLeadControllerSpec
 
       "user selects existing verified email address" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGetEmailVerification()
           mockAddVerifiedEmail(eori1, "foo@example.com")(Future.successful(()))
         }
@@ -413,7 +413,7 @@ class BecomeLeadControllerSpec
 
       "user has existing verified email address but elects to enter a new one" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGetEmailVerification()
           mockMakeVerificationRequestAndRedirect(Redirect(verificationUrl).toFuture)
         }
@@ -430,7 +430,7 @@ class BecomeLeadControllerSpec
 
       "user has no existing email address and enters a new one" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGetEmailVerification(None)
           mockRetrieveEmail(eori1)(Right(RetrieveEmailResponse(EmailType.UnVerifiedEmail, None)))
           mockMakeVerificationRequestAndRedirect(Redirect(verificationUrl).toFuture)
@@ -458,7 +458,7 @@ class BecomeLeadControllerSpec
 
       "the become lead journey is not found" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(None))
         }
 
@@ -470,7 +470,7 @@ class BecomeLeadControllerSpec
 
       "the email verification record is not found" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
           mockApproveVerification(eori1, verificationId)(Right(true))
           mockGetEmailVerification(Option.empty)
@@ -484,7 +484,7 @@ class BecomeLeadControllerSpec
 
       "the verification request is successful" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
           mockApproveVerification(eori1, verificationId)(Right(true))
           mockGetEmailVerification()
@@ -498,7 +498,7 @@ class BecomeLeadControllerSpec
 
       "the verification request is not successful" in {
         inSequence {
-          mockAuthWithEccEnrolmentOnly(eori1)
+          mockAuthWithEnrolment(eori1)
           mockGet[BecomeLeadJourney](eori1)(Right(newBecomeLeadJourney.some))
           mockApproveVerification(eori1, verificationId)(Right(false))
         }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -45,7 +45,7 @@ class BecomeLeadControllerSpec
     with JourneyStoreSupport
     with AuthAndSessionDataBehaviour
     with EmailSupport
-    with EmailVerificationSupport
+    with EmailVerificationServiceSupport
     with AuditServiceSupport
     with EscServiceSupport {
 
@@ -412,7 +412,7 @@ class BecomeLeadControllerSpec
         inSequence {
           mockAuthWithEccEnrolmentOnly(eori1)
           mockGetEmailVerification()
-          mockAddVerifiedEmail(eori1, "foo@example.com")(Future.successful())
+          mockAddVerifiedEmail(eori1, "foo@example.com")(Future.successful(()))
           mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourneyComplete))
         }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityControllerSpec.scala
@@ -105,7 +105,7 @@ class BusinessEntityControllerSpec
 
         "call to get business entity journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -121,7 +121,7 @@ class BusinessEntityControllerSpec
           undertaking: Undertaking
         ): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[BusinessEntityJourney](eori1)(Right(businessEntityJourney))
           }
@@ -181,7 +181,7 @@ class BusinessEntityControllerSpec
           def update(j: BusinessEntityJourney) = j.copy(addBusiness = j.addBusiness.copy(value = Some(true)))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney), eori1)(
               Left(ConnectorError(exception))
@@ -198,7 +198,7 @@ class BusinessEntityControllerSpec
         def displayErrorTest(data: (String, String)*)(errorMessage: String): Unit = {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
 
@@ -219,7 +219,7 @@ class BusinessEntityControllerSpec
 
         "user selected No" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           checkIsRedirect(performAction("addBusiness" -> "false"), routes.AccountController.getAccountPage().url)
@@ -229,7 +229,7 @@ class BusinessEntityControllerSpec
           def update(j: BusinessEntityJourney) = j.copy(addBusiness = j.addBusiness.copy(value = Some(true)))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[BusinessEntityJourney](_ => update(BusinessEntityJourney()), eori1)(
               Right(BusinessEntityJourney(addBusiness = AddBusinessFormPage(true.some)))
@@ -256,7 +256,7 @@ class BusinessEntityControllerSpec
 
         "call to get business entity journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -271,7 +271,7 @@ class BusinessEntityControllerSpec
         def test(businessEntityJourney: BusinessEntityJourney): Unit = {
           val previousUrl = routes.BusinessEntityController.getAddBusinessEntity().url
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
           }
@@ -317,7 +317,7 @@ class BusinessEntityControllerSpec
 
         "call to get business entity journey came back empty" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(None))
           }
@@ -342,7 +342,7 @@ class BusinessEntityControllerSpec
 
         "call to get previous uri fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -361,7 +361,7 @@ class BusinessEntityControllerSpec
             )
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockRetrieveUndertakingWithErrorResponse(eori4)(Right(None))
@@ -380,7 +380,7 @@ class BusinessEntityControllerSpec
 
         def test(data: (String, String)*)(errorMessageKey: String): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
           }
@@ -395,7 +395,7 @@ class BusinessEntityControllerSpec
           data: (String, String)*
         )(retrieveResponse: Either[ConnectorError, Option[Undertaking]], errorMessageKey: String): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockRetrieveUndertakingWithErrorResponse(eori4)(retrieveResponse)
@@ -466,7 +466,7 @@ class BusinessEntityControllerSpec
             withClue(s" For eori entered :: $eoriEntered") {
               val validEori = EORI(getValidEori(eoriEntered))
               inSequence {
-                mockAuthWithNecessaryEnrolmentWithValidEmail()
+                mockAuthWithEnrolmentAndValidEmail()
                 mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
                 mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
                 mockRetrieveUndertakingWithErrorResponse(validEori)(Right(None))
@@ -497,7 +497,7 @@ class BusinessEntityControllerSpec
         val exception = new Exception("oh no!")
         "Call to fetch Business Entity journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -511,7 +511,7 @@ class BusinessEntityControllerSpec
 
         "call to fetch Business Entity journey returns journey without eori" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.copy(eori = AddEoriFormPage()).some))
           }
@@ -520,7 +520,7 @@ class BusinessEntityControllerSpec
 
         "call to fetch Business Entity journey returns Nothing" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(None))
           }
@@ -532,7 +532,7 @@ class BusinessEntityControllerSpec
 
         val previousUrl = routes.BusinessEntityController.getEori().url
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
         }
@@ -574,7 +574,7 @@ class BusinessEntityControllerSpec
 
         "call to get business entity fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -583,7 +583,7 @@ class BusinessEntityControllerSpec
 
         "call to get business entity returns nothing" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(None))
           }
@@ -592,7 +592,7 @@ class BusinessEntityControllerSpec
 
         "call to get business entity  return  without EORI" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.copy(eori = AddEoriFormPage(None)).some))
           }
@@ -603,7 +603,7 @@ class BusinessEntityControllerSpec
 
           val businessEntity = BusinessEntity(eori2, leadEORI = false)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Left(ConnectorError(exception)))
@@ -614,7 +614,7 @@ class BusinessEntityControllerSpec
         "call to send email fails" in {
           val businessEntity = BusinessEntity(businessEntityIdentifier = eori2, leadEORI = false)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney1.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
@@ -637,7 +637,7 @@ class BusinessEntityControllerSpec
         ): Unit = {
           val businessEntity = BusinessEntity(eori2, leadEORI = false)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockAddMember(undertakingRef, businessEntity)(Right(undertakingRef))
@@ -697,7 +697,7 @@ class BusinessEntityControllerSpec
           val businessEntity = BusinessEntity(eori2, leadEORI = false)
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[BusinessEntityJourney](eori1)(Right(businessEntityJourney.some))
             mockRemoveMember(
@@ -738,7 +738,7 @@ class BusinessEntityControllerSpec
 
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+            mockAuthWithEnrolmentAndNoEmailVerification(eori4)
             mockRetrieveUndertaking(eori4)(undertaking.some.toFuture)
           }
           assertThrows[Exception](await(performAction()))
@@ -749,7 +749,7 @@ class BusinessEntityControllerSpec
       "display the page" when {
         def test(undertaking: Undertaking, inputDate: Option[String]): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+            mockAuthWithEnrolmentAndNoEmailVerification(eori4)
             mockRetrieveUndertaking(eori4)(undertaking.some.toFuture)
           }
           checkPageIsDisplayed(
@@ -789,7 +789,7 @@ class BusinessEntityControllerSpec
       "throw a technical error" when {
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+            mockAuthWithEnrolmentAndNoEmailVerification(eori4)
             mockRetrieveUndertaking(eori4)(undertaking.some.toFuture)
           }
           assertThrows[Exception](await(performAction()))
@@ -801,7 +801,7 @@ class BusinessEntityControllerSpec
 
         "nothing is selected" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+            mockAuthWithEnrolmentAndNoEmailVerification(eori4)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
           }
           checkFormErrorIsDisplayed(
@@ -818,7 +818,7 @@ class BusinessEntityControllerSpec
 
         "user selected yes as input" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+            mockAuthWithEnrolmentAndNoEmailVerification(eori4)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
           }
           checkIsRedirect(
@@ -829,7 +829,7 @@ class BusinessEntityControllerSpec
 
         "user selected No as input" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification(eori4)
+            mockAuthWithEnrolmentAndNoEmailVerification(eori4)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
           }
           checkIsRedirect(
@@ -848,7 +848,7 @@ class BusinessEntityControllerSpec
 
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
           }
           assertThrows[Exception](await(performAction()))
@@ -859,7 +859,7 @@ class BusinessEntityControllerSpec
       "display the page" when {
         def test(undertaking: Undertaking, inputDate: Option[String]): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockRetrieveUndertaking(eori4)(undertaking.some.toFuture)
           }
@@ -911,7 +911,7 @@ class BusinessEntityControllerSpec
 
         "call to retrieve undertaking returns undertaking having no BE with that eori" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           assertThrows[Exception](await(performAction()(eori4)))
@@ -919,7 +919,7 @@ class BusinessEntityControllerSpec
 
         "call to remove BE fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
             mockTimeToday(effectiveDate)
@@ -930,7 +930,7 @@ class BusinessEntityControllerSpec
 
         "call to send email fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
             mockTimeToday(effectiveDate)
@@ -948,7 +948,7 @@ class BusinessEntityControllerSpec
 
         "nothing is selected" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
           }
@@ -966,7 +966,7 @@ class BusinessEntityControllerSpec
 
         def testRedirection(date: String): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
             mockTimeToday(effectiveDate)
@@ -988,7 +988,7 @@ class BusinessEntityControllerSpec
 
         "user selects No as input" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori1)
+            mockAuthWithEnrolmentAndValidEmail(eori1)
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockRetrieveUndertaking(eori4)(undertaking1.some.toFuture)
           }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -62,7 +62,7 @@ class EligibilityControllerSpec
 
         "call to get eligibility journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
             mockGet[EligibilityJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -74,7 +74,7 @@ class EligibilityControllerSpec
 
         def redirect(eligibilityJourney: Option[EligibilityJourney], expectedRedirectLocation: String) = {
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
             mockGet[EligibilityJourney](eori1)(Right(eligibilityJourney))
           }
           checkIsRedirect(performAction(), expectedRedirectLocation)
@@ -105,7 +105,7 @@ class EligibilityControllerSpec
 
         def testDisplay(eligibilityJourney: EligibilityJourney) = {
           inSequence {
-            mockAuthWithNoEnrolmentNoCheck()
+            mockAuthWithoutEnrolment()
           }
           checkPageIsDisplayed(
             performAction(),
@@ -140,7 +140,7 @@ class EligibilityControllerSpec
 
         "nothing is submitted" in {
           inSequence {
-            mockAuthWithNoEnrolmentNoCheck()
+            mockAuthWithoutEnrolment()
           }
 
           checkFormErrorIsDisplayed(
@@ -155,7 +155,7 @@ class EligibilityControllerSpec
 
         def testRedirection(inputValue: Boolean, nextCall: String) = {
           inSequence {
-            mockAuthWithNoEnrolmentNoCheck()
+            mockAuthWithoutEnrolment()
           }
           checkIsRedirect(
             performAction("customswaivers" -> inputValue.toString),
@@ -187,7 +187,7 @@ class EligibilityControllerSpec
         val previousUrl = routes.EligibilityController.getDoYouClaim().url
 
         inSequence {
-          mockAuthWithNoEnrolmentNoCheck()
+          mockAuthWithoutEnrolment()
         }
         checkPageIsDisplayed(
           performAction(),
@@ -218,7 +218,7 @@ class EligibilityControllerSpec
 
         "nothing is submitted" in {
           inSequence {
-            mockAuthWithNoEnrolmentNoCheck()
+            mockAuthWithoutEnrolment()
           }
 
           checkFormErrorIsDisplayed(
@@ -233,7 +233,7 @@ class EligibilityControllerSpec
 
         def testRedirection(input: Boolean, nextCall: String) = {
           inSequence {
-            mockAuthWithNoEnrolmentNoCheck()
+            mockAuthWithoutEnrolment()
           }
           checkIsRedirect(
             performAction("willyouclaim" -> input.toString),
@@ -263,7 +263,7 @@ class EligibilityControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNoEnrolmentNoCheck()
+          mockAuthWithoutEnrolment()
         }
         checkPageIsDisplayed(
           performAction(),
@@ -285,7 +285,7 @@ class EligibilityControllerSpec
 
         def testDisplay(eligibilityJourney: EligibilityJourney) = {
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
             mockRetrieveUndertaking(eori1)(Option.empty.toFuture)
             mockGetOrCreate[EligibilityJourney](eori1)(Right(eligibilityJourney))
           }
@@ -324,7 +324,7 @@ class EligibilityControllerSpec
       "redirect to account home" when {
         "undertaking has already been created" in {
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
 
@@ -350,7 +350,7 @@ class EligibilityControllerSpec
 
         "eligibility journey fail to update" in {
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
             mockUpdate[EligibilityJourney](_ => update(eligibilityJourney), eori1)(
               Left(ConnectorError(exception))
             )
@@ -362,7 +362,7 @@ class EligibilityControllerSpec
       "display form error" when {
         "nothing is submitted" in {
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
           }
           checkFormErrorIsDisplayed(
             performAction(),
@@ -380,7 +380,7 @@ class EligibilityControllerSpec
 
         def testRedirection(input: Boolean, nextCall: String) =
           inSequence {
-            mockAuthWithNecessaryEnrolment()
+            mockAuthWithEnrolment()
             mockUpdate[EligibilityJourney](_ => update(journey), eori1)(
               Right(journey.copy(eoriCheck = EoriCheckFormPage(input.some)))
             )
@@ -409,7 +409,7 @@ class EligibilityControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolment()
+          mockAuthWithEnrolment()
         }
         checkPageIsDisplayed(
           performAction(),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EscServiceSupport.scala
@@ -41,6 +41,12 @@ trait EscServiceSupport { this: ControllerSpec =>
       .expects(eori, *)
       .returning(result)
 
+  def mockGetUndertaking(eori: EORI)(result: Future[Undertaking]) =
+    (mockEscService
+      .getUndertaking(_: EORI)(_: HeaderCarrier))
+      .expects(eori, *)
+      .returning(result)
+
   def mockRetrieveUndertakingWithErrorResponse(
     eori: EORI
   )(result: Either[ConnectorError, Option[Undertaking]]) =

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/FinancialDashboardControllerSpec.scala
@@ -66,7 +66,7 @@ class FinancialDashboardControllerSpec
     "getFinancialDashboard is called" must {
 
       "return the dashboard page for a logged in user with a valid EORI" in {
-        mockAuthWithNecessaryEnrolmentNoEmailVerification(eori1)
+        mockAuthWithEnrolmentAndNoEmailVerification(eori1)
         mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
         mockRetrieveSubsidy(subsidyRetrieveForDate(fakeTimeProvider.today))(undertakingSubsidies.toFuture)
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyRedirectSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/LeadOnlyRedirectSupport.scala
@@ -30,7 +30,7 @@ trait LeadOnlyRedirectSupport extends MockFactory with Matchers {
 
   protected def testLeadOnlyRedirect(f: () => Future[Result]) = {
     inSequence {
-      mockAuthWithNecessaryEnrolmentWithValidEmail(eori3)
+      mockAuthWithEnrolmentAndValidEmail(eori3)
       mockRetrieveUndertaking(eori3)(undertaking.some.toFuture)
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentControllerSpec.scala
@@ -48,11 +48,11 @@ class NoBusinessPresentControllerSpec
     "handling request to get No Business Present" must {
       def performAction() = controller.getNoBusinessPresent(FakeRequest())
 
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
         }
         checkPageIsDisplayed(
@@ -82,7 +82,7 @@ class NoBusinessPresentControllerSpec
         val exception = new Exception("oh no!")
         "call to update business entity journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(
               Left(ConnectorError(exception))
@@ -95,7 +95,7 @@ class NoBusinessPresentControllerSpec
 
       "redirect to next page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
           mockUpdate[BusinessEntityJourney](_ => update(businessEntityJourney1), eori1)(
             Right(businessEntityJourney1)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -57,13 +57,13 @@ class NoClaimNotificationControllerSpec
     "handling request to get No claim notification" must {
 
       def performAction() = controller.getNoClaimNotification(FakeRequest())
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       val startDate = LocalDate.of(2018, 4, 6)
 
       "display the page correctly if no previous claims have been submitted" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockTimeToday(fixedDate)
           mockRetrieveSubsidy(SubsidyRetrieve(undertaking.reference, (startDate, fixedDate).some))(emptyUndertakingSubsidies.toFuture)
@@ -149,7 +149,7 @@ class NoClaimNotificationControllerSpec
 
         "call to update  Nil return journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDay)
             mockRetrieveSubsidy(subsidyRetrieve)(undertakingSubsidies.toFuture)
@@ -162,7 +162,7 @@ class NoClaimNotificationControllerSpec
 
         "call to create Subsidy fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDay)
             mockRetrieveSubsidy(subsidyRetrieve)(undertakingSubsidies.toFuture)
@@ -182,7 +182,7 @@ class NoClaimNotificationControllerSpec
 
         "check box is not checked" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDay)
             mockRetrieveSubsidy(subsidyRetrieve)(undertakingSubsidies.toFuture)
@@ -200,7 +200,7 @@ class NoClaimNotificationControllerSpec
       "redirect to next page " in {
 
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockTimeToday(currentDay)
           mockRetrieveSubsidy(subsidyRetrieve)(undertakingSubsidies.toFuture)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -87,7 +87,7 @@ class NoClaimNotificationControllerSpec
 
       "display the page correctly if at least one previous claim has been submitted" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockTimeToday(fixedDate)
           mockRetrieveSubsidy(SubsidyRetrieve(undertaking.reference, (startDate, fixedDate).some))(undertakingSubsidies.toFuture)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -59,13 +59,13 @@ class SelectNewLeadControllerSpec
     "handling request to get Select New Lead" must {
 
       def performAction() = controller.getSelectNewLead(FakeRequest())
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
         "call to fetch new lead journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[NewLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -78,7 +78,7 @@ class SelectNewLeadControllerSpec
 
         "new lead journey is blank " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[NewLeadJourney](eori1)(Right(NewLeadJourney()))
           }
@@ -98,7 +98,7 @@ class SelectNewLeadControllerSpec
         }
         "new lead journey already exists" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockGetOrCreate[NewLeadJourney](eori1)(Right(newLeadJourney))
           }
@@ -145,7 +145,7 @@ class SelectNewLeadControllerSpec
         "call to update new lead journey fails" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(Left(ConnectorError(exception)))
           }
@@ -154,7 +154,7 @@ class SelectNewLeadControllerSpec
 
         "call to send email fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
@@ -171,7 +171,7 @@ class SelectNewLeadControllerSpec
 
         "nothing is selected" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           checkFormErrorIsDisplayed(
@@ -188,7 +188,7 @@ class SelectNewLeadControllerSpec
 
         def testRedirection(nextCall: String): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
@@ -209,7 +209,7 @@ class SelectNewLeadControllerSpec
 
         "email address of BE is unverified" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[NewLeadJourney](_ => update(NewLeadJourney()), eori1)(
               Right(NewLeadJourney(SelectNewLeadFormPage(eori4.some)))
@@ -237,7 +237,7 @@ class SelectNewLeadControllerSpec
     "handling request to get lead EORI changed" must {
 
       def performAction() = controller.getLeadEORIChanged(FakeRequest())
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       def update(b: BusinessEntityJourney) = b.copy(isLeadSelectJourney = None)
 
@@ -246,7 +246,7 @@ class SelectNewLeadControllerSpec
 
         "call to fetch new lead journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[NewLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -256,7 +256,7 @@ class SelectNewLeadControllerSpec
 
         "call to fetch new lead journey came back with response but there is no selected EORI in it" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[NewLeadJourney](eori1)(Right(NewLeadJourney().some))
           }
@@ -266,7 +266,7 @@ class SelectNewLeadControllerSpec
 
         "call to update business entity journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
             mockUpdate[BusinessEntityJourney](
@@ -280,7 +280,7 @@ class SelectNewLeadControllerSpec
 
         "call to reset business entity journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
             mockUpdate[BusinessEntityJourney](
@@ -302,7 +302,7 @@ class SelectNewLeadControllerSpec
       "display the page" in {
 
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
           mockUpdate[BusinessEntityJourney](
@@ -344,7 +344,7 @@ class SelectNewLeadControllerSpec
 
         "call to fetch new lead journey came back with None" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[NewLeadJourney](eori1)(Right(None))
           }
@@ -358,13 +358,13 @@ class SelectNewLeadControllerSpec
     "handling request to Email not verified" must {
 
       def performAction() = controller.emailNotVerified(FakeRequest())
-      behave like authBehaviourWithPredicate(() => performAction())
+      behave like authBehaviour(() => performAction())
 
       "throw technical error" when {
         val exception = new Exception("oh no!")
         "call to get New lead journey  fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[NewLeadJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -372,7 +372,7 @@ class SelectNewLeadControllerSpec
 
         "call to reset New lead journey  fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
             mockPut[NewLeadJourney](NewLeadJourney(), eori1)(Left(ConnectorError(exception)))
           }
@@ -384,7 +384,7 @@ class SelectNewLeadControllerSpec
       "display the page" in {
 
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockGet[NewLeadJourney](eori1)(Right(newLeadJourney.some))
           mockPut[NewLeadJourney](NewLeadJourney(), eori1)(Right(NewLeadJourney()))
         }
@@ -400,7 +400,7 @@ class SelectNewLeadControllerSpec
 
         "call to fetch new lead journey came back with None" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[NewLeadJourney](eori1)(Right(None))
           }
           checkIsRedirect(performAction(), routes.SelectNewLeadController.getSelectNewLead().url)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SignOutControllerSpec.scala
@@ -108,7 +108,7 @@ class SignOutControllerSpec
 
         "call to retrieve email fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
           }
 
           assertThrows[Exception](await(performAction()))
@@ -116,7 +116,7 @@ class SignOutControllerSpec
 
         "call to retrieve Undertaking fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockRetrieveUndertaking(eori4)(Future.failed(exception))
           }
           assertThrows[Exception](await(performAction()))
@@ -124,7 +124,7 @@ class SignOutControllerSpec
 
         "call to remove member fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(currentDate)
             mockRemoveMember(CommonTestData.undertakingRef, businessEntity4)(Left(ConnectorError(exception)))
@@ -138,7 +138,7 @@ class SignOutControllerSpec
 
         def testDisplay(effectiveDate: String): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail(eori4)
+            mockAuthWithEnrolmentAndValidEmail(eori4)
             mockRetrieveUndertaking(eori4)(Future.successful(undertaking1.some))
             mockTimeToday(currentDate)
             mockRemoveMember(undertakingRef, businessEntity4)(Right(undertakingRef))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyControllerSpec.scala
@@ -81,7 +81,7 @@ class SubsidyControllerSpec
       "throw technical error" when {
         "call to get undertaking from EIS fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(Future.failed(new RuntimeException("Oh no!")))
           }
 
@@ -90,7 +90,7 @@ class SubsidyControllerSpec
 
         "call to get subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           assertThrows[Exception](await(performAction()))
@@ -105,7 +105,7 @@ class SubsidyControllerSpec
         def test(nonHMRCSubsidyUsage: List[NonHmrcSubsidy]) = {
           val subsidies = undertakingSubsidies.copy(nonHMRCSubsidyUsage = nonHMRCSubsidyUsage)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
             mockTimeToday(currentDate)
@@ -173,7 +173,7 @@ class SubsidyControllerSpec
 
         "call to get session fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -187,7 +187,7 @@ class SubsidyControllerSpec
 
         "a valid request is made" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Right(subsidyJourney))
             mockTimeToday(fixedDate)
@@ -226,7 +226,7 @@ class SubsidyControllerSpec
         "entered date is valid" in {
           val updatedDate = DateFormValues("1", "2", LocalDate.now().getYear.toString)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
             mockUpdate[SubsidyJourney](j => j.copy(claimDate = ClaimDateFormPage(updatedDate.some)), eori1)(
@@ -244,7 +244,7 @@ class SubsidyControllerSpec
         "entered date is not valid" in {
           val updatedDate = DateFormValues("20", "20", LocalDate.now().getYear.toString)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
             mockTimeToday(fixedDate)
@@ -273,7 +273,7 @@ class SubsidyControllerSpec
 
         "call to get subsidy journey fails " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -284,7 +284,7 @@ class SubsidyControllerSpec
       "redirect" when {
         "call to get subsidy journey come back with no claim date " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(SubsidyJourney().some))
           }
@@ -298,7 +298,7 @@ class SubsidyControllerSpec
         val claimAmountPoundsId = "claim-amount-gbp"
 
         def test(subsidyJourney: SubsidyJourney, elementId: String): Unit = {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
 
@@ -378,7 +378,7 @@ class SubsidyControllerSpec
 
         "call to get subsidy journey fails " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -387,7 +387,7 @@ class SubsidyControllerSpec
 
         "call to get subsidy journey passes but come back empty " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(None))
           }
@@ -396,7 +396,7 @@ class SubsidyControllerSpec
 
         "call to get subsidy journey passes but come back with No claim date " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(None))
           }
@@ -405,7 +405,7 @@ class SubsidyControllerSpec
 
         "call to get subsidy journey come back with no claim date " in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(SubsidyJourney().some))
           }
@@ -422,7 +422,7 @@ class SubsidyControllerSpec
             subsidyJourney.copy(claimAmount = ClaimAmountFormPage(value = claimAmountPounds.some))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
             mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
@@ -442,7 +442,7 @@ class SubsidyControllerSpec
             claimDate = ClaimDateFormPage(DateFormValues("9", "10", "2022").some)
           ).some
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourneyOpt))
           }
@@ -520,7 +520,7 @@ class SubsidyControllerSpec
         )
 
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
           mockUpdate[SubsidyJourney](_ => subsidyJourneyWithClaimAmount, eori1)(Right(subsidyJourneyWithClaimAmount))
@@ -547,7 +547,7 @@ class SubsidyControllerSpec
       )
 
       inSequence {
-        mockAuthWithNecessaryEnrolmentWithValidEmail()
+        mockAuthWithEnrolmentAndValidEmail()
         mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
         mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
         mockUpdate[SubsidyJourney](_ => subsidyJourneyWithClaimAmount, eori1)(Right(subsidyJourney))
@@ -581,7 +581,7 @@ class SubsidyControllerSpec
 
         "the call to fetch the subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -591,7 +591,7 @@ class SubsidyControllerSpec
 
         "the call to retrieve the exchange rate fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.copy(claimAmount = ClaimAmountFormPage(claimAmountPounds.some)).some))
             mockRetrieveExchangeRate(claimDate)(Future.failed(exception))
@@ -607,7 +607,7 @@ class SubsidyControllerSpec
         "a successful request is made" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.copy(claimAmount = ClaimAmountFormPage(claimAmountPounds.some)).some))
             mockRetrieveExchangeRate(claimDate)(exchangeRate.toFuture)
@@ -642,7 +642,7 @@ class SubsidyControllerSpec
 
         "the call to fetch the subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -652,7 +652,7 @@ class SubsidyControllerSpec
 
         "the call to retrieve the exchange rate fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.copy(claimAmount = ClaimAmountFormPage(claimAmountPounds.some)).some))
             mockRetrieveExchangeRate(claimDate)(Future.failed(exception))
@@ -676,7 +676,7 @@ class SubsidyControllerSpec
           )
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(initialJourney.some))
             mockRetrieveExchangeRate(claimDate)(exchangeRate.toFuture)
@@ -703,7 +703,7 @@ class SubsidyControllerSpec
 
         "the call to get subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -716,7 +716,7 @@ class SubsidyControllerSpec
 
         def test(subsidyJourney: SubsidyJourney): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Right(subsidyJourney))
           }
@@ -779,7 +779,7 @@ class SubsidyControllerSpec
 
         "call to get journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -792,7 +792,7 @@ class SubsidyControllerSpec
             subsidyJourney.copy(addClaimEori = AddClaimEoriFormPage(OptionalEORI("false", None).some))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
             mockUpdate[SubsidyJourney](
@@ -812,7 +812,7 @@ class SubsidyControllerSpec
         ): Unit = {
           val answers = inputAnswer.getOrElse(Nil)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
           }
@@ -863,7 +863,7 @@ class SubsidyControllerSpec
           val updatedSubsidyJourney = update(journey, optionalEORI.some)
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(journey.some))
             mockUpdate[SubsidyJourney](_ => update(journey, optionalEORI.some), eori1)(
@@ -911,7 +911,7 @@ class SubsidyControllerSpec
       "display the page" when {
         "a valid request is made" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Right(subsidyJourney))
           }
@@ -946,7 +946,7 @@ class SubsidyControllerSpec
 
         "valid input" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(journey.some))
             mockUpdate[SubsidyJourney](
@@ -967,7 +967,7 @@ class SubsidyControllerSpec
 
         def displayError(data: (String, String)*)(messageKey: String): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
           }
@@ -1005,7 +1005,7 @@ class SubsidyControllerSpec
 
         "the call to get subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -1018,7 +1018,7 @@ class SubsidyControllerSpec
 
         def test(subsidyJourney: SubsidyJourney): Unit = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGetOrCreate[SubsidyJourney](eori1)(Right(subsidyJourney))
           }
@@ -1089,7 +1089,7 @@ class SubsidyControllerSpec
         val exception = new Exception("oh no")
         "call to get fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -1102,7 +1102,7 @@ class SubsidyControllerSpec
         def testFormError(inputAnswer: Option[List[(String, String)]], errorMessageKey: String): Unit = {
           val answers = inputAnswer.getOrElse(Nil)
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
           }
@@ -1146,7 +1146,7 @@ class SubsidyControllerSpec
         "call to fetch undertaking passes but come back with empty reference" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
           }
           assertThrows[Exception](await(performAction(transactionId)))
@@ -1154,7 +1154,7 @@ class SubsidyControllerSpec
 
         "call to retrieve subsidy failed" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(Future.failed(exception))
@@ -1164,7 +1164,7 @@ class SubsidyControllerSpec
 
         "call to retrieve subsidy comes back with nonHMRC subsidy usage list with missing transactionId" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies.toFuture)
@@ -1199,7 +1199,7 @@ class SubsidyControllerSpec
         )
 
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockTimeToday(currentDate)
           mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
@@ -1243,7 +1243,7 @@ class SubsidyControllerSpec
 
         "call to retrieve subsidy fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(Future.failed(exception))
@@ -1253,7 +1253,7 @@ class SubsidyControllerSpec
 
         "call to remove subsidy fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
@@ -1268,7 +1268,7 @@ class SubsidyControllerSpec
 
         "nothing is submitted" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
@@ -1285,7 +1285,7 @@ class SubsidyControllerSpec
 
         "If user select yes" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockTimeToday(currentDate)
             mockRetrieveSubsidy(subsidyRetrieveWithDates)(undertakingSubsidies1.toFuture)
@@ -1301,7 +1301,7 @@ class SubsidyControllerSpec
 
         "if user selects no" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           checkIsRedirect(
@@ -1330,7 +1330,7 @@ class SubsidyControllerSpec
 
         def testErrorFor(s: SubsidyJourney) = {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockGet[SubsidyJourney](eori1)(Right(s.some))
           }
@@ -1362,7 +1362,7 @@ class SubsidyControllerSpec
 
       "redirect to account home if no subsidy journey data found" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
           mockGet[SubsidyJourney](eori1)(Right(Option.empty))
         }
@@ -1375,7 +1375,7 @@ class SubsidyControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
           mockGet[SubsidyJourney](eori1)(Right(subsidyJourney.some))
         }
@@ -1402,7 +1402,7 @@ class SubsidyControllerSpec
 
         "call to update subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Left(ConnectorError(exception)))
           }
@@ -1412,7 +1412,7 @@ class SubsidyControllerSpec
 
         "call to create subsidy fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
             mockTimeToday(currentDate)
@@ -1425,7 +1425,7 @@ class SubsidyControllerSpec
 
         "call to delete subsidy journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockUpdate[SubsidyJourney](_ => update(subsidyJourney), eori1)(Right(updatedJourney))
             mockTimeToday(currentDate)
@@ -1444,7 +1444,7 @@ class SubsidyControllerSpec
 
           val updatedSJ = subsidyJourney.copy(cya = CyaFormPage(value = true.some))
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockUpdate[SubsidyJourney](
               _ => update(subsidyJourney),
@@ -1487,7 +1487,7 @@ class SubsidyControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockTimeToday(fixedDate)
         }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -53,7 +53,7 @@ class UndertakingControllerSpec
     with EmailSupport
     with AuditServiceSupport
     with EscServiceSupport
-    with EmailVerificationSupport
+    with EmailVerificationServiceSupport
     with TimeProviderSupport {
 
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -17,8 +17,6 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.implicits.catsSyntaxOptionId
-import com.mongodb.client.result.UpdateResult
-import org.bson.BsonBoolean
 import play.api.Configuration
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
@@ -581,7 +579,7 @@ class UndertakingControllerSpec
           inSequence {
             mockAuthWithNecessaryEnrolmentNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
-            mockApproveVerification(eori1, "id")(Right(UpdateResult.acknowledged(1, 1, BsonBoolean.TRUE)))
+            mockApproveVerification(eori1, "id")(Right(true))
             mockGetEmailVerification(eori1)(Right(VerifiedEmail("", "", verified = true).some))
             mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourney))
           }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -440,7 +440,7 @@ class UndertakingControllerSpec
 
         "about has not been answered" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney().some))
           }
           checkIsRedirect(performAction(), routes.UndertakingController.getAboutUndertaking().url)
@@ -584,7 +584,7 @@ class UndertakingControllerSpec
             mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourney))
           }
 
-          redirectLocation(performAction("id")) shouldBe Some(routes.UndertakingController.getCheckAnswers().url)
+          redirectLocation(performAction("id")) shouldBe Some(routes.UndertakingController.getAddBusiness().url)
         }
       }
 
@@ -752,7 +752,7 @@ class UndertakingControllerSpec
         val exception = new Exception("oh no")
         "call to fetch undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -771,7 +771,7 @@ class UndertakingControllerSpec
           val previousCall = routes.UndertakingController.getConfirmEmail().url
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
           }
           checkPageIsDisplayed(
@@ -798,7 +798,7 @@ class UndertakingControllerSpec
           val previousCall = routes.UndertakingController.getConfirmEmail().url
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
           }
           checkPageIsDisplayed(
@@ -820,7 +820,7 @@ class UndertakingControllerSpec
 
         "call to fetch undertaking journey passes  but return no undertaking journey" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
           checkIsRedirect(performAction(), routes.UndertakingController.getAboutUndertaking().url)
@@ -831,7 +831,7 @@ class UndertakingControllerSpec
 
         "email question has not been answered" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(UndertakingJourney(
               about = AboutUndertakingFormPage("TestUndertaking".some),
               sector = UndertakingSectorFormPage(Sector(1).some)
@@ -858,7 +858,7 @@ class UndertakingControllerSpec
 
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Left(ConnectorError(exception))
@@ -875,7 +875,7 @@ class UndertakingControllerSpec
         def displayErrorTest(data: (String, String)*)(errorMessage: String): Unit = {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
           }
 
@@ -897,7 +897,7 @@ class UndertakingControllerSpec
 
         "user selected No" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
             mockUpdate[UndertakingJourney](_ => update(UndertakingJourney()), eori1)(
               Right(UndertakingJourney(addBusiness = UndertakingAddBusinessFormPage(false.some)))
@@ -908,7 +908,7 @@ class UndertakingControllerSpec
 
         "user selected Yes" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
             mockUpdate[UndertakingJourney](_ => update(UndertakingJourney()), eori1)(
               Right(UndertakingJourney(addBusiness = UndertakingAddBusinessFormPage(true.some)))
@@ -1124,6 +1124,7 @@ class UndertakingControllerSpec
       "display the page" in {
         inSequence {
           mockAuthWithEnrolmentAndValidEmail()
+          mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
         }
 
         checkPageIsDisplayed(
@@ -1140,7 +1141,7 @@ class UndertakingControllerSpec
 
       "display the page with intent to add business" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.copy(addBusiness = UndertakingAddBusinessFormPage(true.some)).some))
         }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -667,14 +667,14 @@ class UndertakingControllerSpec
         }
       }
 
-      "redirect to journey start page" when {
+      "redirect to previous page" when {
 
-        "call to fetch undertaking journey passes  but return no undertaking journey" in {
+        "call to fetch undertaking journey returns no undertaking journey" in {
           inSequence {
             mockAuthWithNecessaryEnrolmentNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
-          checkIsRedirect(performAction(), routes.UndertakingController.getAboutUndertaking().url)
+          checkIsRedirect(performAction(), routes.UndertakingController.getSector().url)
         }
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -86,7 +86,7 @@ class UndertakingControllerSpec
 
         "call to Get Or Create undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGetOrCreate[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -97,7 +97,7 @@ class UndertakingControllerSpec
 
         "undertaking journey is present and  is not None and is complete" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGetOrCreate[UndertakingJourney](eori1)(Right(undertakingJourneyComplete))
           }
           checkIsRedirect(performAction(), routes.BusinessEntityController.getAddBusinessEntity().url)
@@ -107,7 +107,7 @@ class UndertakingControllerSpec
 
           def testRedirect(undertakingJourney: UndertakingJourney, redirectTo: String): Unit = {
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification()
+              mockAuthWithEnrolmentAndNoEmailVerification()
               mockGetOrCreate[UndertakingJourney](eori1)(Right(undertakingJourney))
             }
             checkIsRedirect(performAction(), redirectTo)
@@ -198,7 +198,7 @@ class UndertakingControllerSpec
         def testDisplay(undertakingJourney: UndertakingJourney, backUrl: String): Unit = {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGetOrCreate[UndertakingJourney](eori1)(Right(undertakingJourney))
           }
           checkPageIsDisplayed(
@@ -214,7 +214,7 @@ class UndertakingControllerSpec
 
         "no undertaking journey is there in store" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
           }
           checkPageIsDisplayed(
@@ -270,7 +270,7 @@ class UndertakingControllerSpec
 
         "call to  get undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingName" -> "TestUndertaking123")))
@@ -278,7 +278,7 @@ class UndertakingControllerSpec
 
         "call to  get undertaking journey passes but com back with empty response" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
           assertThrows[Exception](await(performAction("undertakingName" -> "TestUndertaking123")))
@@ -288,7 +288,7 @@ class UndertakingControllerSpec
           def update(u: UndertakingJourney) = u.copy(about = AboutUndertakingFormPage("TestUndertaking123".some))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Left(ConnectorError(exception))
@@ -299,7 +299,7 @@ class UndertakingControllerSpec
 
         "submitted form does not contain expected data" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
           }
 
@@ -312,7 +312,7 @@ class UndertakingControllerSpec
         def test(undertakingJourney: UndertakingJourney, nextCall: String): Unit = {
           val updatedUndertaking = undertakingJourney.copy(about = AboutUndertakingFormPage("TestUndertaking123".some))
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
             mockUpdate[UndertakingJourney](identity, eori1)(
               Right(updatedUndertaking)
@@ -347,7 +347,7 @@ class UndertakingControllerSpec
         val exception = new Exception("oh no")
         "call to fetch undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -371,7 +371,7 @@ class UndertakingControllerSpec
         def test(undertakingJourney: UndertakingJourney, previousCall: String, inputValue: Option[String]): Unit = {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
           }
           checkPageIsDisplayed(
@@ -429,7 +429,7 @@ class UndertakingControllerSpec
 
         "call to fetch undertaking journey passes  but return no undertaking journey" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
           checkIsRedirect(performAction(), routes.UndertakingController.getAboutUndertaking().url)
@@ -463,7 +463,7 @@ class UndertakingControllerSpec
 
         "call to get previous url fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("undertakingSector" -> "2")))
@@ -471,7 +471,7 @@ class UndertakingControllerSpec
 
         "call to fetch undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -479,7 +479,7 @@ class UndertakingControllerSpec
 
         "call to fetch undertaking journey passes  buy fetches nothing" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
           assertThrows[Exception](await(performAction()))
@@ -488,7 +488,7 @@ class UndertakingControllerSpec
         "call to update undertaking journey fails" in {
           val currentUndertaking = UndertakingJourney(about = AboutUndertakingFormPage("TestUndertaking".some))
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(currentUndertaking.some))
             mockUpdate[UndertakingJourney](_ => update(currentUndertaking), eori1)(Left(ConnectorError(exception)))
           }
@@ -501,7 +501,7 @@ class UndertakingControllerSpec
 
         "nothing is submitted" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(
               Right(undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage()).some)
             )
@@ -526,7 +526,7 @@ class UndertakingControllerSpec
 
           val updatedUndertaking = undertakingJourney.copy(sector = newSector)
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
             mockUpdate[UndertakingJourney](_ => update(undertakingJourney), eori1)(Right(updatedUndertaking))
           }
@@ -559,7 +559,7 @@ class UndertakingControllerSpec
         val exception = new Exception("oh no")
         "call to fetch undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("abcdefh")))
@@ -577,7 +577,7 @@ class UndertakingControllerSpec
           )
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
             mockApproveVerification(eori1, "id")(Right(true))
             mockGetEmailVerification(eori1)(Right(VerifiedEmail("", "", verified = true).some))
@@ -599,7 +599,7 @@ class UndertakingControllerSpec
         val exception = new Exception("oh no")
         "call to fetch undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -617,7 +617,7 @@ class UndertakingControllerSpec
             val previousCall = routes.UndertakingController.getSector().url
 
             inSequence {
-              mockAuthWithNecessaryEnrolmentNoEmailVerification()
+              mockAuthWithEnrolmentAndNoEmailVerification()
               mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
               mockGetEmailVerification(eori1)(Right(VerifiedEmail("", "", verified = true).some))
             }
@@ -643,7 +643,7 @@ class UndertakingControllerSpec
           val previousCall = routes.UndertakingController.getSector().url
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourney.some))
             mockGetEmailVerification(eori1)(Right(VerifiedEmail("", "", verified = true).some))
           }
@@ -666,7 +666,7 @@ class UndertakingControllerSpec
 
         "call to fetch undertaking journey returns no undertaking journey" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
           checkIsRedirect(performAction(), routes.UndertakingController.getSector().url)
@@ -688,7 +688,7 @@ class UndertakingControllerSpec
         "email submitted is empty" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
           }
           assertThrows[Exception](await(performAction(
             "using-stored-email" -> "false"
@@ -698,7 +698,7 @@ class UndertakingControllerSpec
         "email submitted is invalid" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentNoEmailVerification()
+            mockAuthWithEnrolmentAndNoEmailVerification()
           }
           assertThrows[Exception](await(performAction(
             "using-stored-email" -> "false",
@@ -712,7 +712,7 @@ class UndertakingControllerSpec
 
        "all api calls are successful" in {
          inSequence {
-           mockAuthWithNecessaryEnrolmentWithValidEmail()
+           mockAuthWithEnrolmentAndValidEmail()
            mockAddVerifiedEmail(eori1, "foo@example.com")()
            mockUpdate[UndertakingJourney](identity, eori1)(Right(undertakingJourneyComplete))
          }
@@ -724,7 +724,7 @@ class UndertakingControllerSpec
 
       "No verification found or cds with valid form should redirect" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockMakeVerificationRequestAndRedirect(Redirect("email-verification-redirect").toFuture)
         }
         redirectLocation(performAction("using-stored-email" -> "false", "email" -> "something@aol.com")) shouldBe "email-verification-redirect".some
@@ -732,7 +732,7 @@ class UndertakingControllerSpec
 
        "No verification found or cds with invalid form should be bad request" in {
          inSequence {
-           mockAuthWithNecessaryEnrolmentWithValidEmail()
+           mockAuthWithEnrolmentAndValidEmail()
          }
          status(performAction("using-stored-email" -> "false", "email" -> "somethingl.com")) shouldBe BAD_REQUEST
        }
@@ -949,7 +949,7 @@ class UndertakingControllerSpec
           ),
         )
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
         }
 
@@ -977,7 +977,7 @@ class UndertakingControllerSpec
 
         "call to get undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction()))
@@ -988,7 +988,7 @@ class UndertakingControllerSpec
       "redirect" when {
         "call to get undertaking journey fetches the journey without verified email" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(
               Right(undertakingJourneyComplete.copy(verifiedEmail = UndertakingConfirmEmailFormPage()).some)
             )
@@ -998,7 +998,7 @@ class UndertakingControllerSpec
 
         "to journey start when call to get undertaking journey fetches nothing" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
           checkIsRedirect(performAction(), routes.UndertakingController.getAboutUndertaking().url)
@@ -1022,7 +1022,7 @@ class UndertakingControllerSpec
         "cya form is empty, nothing is submitted" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
           }
           assertThrows[Exception](await(performAction()))
         }
@@ -1030,7 +1030,7 @@ class UndertakingControllerSpec
         "call to update undertaking journey fails" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
@@ -1039,7 +1039,7 @@ class UndertakingControllerSpec
         "updated undertaking journey don't have undertaking name" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
@@ -1048,7 +1048,7 @@ class UndertakingControllerSpec
         "updated undertaking journey don't have undertaking sector" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](identity, eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("cya" -> "true")))
@@ -1059,7 +1059,7 @@ class UndertakingControllerSpec
           val updatedUndertakingJourney = undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Left(ConnectorError(exception)))
           }
@@ -1073,7 +1073,7 @@ class UndertakingControllerSpec
             undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
             mockSendEmail(eori1, CreateUndertaking, undertakingCreated.toUndertakingWithRef(undertakingRef))(
@@ -1092,7 +1092,7 @@ class UndertakingControllerSpec
           val updatedUndertakingJourney = undertakingJourneyComplete.copy(cya = UndertakingCyaFormPage(false.some))
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](identity, eori1)(Right(updatedUndertakingJourney))
             mockCreateUndertaking(undertakingCreated)(Right(undertakingRef))
             mockSendEmail(eori1, CreateUndertaking, undertakingCreated.toUndertakingWithRef(undertakingRef))(
@@ -1123,8 +1123,7 @@ class UndertakingControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
-          mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
+          mockAuthWithEnrolmentAndValidEmail()
         }
 
         checkPageIsDisplayed(
@@ -1172,14 +1171,14 @@ class UndertakingControllerSpec
 
         "confirmation form is empty" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
           }
           assertThrows[Exception](await(performAction()))
         }
 
         "call to update undertaking confirmation fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockUpdate[UndertakingJourney](_ => update(undertakingJourney), eori1)(Left(ConnectorError(exception)))
           }
           assertThrows[Exception](await(performAction("confirm" -> "true")))
@@ -1188,7 +1187,7 @@ class UndertakingControllerSpec
 
       "redirect to next page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockUpdate[UndertakingJourney](_ => update(undertakingJourney), eori1)(Right(undertakingJourneyComplete))
         }
 
@@ -1216,7 +1215,7 @@ class UndertakingControllerSpec
         val exception = new Exception("oh no")
         "call to get undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[UndertakingJourney](eori1)(Left(ConnectorError(exception)))
           }
@@ -1226,7 +1225,7 @@ class UndertakingControllerSpec
         "call to update the undertaking journey fails" in {
 
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
@@ -1241,7 +1240,7 @@ class UndertakingControllerSpec
 
         "is Amend is true" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.copy(isAmend = true).some))
           }
@@ -1266,7 +1265,7 @@ class UndertakingControllerSpec
 
         "is Amend flag is false" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[UndertakingJourney](eori1)(Right(undertakingJourneyComplete.some))
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
@@ -1298,7 +1297,7 @@ class UndertakingControllerSpec
 
         "call to get undertaking journey fetches nothing" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockGet[UndertakingJourney](eori1)(Right(None))
           }
@@ -1324,7 +1323,7 @@ class UndertakingControllerSpec
 
         "call to update undertaking journey fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Left(ConnectorError(exception))
@@ -1336,7 +1335,7 @@ class UndertakingControllerSpec
 
         "call to update undertaking journey passes but return undertaking with no name" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(about = AboutUndertakingFormPage()))
@@ -1348,7 +1347,7 @@ class UndertakingControllerSpec
 
         "call to update undertaking journey passes but return undertaking with no secctor" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(about = AboutUndertakingFormPage()))
@@ -1360,7 +1359,7 @@ class UndertakingControllerSpec
 
         "call to retrieve undertaking fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(about = AboutUndertakingFormPage("true".some)))
@@ -1372,7 +1371,7 @@ class UndertakingControllerSpec
 
         "call to retrieve undertaking passes but no undertaking was fetched" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(about = AboutUndertakingFormPage("true".some)))
@@ -1386,7 +1385,7 @@ class UndertakingControllerSpec
           val updatedUndertaking =
             undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
             mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
               Right(undertakingJourneyComplete.copy(isAmend = true))
@@ -1403,7 +1402,7 @@ class UndertakingControllerSpec
         val updatedUndertaking =
           undertaking1.copy(name = UndertakingName("TestUndertaking"), industrySector = Sector(1))
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           mockUpdate[UndertakingJourney](_ => update(undertakingJourneyComplete), eori1)(
             Right(undertakingJourneyComplete.copy(isAmend = true))
@@ -1424,7 +1423,7 @@ class UndertakingControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
         }
         checkPageIsDisplayed(
@@ -1441,7 +1440,7 @@ class UndertakingControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
           mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
         }
         checkPageIsDisplayed(
@@ -1473,7 +1472,7 @@ class UndertakingControllerSpec
       "throw technical error" when {
         "call to remove disable fails" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockDisableUndertaking(undertaking1)(Left(ConnectorError(exception)))
           }
@@ -1485,7 +1484,7 @@ class UndertakingControllerSpec
 
         "Nothing is submitted" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           checkFormErrorIsDisplayed(
@@ -1501,7 +1500,7 @@ class UndertakingControllerSpec
 
         "user select Yes" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking1.some.toFuture)
             mockDisableUndertaking(undertaking1)(Right(undertakingRef))
             mockDelete[EligibilityJourney](eori1)(Right(()))
@@ -1532,7 +1531,7 @@ class UndertakingControllerSpec
 
         "user selected No" in {
           inSequence {
-            mockAuthWithNecessaryEnrolmentWithValidEmail()
+            mockAuthWithEnrolmentAndValidEmail()
             mockRetrieveUndertaking(eori1)(undertaking.some.toFuture)
           }
           checkIsRedirect(
@@ -1549,7 +1548,7 @@ class UndertakingControllerSpec
 
       "display the page" in {
         inSequence {
-          mockAuthWithNecessaryEnrolmentWithValidEmail()
+          mockAuthWithEnrolmentAndValidEmail()
         }
         checkPageIsDisplayed(
           performAction(),

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -569,7 +569,7 @@ class UndertakingControllerSpec
 
       }
 
-      "200 OK" when {
+      "display the page" when {
 
         "User has verified email in CDS" in {
           val undertakingJourney = UndertakingJourney(

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 
+// TODO - review the tests - can we easily delegate the journey logic to the BecomeLeadJourney class?
 class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
 
   "BecomeLeadJourney" when {
@@ -44,9 +45,9 @@ class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
           .url
       }
 
-      "Accept terms" in {
+      "Accept responsibilities" in {
         BecomeLeadJourney.FormPages.AcceptResponsibilitiesFormPage().uri shouldBe routes.BecomeLeadController
-          .getAcceptPromotionTerms()
+          .getAcceptResponsibilities()
           .url
       }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
@@ -20,7 +20,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
 
-// TODO - review the tests - can we easily delegate the journey logic to the BecomeLeadJourney class?
 class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
 
   "BecomeLeadJourney" when {

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
@@ -30,8 +30,8 @@ class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
       "return all forms at the start of the journey" in {
         val underTest = BecomeLeadJourney()
         underTest.steps shouldBe Array(
-          underTest.becomeLeadEori,
           underTest.acceptResponsibilities,
+          underTest.becomeLeadEori,
           underTest.confirmation
         )
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/BecomeLeadJourneySpec.scala
@@ -30,7 +30,7 @@ class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
         val underTest = BecomeLeadJourney()
         underTest.steps shouldBe Array(
           underTest.becomeLeadEori,
-          underTest.acceptTerms,
+          underTest.acceptResponsibilities,
           underTest.confirmation
         )
       }
@@ -45,7 +45,7 @@ class BecomeLeadJourneySpec extends AnyWordSpecLike with Matchers {
       }
 
       "Accept terms" in {
-        BecomeLeadJourney.FormPages.TermsAndConditionsFormPage().uri shouldBe routes.BecomeLeadController
+        BecomeLeadJourney.FormPages.AcceptResponsibilitiesFormPage().uri shouldBe routes.BecomeLeadController
           .getAcceptPromotionTerms()
           .url
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
@@ -101,9 +101,9 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
 
     "approveVerificationRequest is called" must {
 
-      "success" in {
+      "report success for a successful update" in {
         repository.put(eori1, unverifiedVerificationRequest.copy(verificationId = "pending")).futureValue.id shouldBe eori1
-        service.approveVerificationRequest(eori1, "pending").futureValue.wasAcknowledged() shouldBe true
+        service.approveVerificationRequest(eori1, "pending").futureValue shouldBe true
 
         service.getEmailVerification(eori1).futureValue should
           contain(unverifiedVerificationRequest.copy(verified = true, verificationId = "pending"))

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
@@ -39,7 +39,6 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-// TODO - this needs a running mongo - move to it:test?
 class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with MockFactory
   with ScalaFutures with DefaultAwaitTimeout with DefaultPlayMongoRepositorySupport[CacheItem] {
 
@@ -58,12 +57,6 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
   )
 
   override def afterAll(): Unit = repository.collection.deleteMany(filter = Filters.exists("_id"))
-
-  private def mockBaseUrlConfig(url: String) =
-    (mockServicesConfig
-      .baseUrl(_: String))
-      .expects(*)
-      .returning(url)
 
   val nextPageUrl = "/next-page-url"
   val previousPage = Call(GET, "/previous-page-url")

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
@@ -108,7 +108,7 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
       "store a new email verification request and mark it as verified" in {
         val email = "foo@example.com"
 
-        service.addVerifiedEmail(eori4, email).futureValue shouldBe ()
+        service.addVerifiedEmail(eori4, email).futureValue shouldBe (())
 
         // Query mongo to confirm that we have a verified record
         val result = service.getEmailVerification(eori4)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
@@ -16,51 +16,72 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
-import cats.implicits.catsSyntaxOptionId
 import org.mongodb.scala.model.Filters
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.test.DefaultAwaitTimeout
+import play.api.mvc.{AnyContent, Call}
 import play.api.test.Helpers._
+import play.api.test.{DefaultAwaitTimeout, FakeRequest}
+import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.cache.EoriEmailDatastore
 import uk.gov.hmrc.eusubsidycompliancefrontend.connectors.EmailVerificationConnector
-import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.routes
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailVerificationResponse, VerifiedEmail}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{EmailVerificationRequest, VerifiedEmail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData._
-import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-// TODO - expand coverage to ensure API changes are properly covered
+// TODO - this needs a running mongo - move to it:test?
 class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with MockFactory
   with ScalaFutures with DefaultAwaitTimeout with DefaultPlayMongoRepositorySupport[CacheItem] {
 
-  implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
   private val mockEmailVerificationConnector: EmailVerificationConnector = mock[EmailVerificationConnector]
 
-    override protected def repository = new EoriEmailDatastore(mongoComponent)
+  override protected def repository = new EoriEmailDatastore(mongoComponent)
 
-    private val service = new EmailVerificationService(
+  private val mockServicesConfig = mock[ServicesConfig]
+
+  private val service = new EmailVerificationService(
     mockEmailVerificationConnector,
     repository,
-    mock[ServicesConfig]
+    mockServicesConfig,
   )
-  override def afterAll(): Unit = {
-    repository.collection.deleteMany(filter = Filters.exists("_id"))
-  }
+
+  override def afterAll(): Unit = repository.collection.deleteMany(filter = Filters.exists("_id"))
+
+  private def mockBaseUrlConfig(url: String) =
+    (mockServicesConfig
+      .baseUrl(_: String))
+      .expects(*)
+      .returning(url)
+
+  val nextPageUrl = "/next-page-url"
+  val previousPage = Call(GET, "/previous-page-url")
+
+  val responseBody =
+    s"""
+       |{
+       |  "redirectUri": "$nextPageUrl"
+       |}""".stripMargin
+
+
+  def mockVerifyEmail(status: Int = CREATED) = (mockEmailVerificationConnector
+    .verifyEmail(_: EmailVerificationRequest)(_: HeaderCarrier, _: ExecutionContext))
+    .expects(*, *, *)
+    .returning(Right(HttpResponse(status, responseBody)).toFuture)
 
   private val unverifiedVerificationRequest = VerifiedEmail("unverified@something.com", "someId", verified = false)
   private val verifiedVerificationRequest = VerifiedEmail("verified@something.com", "someId", verified = true)
-
-  private val mockVerifyEmailResponse = EmailVerificationResponse("testRedirectUrl")
 
   "EmailVerificationService" when {
 
@@ -78,62 +99,74 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
 
     }
 
-//    "verifyEori is called" must {
-
-//        "record is verified" in {
-//          repository.put(eori3, unverifiedVerificationRequest).futureValue.id shouldBe eori3
-
-//          service.getEmailVerification(eori3).futureValue shouldBe None
-//          service.verifyEori(eori3).futureValue.id shouldBe eori3
-
-//          service.getEmailVerification(eori3).futureValue should contain(unverifiedVerificationRequest.copy(verified = true))
-//        }
-//    }
-
     "approveVerificationRequest is called" must {
 
-        "success" in {
-          repository.put(eori1, unverifiedVerificationRequest.copy(verificationId = "pending")).futureValue.id shouldBe eori1
-          service.approveVerificationRequest(eori1, "pending").futureValue.wasAcknowledged() shouldBe true
+      "success" in {
+        repository.put(eori1, unverifiedVerificationRequest.copy(verificationId = "pending")).futureValue.id shouldBe eori1
+        service.approveVerificationRequest(eori1, "pending").futureValue.wasAcknowledged() shouldBe true
 
-          service.getEmailVerification(eori1).futureValue should
-            contain(unverifiedVerificationRequest.copy(verified = true, verificationId = "pending"))
-        }
+        service.getEmailVerification(eori1).futureValue should
+          contain(unverifiedVerificationRequest.copy(verified = true, verificationId = "pending"))
+      }
     }
 
-//    "emailVerificationRedirect is called" must {
-//
-//
-//        "correct redirect is given" in {
-//          (mockEmailVerificationConnector
-//            .getVerificationJourney(_: String))
-//            .expects(*)
-//            .returning("redirecturl")
-//          // TODO - review call param here and revise to ensure we cover the redirect URL correctly
-//          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(mockVerifyEmailResponse.some)
-//          // TODO - review what this is covering
-//          redirectLocation(a.toFuture) should contain("redirecturl")
-//
-//      }
-//
-//        "no redirect is given" in {
-//          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(None)
-//          redirectLocation(a.toFuture) should contain(routes.UndertakingController.getConfirmEmail().url)
-//        }
-//
-//
-//    }
+    "addVerifiedEmail is called" must {
 
-//    "addVerificationRequest is called" must {
-//
-//        "add verification record successfully" in {
-//          val pendingId = service.addVerificationRequest(eori4, "testemail@aol.com").futureValue
-//          service.getEmailVerification(eori4).futureValue shouldBe None
-//          service.verifyEori(eori4).futureValue.id shouldBe eori4
-//
-//          service.getEmailVerification(eori4).futureValue should contain(VerifiedEmail("testemail@aol.com", pendingId, verified = true))
-//        }
-//
-//    }
+      "store a new email verification request and mark it as verified" in {
+        val email = "foo@example.com"
+
+        service.addVerifiedEmail(eori4, email).futureValue shouldBe ()
+
+        // Query mongo to confirm that we have a verified record
+        val result = service.getEmailVerification(eori4)
+
+        result.futureValue.map(_.email) should contain(email)
+        result.futureValue.map(_.verified) should contain(true)
+        result.futureValue.map(_.verificationId.length) should contain(36) // Crude UUID is set check
+      }
+
+    }
+
+    "makeVerificationRequest is called" must {
+
+      implicit val request: AuthenticatedEnrolledRequest[AnyContent] = AuthenticatedEnrolledRequest(
+        authorityId = "SomeAuthorityId",
+        groupId = "SomeGroupId",
+        request = FakeRequest(GET, "/"),
+        eoriNumber = eori1
+      )
+
+      "redirect to the next page if the email verification succeeded" in {
+        inSequence {
+          mockVerifyEmail()
+        }
+
+        val result = service.makeVerificationRequestAndRedirect(
+          "foo@example.com",
+          previousPage,
+          _ => nextPageUrl,
+        )
+
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(nextPageUrl)
+      }
+
+      "redirect to the previous page if the email verification failed" in {
+        inSequence {
+          mockVerifyEmail(status = BAD_REQUEST)
+        }
+
+        val result = service.makeVerificationRequestAndRedirect(
+          "foo@example.com",
+          previousPage,
+          _ => nextPageUrl,
+        )
+
+        status(result) shouldBe SEE_OTHER
+        redirectLocation(result) should contain(previousPage.url)
+      }
+
+    }
+
   }
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
@@ -78,17 +78,17 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
 
     }
 
-    "verifyEori is called" must {
+//    "verifyEori is called" must {
 
-        "record is verified" in {
-          repository.put(eori3, unverifiedVerificationRequest).futureValue.id shouldBe eori3
+//        "record is verified" in {
+//          repository.put(eori3, unverifiedVerificationRequest).futureValue.id shouldBe eori3
 
-          service.getEmailVerification(eori3).futureValue shouldBe None
-          service.verifyEori(eori3).futureValue.id shouldBe eori3
+//          service.getEmailVerification(eori3).futureValue shouldBe None
+//          service.verifyEori(eori3).futureValue.id shouldBe eori3
 
-          service.getEmailVerification(eori3).futureValue should contain(unverifiedVerificationRequest.copy(verified = true))
-        }
-    }
+//          service.getEmailVerification(eori3).futureValue should contain(unverifiedVerificationRequest.copy(verified = true))
+//        }
+//    }
 
     "approveVerificationRequest is called" must {
 
@@ -101,39 +101,39 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
         }
     }
 
-    "emailVerificationRedirect is called" must {
+//    "emailVerificationRedirect is called" must {
+//
+//
+//        "correct redirect is given" in {
+//          (mockEmailVerificationConnector
+//            .getVerificationJourney(_: String))
+//            .expects(*)
+//            .returning("redirecturl")
+//          // TODO - review call param here and revise to ensure we cover the redirect URL correctly
+//          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(mockVerifyEmailResponse.some)
+//          // TODO - review what this is covering
+//          redirectLocation(a.toFuture) should contain("redirecturl")
+//
+//      }
+//
+//        "no redirect is given" in {
+//          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(None)
+//          redirectLocation(a.toFuture) should contain(routes.UndertakingController.getConfirmEmail().url)
+//        }
+//
+//
+//    }
 
-
-        "correct redirect is given" in {
-          (mockEmailVerificationConnector
-            .getVerificationJourney(_: String))
-            .expects(*)
-            .returning("redirecturl")
-          // TODO - review call param here and revise to ensure we cover the redirect URL correctly
-          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(mockVerifyEmailResponse.some)
-          // TODO - review what this is covering
-          redirectLocation(a.toFuture) should contain("redirecturl")
-
-      }
-
-        "no redirect is given" in {
-          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(None)
-          redirectLocation(a.toFuture) should contain(routes.UndertakingController.getConfirmEmail().url)
-        }
-
-
-    }
-
-    "addVerificationRequest is called" must {
-
-        "add verification record successfully" in {
-          val pendingId = service.addVerificationRequest(eori4, "testemail@aol.com").futureValue
-          service.getEmailVerification(eori4).futureValue shouldBe None
-          service.verifyEori(eori4).futureValue.id shouldBe eori4
-
-          service.getEmailVerification(eori4).futureValue should contain(VerifiedEmail("testemail@aol.com", pendingId, verified = true))
-        }
-
-    }
+//    "addVerificationRequest is called" must {
+//
+//        "add verification record successfully" in {
+//          val pendingId = service.addVerificationRequest(eori4, "testemail@aol.com").futureValue
+//          service.getEmailVerification(eori4).futureValue shouldBe None
+//          service.verifyEori(eori4).futureValue.id shouldBe eori4
+//
+//          service.getEmailVerification(eori4).futureValue should contain(VerifiedEmail("testemail@aol.com", pendingId, verified = true))
+//        }
+//
+//    }
   }
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSpec.scala
@@ -38,6 +38,7 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+// TODO - expand coverage to ensure API changes are properly covered
 class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with MockFactory
   with ScalaFutures with DefaultAwaitTimeout with DefaultPlayMongoRepositorySupport[CacheItem] {
 
@@ -108,13 +109,15 @@ class EmailVerificationServiceSpec extends AnyWordSpec with Matchers with Before
             .getVerificationJourney(_: String))
             .expects(*)
             .returning("redirecturl")
-          val a = service.emailVerificationRedirect(mockVerifyEmailResponse.some)
+          // TODO - review call param here and revise to ensure we cover the redirect URL correctly
+          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(mockVerifyEmailResponse.some)
+          // TODO - review what this is covering
           redirectLocation(a.toFuture) should contain("redirecturl")
 
       }
 
         "no redirect is given" in {
-          val a = service.emailVerificationRedirect(None)
+          val a = service.emailVerificationRedirect(routes.UndertakingController.getConfirmEmail())(None)
           redirectLocation(a.toFuture) should contain(routes.UndertakingController.getConfirmEmail().url)
         }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSupport.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.mongo.cache.CacheItem
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait EmailVerificationSupport { this: MockFactory with AuthSupport =>
+trait EmailVerificationServiceSupport { this: MockFactory with AuthSupport =>
 
 
   def mockEmailVerification(eori: EORI)(result: Either[ConnectorError, CacheItem]) =

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSupport.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
-import org.mongodb.scala.result.UpdateResult
 import org.scalamock.scalatest.MockFactory
 import play.api.mvc.{AnyContent, Call, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
@@ -30,11 +29,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait EmailVerificationServiceSupport { this: MockFactory with AuthSupport =>
 
-
-  def mockApproveVerification(eori: EORI, verificationId: String)(result: Either[ConnectorError, UpdateResult]) =
+  def mockApproveVerification(eori: EORI, verificationId: String)(result: Either[ConnectorError, Boolean]) =
     (mockEmailVerificationService
-      .approveVerificationRequest(_: EORI, _: String))
-      .expects(eori, verificationId)
+      .approveVerificationRequest(_: EORI, _: String)(_: ExecutionContext))
+      .expects(eori, verificationId, *)
       .returning(result.fold(Future.failed, _.toFuture))
 
   def mockGetEmailVerification(eori: EORI)(result: Either[ConnectorError, Option[VerifiedEmail]]) =

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationServiceSupport.scala
@@ -22,21 +22,13 @@ import play.api.mvc.{AnyContent, Call, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.AuthSupport
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, EmailVerificationResponse, VerifiedEmail}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, VerifiedEmail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.mongo.cache.CacheItem
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait EmailVerificationServiceSupport { this: MockFactory with AuthSupport =>
-
-
-  def mockEmailVerification(eori: EORI)(result: Either[ConnectorError, CacheItem]) =
-    (mockEmailVerificationService
-      .verifyEori(_: EORI))
-      .expects(eori)
-      .returning(result.fold(Future.failed, _.toFuture))
 
 
   def mockApproveVerification(eori: EORI, verificationId: String)(result: Either[ConnectorError, UpdateResult]) =
@@ -50,26 +42,6 @@ trait EmailVerificationServiceSupport { this: MockFactory with AuthSupport =>
       .getEmailVerification(_: EORI))
       .expects(eori)
       .returning(result.fold(Future.failed, _.toFuture))
-
-  def mockAddEmailVerification(eori: EORI)(result: Either[ConnectorError, String]) =
-    (mockEmailVerificationService
-      .addVerificationRequest(_: EORI, _: String)(_: ExecutionContext))
-      .expects(eori, *, *)
-      .returning(result.fold(Future.failed, _.toFuture))
-
-  // TODO - do we care about redirect locations here?
-  def mockVerifyEmail(email: String)(result: Either[ConnectorError, Option[EmailVerificationResponse]]) =
-    (mockEmailVerificationService
-      .verifyEmail(_: String, _: String)( _: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, *, *, email, *, *)
-      .returning(result.fold(Future.failed, _.toFuture))
-
-  // TODO - do we need to check the call here?
-  def mockEmailVerificationRedirect(verifyEmailResponse: Option[EmailVerificationResponse])(result: Result) =
-    (mockEmailVerificationService
-      .emailVerificationRedirect(_: Call)(_: Option[EmailVerificationResponse]))
-      .expects(*, verifyEmailResponse)
-      .returning(result)
 
   def mockAddVerifiedEmail(eori: EORI, emailAddress: String)(result: Future[Unit] = ().toFuture) =
     (mockEmailVerificationService

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationSupport.scala
@@ -18,10 +18,10 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import org.mongodb.scala.result.UpdateResult
 import org.scalamock.scalatest.MockFactory
-import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.{Call, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.AuthSupport
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, EmailVerificationResponse, VerifiedEmail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, EmailVerificationResponse, VerifiedEmail}
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.CacheItem
@@ -56,15 +56,17 @@ trait EmailVerificationSupport { this: MockFactory with AuthSupport =>
       .expects(eori, *, *)
       .returning(result.fold(Future.failed, _.toFuture))
 
+  // TODO - do we care about redirect locations here?
   def mockVerifyEmail(email: String)(result: Either[ConnectorError, Option[EmailVerificationResponse]]) =
     (mockEmailVerificationService
-      .verifyEmail(_: String, _: String, _: String)(_: HeaderCarrier, _: ExecutionContext, _: RequestHeader))
+      .verifyEmail(_: String, _: String)( _: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
       .expects(*, email, *, *, *,*)
       .returning(result.fold(Future.failed, _.toFuture))
 
+  // TODO - do we need to check the call here?
   def mockEmailVerificationRedirect(verifyEmailResponse: Option[EmailVerificationResponse])(result: Result) =
     (mockEmailVerificationService
-      .emailVerificationRedirect(_: Option[EmailVerificationResponse]))
-      .expects(verifyEmailResponse)
+      .emailVerificationRedirect(_: Call)(_: Option[EmailVerificationResponse]))
+      .expects(*, verifyEmailResponse)
       .returning(result)
 }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationSupport.scala
@@ -60,7 +60,7 @@ trait EmailVerificationSupport { this: MockFactory with AuthSupport =>
   def mockVerifyEmail(email: String)(result: Either[ConnectorError, Option[EmailVerificationResponse]]) =
     (mockEmailVerificationService
       .verifyEmail(_: String, _: String)( _: String, _: String)(_: HeaderCarrier, _: ExecutionContext))
-      .expects(*, email, *, *, *,*)
+      .expects(*, *, *, email, *, *)
       .returning(result.fold(Future.failed, _.toFuture))
 
   // TODO - do we need to check the call here?

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationSupport.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailVerificationSupport.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.services
 
 import org.mongodb.scala.result.UpdateResult
 import org.scalamock.scalatest.MockFactory
-import play.api.mvc.{Call, Result}
+import play.api.mvc.{AnyContent, Call, Result}
+import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.AuthSupport
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{ConnectorError, EmailVerificationResponse, VerifiedEmail}
@@ -68,5 +69,21 @@ trait EmailVerificationSupport { this: MockFactory with AuthSupport =>
     (mockEmailVerificationService
       .emailVerificationRedirect(_: Call)(_: Option[EmailVerificationResponse]))
       .expects(*, verifyEmailResponse)
+      .returning(result)
+
+  def mockAddVerifiedEmail(eori: EORI, emailAddress: String)(result: Future[Unit] = ().toFuture) =
+    (mockEmailVerificationService
+      .addVerifiedEmail(_: EORI, _: String)(_: ExecutionContext))
+      .expects(eori, emailAddress, *)
+      .returning(result)
+
+  def mockMakeVerificationRequestAndRedirect(result: Future[Result]) =
+    (mockEmailVerificationService
+      .makeVerificationRequestAndRedirect(
+        _: String,
+        _: Call,
+        _: String => String
+      )(_: AuthenticatedEnrolledRequest[AnyContent], _: ExecutionContext, _: HeaderCarrier))
+      .expects(*, *, *, *, *, *)
       .returning(result)
 }


### PR DESCRIPTION
Summary of changes
* introduced email verification flow to business entity become lead journey
* factored out email verification code so it can be shared by the undertaking and business entity controllers
* some refactoring including simplification of auth test code 

Note - this work temporarily removes the support for absolute URLs on local environments (a TD ticket has been raised to address this later)