### PR TITLE
ESC-755 revise email validation adding further error cases

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadController.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 import play.api.mvc._
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.formWithSingleMandatoryField
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.BecomeLeadJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BusinessEntityController.scala
@@ -23,6 +23,7 @@ import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.{formWithSingleMandatoryField, mandatory}
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.BusinessEntityJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessEntityRemovedSelf
@@ -61,7 +62,7 @@ class BusinessEntityController @Inject() (
   val executionContext: ExecutionContext
 ) extends BaseController(mcc)
     with LeadOnlyUndertakingSupport
-    with FormHelpers {
+    with ControllerFormHelpers {
 
   import actionBuilders._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerFormHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/ControllerFormHelpers.scala
@@ -17,20 +17,16 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.data.OptionT
-import play.api.data.{Form, Mapping}
 import play.api.libs.json.Reads
 import play.api.mvc.Result
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
-import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
-import play.api.data.Forms.{mapping, text}
-import play.api.data.validation.{Constraint, Invalid, Valid}
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
 import uk.gov.hmrc.eusubsidycompliancefrontend.persistence.Store
+import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.OptionTSyntax._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
-trait FormHelpers {
+trait ControllerFormHelpers {
 
   protected val store: Store
   protected implicit val executionContext: ExecutionContext
@@ -40,16 +36,5 @@ trait FormHelpers {
       .flatMap(f)
       .getOrElse(throw new IllegalStateException("Missing journey data - unable to process form submission"))
 
-  protected def mandatory(key: String): Mapping[String] =
-    text.transform[String](_.trim, s => s).verifying(required(key))
-
-  private def required(key: String): Constraint[String] = Constraint {
-    case "" => Invalid(s"error.$key.required")
-    case _ => Valid
-  }
-
-  protected def formWithSingleMandatoryField(fieldName: String): Form[FormValues] = Form(
-    mapping(fieldName -> mandatory(fieldName))(FormValues.apply)(FormValues.unapply)
-  )
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
@@ -20,6 +20,7 @@ import play.api.mvc._
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.formWithSingleMandatoryField
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.EligibilityJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
@@ -51,7 +52,7 @@ class EligibilityController @Inject() (
   val appConfig: AppConfig,
   override val executionContext: ExecutionContext
 ) extends BaseController(mcc)
-    with FormHelpers {
+    with ControllerFormHelpers {
 
   import actionBuilders._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoBusinessPresentController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.BusinessEntityJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.eusubsidycompliancefrontend.persistence.Store
-import uk.gov.hmrc.eusubsidycompliancefrontend.services.{EscService}
+import uk.gov.hmrc.eusubsidycompliancefrontend.services.EscService
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.FutureSyntax.FutureOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.views.html._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationController.scala
@@ -22,6 +22,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.formWithSingleMandatoryField
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.NilReturnJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.NonCustomsSubsidyNilReturn
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
@@ -50,7 +51,7 @@ class NoClaimNotificationController @Inject() (
                                                 noClaimConfirmationPage: NoClaimConfirmationPage,
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc)
-    with FormHelpers
+    with ControllerFormHelpers
     with LeadOnlyUndertakingSupport {
   import actionBuilders._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadController.scala
@@ -21,6 +21,7 @@ import play.api.data.Form
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.formWithSingleMandatoryField
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.{BusinessEntityJourney, NewLeadJourney}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent.BusinessEntityPromoted
@@ -49,7 +50,7 @@ class SelectNewLeadController @Inject() (
                                           emailNotVerifiedForLeadPromotionPage: EmailNotVerifiedForLeadPromotionPage
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc)
-    with FormHelpers
+    with ControllerFormHelpers
     with LeadOnlyUndertakingSupport {
 
   import actionBuilders._

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.toSubsidyUpdate
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.{formWithSingleMandatoryField, mandatory}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.{ClaimAmountFormProvider, ClaimDateFormProvider, ClaimEoriFormProvider}
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.{Journey, SubsidyJourney}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.CurrencyCode.{EUR, GBP}
@@ -70,7 +71,7 @@ class SubsidyController @Inject() (
 )(implicit val appConfig: AppConfig, val executionContext: ExecutionContext)
     extends BaseController(mcc)
     with LeadOnlyUndertakingSupport
-    with FormHelpers {
+    with ControllerFormHelpers {
 
   import actionBuilders._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingController.scala
@@ -24,6 +24,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.{formWithSingleMandatoryField, mandatory}
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.UndertakingJourney
 import uk.gov.hmrc.eusubsidycompliancefrontend.models._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.audit.AuditEvent
@@ -71,7 +72,7 @@ class UndertakingController @Inject() (
 ) extends BaseController(mcc)
     with LeadOnlyUndertakingSupport
     with EmailVerificationSupport
-    with FormHelpers {
+    with ControllerFormHelpers {
 
   import actionBuilders._
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimAmountFormProvider.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
 import play.api.data.Forms.text
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult}
-import play.api.data.{Form, Forms, Mapping}
+import play.api.data.{Forms, Mapping}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Errors.{TooBig, TooSmall}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.Fields
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormProvider.CommonErrors.IncorrectFormat
@@ -41,8 +41,6 @@ case class ClaimAmountFormProvider() extends FormProvider[ClaimAmount] {
   )(ClaimAmount.fromForm)(ClaimAmount.toForm)
     .verifying(claimAmountCurrencyMatchesSelection)
     .transform(c => c.copy(amount = cleanAmount(c.amount)), identity[ClaimAmount])
-
-  override def form: Form[ClaimAmount] = Form(mapping)
 
   private def claimAmountMapping: Mapping[String] =
     text

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimDateFormProvider.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
 import play.api.data.Forms.{text, tuple}
+import play.api.data.Mapping
 import play.api.data.validation._
-import play.api.data.{Form, Mapping}
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimDateFormProvider.Errors._
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimDateFormProvider.Fields._
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormProvider.CommonErrors._
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.DateFormValues
 import uk.gov.hmrc.eusubsidycompliancefrontend.syntax.TaxYearSyntax.LocalDateTaxYearOps
 import uk.gov.hmrc.eusubsidycompliancefrontend.util.TimeProvider
-import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimDateFormProvider.Fields._
-import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimDateFormProvider.Errors._
-import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormProvider.CommonErrors._
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZoneId}
@@ -33,8 +33,6 @@ import scala.util.Try
 case class ClaimDateFormProvider(timeProvider: TimeProvider) extends FormProvider[DateFormValues] {
 
   private type RawFormValues = (String, String, String)
-
-  override val form: Form[DateFormValues] = Form(mapping)
 
   private val dateFormatter = DateTimeFormatter.ofPattern("d M yyyy")
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProvider.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 
 import play.api.data.Forms.text
 import play.api.data.validation.{Constraint, Invalid, Valid}
-import play.api.data.{Form, Forms, Mapping}
+import play.api.data.{Forms, Mapping}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimEoriFormProvider.Fields._
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimEoriFormProvider.{fromOptionalClaimEori, toOptionalClaimEori}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormProvider.CommonErrors._
@@ -28,8 +28,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.models.{OptionalClaimEori, Undert
 import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfEqual
 
 case class ClaimEoriFormProvider(undertaking: Undertaking) extends FormProvider[OptionalClaimEori] {
-
-  override def form: Form[OptionalClaimEori] = Form(mapping)
 
   override protected def mapping: Mapping[OptionalClaimEori] = Forms.mapping(
     YesNoRadioButton -> text,

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
@@ -47,7 +47,7 @@ case class OptionalEmailFormProvider() extends FormProvider[OptionalEmailFormInp
 
 object EmailFormProvider {
 
-  private val MaximumEmailLength = 254
+  val MaximumEmailLength = 254
 
   val EmailAddressFieldMapping: Mapping[String] =
     nonEmptyText(maxLength = MaximumEmailLength)
@@ -59,8 +59,8 @@ object EmailFormProvider {
   }
 
   object Errors {
-    val TooLong = "error.tooLong"
-    val InvalidFormat = "error.invalidFormat"
+    val MaxLength = "error.maxLength"
+    val InvalidFormat = "error.email"
   }
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.forms
+import play.api.data.Forms.nonEmptyText
+import play.api.data.validation.Constraints
+import play.api.data.{Form, Forms, Mapping}
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.EmailFormProvider.{EmailAddressFieldMapping, Fields}
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.mandatory
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, OptionalEmailFormInput}
+import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfEqual
+
+case class EmailFormProvider() extends FormProvider[FormValues] {
+
+  override protected def mapping: Mapping[FormValues] = Forms.mapping(
+      Fields.Email -> EmailAddressFieldMapping
+    )(FormValues.apply)(FormValues.unapply)
+
+  // TODO - can we generalise this using the type param so it only needs to be implemented once?
+  override def form: Form[FormValues] = Form(mapping)
+
+}
+
+case class OptionalEmailFormProvider() extends FormProvider[OptionalEmailFormInput] {
+
+  override protected def mapping: Mapping[OptionalEmailFormInput] = Forms.mapping(
+    Fields.UsingStoredEmail -> mandatory(Fields.UsingStoredEmail),
+    Fields.Email -> mandatoryIfEqual(Fields.UsingStoredEmail, "false", EmailAddressFieldMapping)
+  )(OptionalEmailFormInput.apply)(OptionalEmailFormInput.unapply)
+
+  override def form: Form[OptionalEmailFormInput] = Form(mapping)
+
+}
+
+object EmailFormProvider {
+
+  private val MaximumEmailLength = 254
+
+  val EmailAddressFieldMapping: Mapping[String] =
+    nonEmptyText(maxLength = MaximumEmailLength)
+      .verifying(Constraints.emailAddress)
+
+  object Fields {
+    val Email = "email"
+    val UsingStoredEmail = "using-stored-email"
+  }
+
+  object Errors {
+    val TooLong = "error.tooLong"
+    val InvalidFormat = "error.invalidFormat"
+  }
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
@@ -47,6 +47,8 @@ case class OptionalEmailFormProvider() extends FormProvider[OptionalEmailFormInp
 
 object EmailFormProvider {
 
+  // Per RFC 3696 - Restrictions on Email addresses
+  // see https://www.rfc-editor.org/errata/eid1690
   val MaximumEmailLength = 254
 
   val EmailAddressFieldMapping: Mapping[String] =

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProvider.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.eusubsidycompliancefrontend.forms
 import play.api.data.Forms.nonEmptyText
 import play.api.data.validation.Constraints
-import play.api.data.{Form, Forms, Mapping}
+import play.api.data.{Forms, Mapping}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.EmailFormProvider.{EmailAddressFieldMapping, Fields}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.mandatory
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, OptionalEmailFormInput}
@@ -29,9 +29,6 @@ case class EmailFormProvider() extends FormProvider[FormValues] {
       Fields.Email -> EmailAddressFieldMapping
     )(FormValues.apply)(FormValues.unapply)
 
-  // TODO - can we generalise this using the type param so it only needs to be implemented once?
-  override def form: Form[FormValues] = Form(mapping)
-
 }
 
 case class OptionalEmailFormProvider() extends FormProvider[OptionalEmailFormInput] {
@@ -40,8 +37,6 @@ case class OptionalEmailFormProvider() extends FormProvider[OptionalEmailFormInp
     Fields.UsingStoredEmail -> mandatory(Fields.UsingStoredEmail),
     Fields.Email -> mandatoryIfEqual(Fields.UsingStoredEmail, "false", EmailAddressFieldMapping)
   )(OptionalEmailFormInput.apply)(OptionalEmailFormInput.unapply)
-
-  override def form: Form[OptionalEmailFormInput] = Form(mapping)
 
 }
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormHelpers.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.forms
+
+import play.api.data.Forms.{mapping, text}
+import play.api.data.{Form, Mapping}
+import play.api.data.validation.{Constraint, Invalid, Valid}
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
+
+object FormHelpers {
+
+  def mandatory(key: String): Mapping[String] =
+    text.transform[String](_.trim, s => s).verifying(required(key))
+
+  private def required(key: String): Constraint[String] = Constraint {
+    case "" => Invalid(s"error.$key.required")
+    case _ => Valid
+  }
+
+  def formWithSingleMandatoryField(fieldName: String): Form[FormValues] = Form(
+    mapping(fieldName -> mandatory(fieldName))(FormValues.apply)(FormValues.unapply)
+  )
+
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/forms/FormProvider.scala
@@ -20,7 +20,7 @@ import play.api.data.{Form, Mapping}
 
 trait FormProvider[T] {
   protected def mapping: Mapping[T]
-  def form: Form[T]
+  def form: Form[T] = Form(mapping)
 }
 
 object FormProvider {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmEmailPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmEmailPage.scala.html
@@ -69,10 +69,10 @@
       @if(form.hasErrors) {
           @govukErrorSummary(
               ErrorSummary(
-                  errorList = form.errors.map { err =>
+                  errorList = form.errors.take(1).map { err =>
                       ErrorLink(
                           href = Some(s"#${err.key}"),
-                          content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}"),
+                          content = Text(s"${messages(s"${err.key}.${err.message}")}"),
                           attributes = Map("class" ->"govuk-link")
                       )
                   },

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/InputEmailPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/InputEmailPage.scala.html
@@ -42,15 +42,14 @@
     hasErrors = form.hasErrors
 ) {
 
-
     @formHelper(action = controllers.routes.UndertakingController.postConfirmEmail()) {
       @if(form.hasErrors) {
           @govukErrorSummary(
               ErrorSummary(
-                  errorList = form.errors.map { err =>
+                  errorList = form.errors.take(1).map { err =>
                       ErrorLink(
                           href = Some(s"#${err.key}"),
-                          content = Text(s"${messages(s"${form.errors.head.key}.${form.errors.head.message}")}"),
+                          content = Text(s"${messages(s"${err.key}.${err.message}")}"),
                           attributes = Map("class" ->"govuk-link")
                       )
                   },

--- a/conf/messages
+++ b/conf/messages
@@ -156,7 +156,9 @@ inputEmail.title=What is your email address?
 inputEmail.label=Enter an email address
 inputEmail.p=This email address will be used to send you notifications from this service.
 
-email.error.email = Enter your email address
+email.error.required = Enter your email address
+email.error.email = Enter a valid email address
+email.error.maxLength = The email address for your undertaking must be 254 characters or less
 using-stored-email.error.required = Select yes if this is the email address you want to use for your undertaking
 
 undertaking.cya.title=Check your answers

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/ClaimEoriFormProviderSpec.scala
@@ -65,8 +65,9 @@ class ClaimEoriFormProviderSpec extends AnyWordSpecLike with Matchers {
   )(errorField: String, errorMessage: String, args: String*) = {
     val result = processForm(radioButton, eoriNumber)
 
+
     val foundExpectedErrorMessage = result.leftSideValue match {
-      case Left(errors) => errors.contains(FormError(errorField, s"$errorMessage", args))
+      case Left(errors) => errors.contains(FormError(errorField, errorMessage, args))
       case _ => false
     }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProviderSpec.scala
@@ -1,0 +1,110 @@
+package uk.gov.hmrc.eusubsidycompliancefrontend.forms
+
+import org.scalatest.AppendedClues.convertToClueful
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.data.FormError
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.EmailFormProvider.Errors.{InvalidFormat, MaxLength}
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.EmailFormProvider.Fields.Email
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.EmailFormProvider.MaximumEmailLength
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormProvider.CommonErrors.Required
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.FormValues
+
+class EmailFormProviderSpec extends AnyWordSpecLike with Matchers {
+
+  private val emailFormProvider = EmailFormProvider()
+  private val optionalEmailFormProvider = OptionalEmailFormProvider()
+
+  "EmailFormProvider" when {
+
+    "validating an EmailForm" must {
+
+      val testSuccess = validateAndCheckSuccess(emailFormProvider) _
+      val testError = validateAndCheckError(emailFormProvider) _
+
+      "return no errors for a valid email address" in {
+        testSuccess("someone@example.com")
+      }
+
+      "return no errors for a valid email address that meets the maximum allowed length" in {
+        val domain = "@example.com"
+        val user = (1 to (MaximumEmailLength - domain.length)).map(_ => "l").mkString("")
+
+        testError(s"$user$domain")
+      }
+
+      "return an error if no email is entered" in {
+        testError("")(Email, Required)
+      }
+
+      "return an error for an invalid email address" in {
+        testError("this is not a valid email address")(Email, InvalidFormat)
+      }
+
+      "return an error if the email address is too long" in {
+        val domain = "@example.com"
+        val user = (1 to 500).map(_ => "l").mkString("")
+        val email = s"$user$domain"
+
+        testError(email)(Email, MaxLength)
+      }
+
+    }
+
+    "validating an OptionalEmailForm" must {
+
+      val testSuccess = validateAndCheckSuccess(optionalEmailFormProvider) _
+      val testError = validateAndCheckError(optionalEmailFormProvider) _
+
+      "return no errors for a valid email address" in {
+        testSuccess("someone@example.com")
+      }
+
+      "return no errors for a valid email address that meets the maximum allowed length" in {
+        val domain = "@example.com"
+        val user = (1 to (MaximumEmailLength - domain.length)).map(_ => "l").mkString("")
+
+        testError(s"$user$domain")
+      }
+
+      "return an error if no email is entered" in {
+        testError("")(Email, Required)
+      }
+
+      "return an error for an invalid email address" in {
+        testError("this is not a valid email address")(Email, InvalidFormat)
+      }
+
+      "return an error if the email address is too long" in {
+        val domain = "@example.com"
+        val user = (1 to 500).map(_ => "l").mkString("")
+        val email = s"$user$domain"
+
+        testError(email)(Email, MaxLength)
+      }
+
+    }
+
+  }
+
+  private def validateAndCheckSuccess[A](provider: FormProvider[A])(emailAddress: String) = {
+    val result = processForm[A](provider)(Map(Email -> emailAddress))
+    result mustBe Right(FormValues(emailAddress))
+  }
+
+  private def validateAndCheckError[A](provider: FormProvider[A])(emailAddress: String)(errorField: String, errorMessage: String) = {
+    val result = processForm[A](provider)(Map(Email -> emailAddress))
+
+    val foundExpectedErrorMessage = result.leftSideValue match {
+      case Left(errors) => errors.map(_.message).contains(errorMessage)
+      case _ => false
+    }
+
+    foundExpectedErrorMessage mustBe true withClue
+      s"got result $result which did not contain expected error $errorMessage for field $errorField"
+  }
+
+  private def processForm[A](provider: FormProvider[A])(data: Map[String, String]): Either[Seq[FormError], A] =
+    provider.form.mapping.bind(data)
+
+}

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/forms/EmailFormProviderSpec.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.eusubsidycompliancefrontend.forms.EmailFormProvider.MaximumEm
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormProvider.CommonErrors.Required
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.{FormValues, OptionalEmailFormInput}
 
-// TODO - review this - may be scope for a refactor here
 class EmailFormProviderSpec extends AnyWordSpecLike with Matchers {
 
   "EmailFormProvider" when {


### PR DESCRIPTION
Summary of changes
* email validation revised to include error messages for the following cases
  * email not entered
  * email too long
  * email not in valid format
* factored out the email forms into separate form providers with dedicated tests
* simplified form providers by providing a common form method in the trait
* added messages
* other minor refactoring