### PR TITLE
ESC-825 ensure the saved EligiblityJourney state is valid to prevent redirect loops

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityController.scala
@@ -130,8 +130,10 @@ class EligibilityController @Inject() (
     implicit val eori: EORI = request.eoriNumber
 
     def renderPage = {
-      // At this stage we have an enrolment so the user must be eligible to use the service.
+      // At this stage, we have an enrolment, so the user must be eligible to use the service. Thus we can provide
+      // defaults for the first two eligibility questions to reflect this.
       val eligibilityJourney = EligibilityJourney()
+        .withDoYouClaim(false)
         .withWillYouClaim(true)
 
       store.getOrCreate[EligibilityJourney](eligibilityJourney).map { journey =>


### PR DESCRIPTION
Summary of changes
* A new user hitting the service for the first time arrives at the eori check page once they're enrolled. This creates some default state which was invalid, causing a redirect loop.
* This has been fixed by providing answers for both kickout pages, thus allowing the 'get first empty' logic to return the next page in the sequence correcty should the user navigate away from the eori check page without submitting it