### PR TITLE
ESC-821 exclude removed payments when generating summary data

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/models/FinancialDashboardSummary.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/models/FinancialDashboardSummary.scala
@@ -103,7 +103,9 @@ object FinancialDashboardSummary {
     )
 
     val nonHmrcSubsidiesByTaxYearStart: Map[LocalDate, SubsidyAmount] = sumByTaxYear(
-      subsidies.nonHMRCSubsidyUsage
+      subsidies
+        .nonHMRCSubsidyUsage
+        .filterNot(_.isRemoved)
         .map(i => i.allocationDate.toTaxYearStart -> i.nonHMRCSubsidyAmtEUR)
     )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProviderSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.DateFormValues
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.util.FakeTimeProvider
 
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 class ClaimDateFormProviderSpec extends AnyWordSpecLike with Matchers {
 


### PR DESCRIPTION
Summary of changes
* filter removed subsidy payments from the data when generating the data for the summary page
* updated tests to cover this case
* fixed an unused import warning in one of the tests