### PR TITLE
ESC-828 ensure repeated form submission cannot create a duplicate removed entry

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -501,8 +501,7 @@ class SubsidyController @Inject() (
     retrieveSubsidies(reference, timeProvider.today)
       .recoverWith({ case _ => Option.empty[UndertakingSubsidies].toFuture })
       .toContext
-      .flatMap(_.nonHMRCSubsidyUsage.find(_.subsidyUsageTransactionId.contains(transactionId)).toContext)
-
+      .flatMap(_.findNonHmrcSubsidy(transactionId).toContext)
 
   private def handleRemoveSubsidyFormError(
     formWithErrors: Form[FormValues],

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingSubsidies.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingSubsidies.scala
@@ -40,13 +40,21 @@ case class UndertakingSubsidies(
         .map(_.submissionDate)
 
   // For display use cases that require the payments to be ordered by reverse allocation date
-  def forReportedPaymentsPage =
+  def forReportedPaymentsPage: UndertakingSubsidies =
     this.copy(
       nonHMRCSubsidyUsage =
         nonHMRCSubsidyUsage
           .sorted(NonHmrcSubsidy.SortOrder.byAllocationDate)
           .reverse
     )
+
+  // Finds a matching subsidy for a given transactionID, but only where that subsidy has not been removed.
+  def findNonHmrcSubsidy(transactionId: String): Option[NonHmrcSubsidy] =
+    nonHMRCSubsidyUsage
+      .find { subsidy =>
+        subsidy.subsidyUsageTransactionId.contains(transactionId) &&
+          !subsidy.isRemoved
+      }
 
 }
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingSubsidiesSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/models/UndertakingSubsidiesSpec.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models
 
+import cats.implicits.catsSyntaxOptionId
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.SubsidyRef
 import uk.gov.hmrc.eusubsidycompliancefrontend.test.CommonTestData.{fixedDate, nonHmrcSubsidy, undertakingSubsidies}
 
 class UndertakingSubsidiesSpec extends AnyWordSpec with Matchers {
@@ -77,6 +79,33 @@ class UndertakingSubsidiesSpec extends AnyWordSpec with Matchers {
 
         underTest.forReportedPaymentsPage.nonHMRCSubsidyUsage shouldBe List(subsidy3, subsidy2, subsidy1)
       }
+    }
+
+    "findNonHmrcSubsidy" must {
+
+      val subsidy1 = nonHmrcSubsidy.copy(subsidyUsageTransactionId = SubsidyRef("12").some)
+      val subsidy2 = nonHmrcSubsidy.copy(subsidyUsageTransactionId = SubsidyRef("34").some)
+      val subsidy3 = nonHmrcSubsidy.copy(subsidyUsageTransactionId = SubsidyRef("56").some, removed = true.some)
+
+      val underTest = undertakingSubsidies.copy(nonHMRCSubsidyUsage = List(
+        subsidy1,
+        subsidy2,
+        subsidy3
+      ))
+
+
+      "return None if no subsidy matching given transaction ID is found" in {
+        underTest.findNonHmrcSubsidy("This ID does not exist") shouldBe None
+      }
+
+      "return the subsidy matching the given transaction ID where one exists" in {
+        underTest.findNonHmrcSubsidy("12") should contain(subsidy1)
+      }
+
+      "ignore subsidies that are marked as removed" in {
+          underTest.findNonHmrcSubsidy("56") shouldBe None
+      }
+
     }
   }
 }


### PR DESCRIPTION
Summary of changes
* fixed a bug where there `isRemoved` state was not being checked when handling a remove request
* added `findNonHmrcSubsidy` method to UndertakingSubsidies which only matches on subsidies that are not removed and added tests