### PR TITLE
ESC-793 validate converted GBP amounts to ensure max value is not exceeded

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -18,13 +18,14 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.controllers
 
 import cats.data.OptionT
 import cats.implicits._
-import play.api.data.Form
+import play.api.data.{Form, FormError}
 import play.api.data.Forms.{mapping, nonEmptyText}
 import play.api.mvc._
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.ActionBuilders
 import uk.gov.hmrc.eusubsidycompliancefrontend.actions.requests.AuthenticatedEnrolledRequest
 import uk.gov.hmrc.eusubsidycompliancefrontend.config.AppConfig
 import uk.gov.hmrc.eusubsidycompliancefrontend.controllers.SubsidyController.toSubsidyUpdate
+import uk.gov.hmrc.eusubsidycompliancefrontend.forms.ClaimAmountFormProvider.{Errors, Fields}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.FormHelpers.{formWithSingleMandatoryField, mandatory}
 import uk.gov.hmrc.eusubsidycompliancefrontend.forms.{ClaimAmountFormProvider, ClaimDateFormProvider, ClaimEoriFormProvider}
 import uk.gov.hmrc.eusubsidycompliancefrontend.journeys.{Journey, SubsidyJourney}
@@ -187,11 +188,23 @@ class SubsidyController @Inject() (
           claimAmountEntered => {
             val result = for {
               // At this point we validate and yield either a redirect or a bad request
-              validatedClaimAmount <- validateClaimAmount(addClaimDate.toLocalDate, claimAmountEntered).toContext
+              _ <- validateClaimAmount(addClaimDate.toLocalDate, claimAmountEntered).toContext
               journey <- store.update[SubsidyJourney](_.setClaimAmount(claimAmountEntered)).toContext
               redirect <- journey.next.toContext
             } yield redirect
-              result.getOrElse(BadRequest(addClaimAmountPage(claimAmountForm, previous, addClaimDate.year, addClaimDate.month)))
+
+            result.getOrElse(BadRequest(
+              addClaimAmountPage(
+                // The error case here will be due to failure to convert the converted amount into a SubsidyAmount.
+                // In this instance we report this as a 'tooBig' error in the form for the user to action.
+                claimAmountForm
+                  .bindFromRequest()
+                  .withError(FormError(Fields.ClaimAmountGBP, List(Errors.TooBig))),
+                previous,
+                addClaimDate.year,
+                addClaimDate.month
+              ))
+            )
           }
         )
 

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SubsidyController.scala
@@ -187,7 +187,6 @@ class SubsidyController @Inject() (
             BadRequest(addClaimAmountPage(formWithErrors, previous, addClaimDate.year, addClaimDate.month)).toFuture,
           claimAmountEntered => {
             val result = for {
-              // At this point we validate and yield either a redirect or a bad request
               _ <- validateClaimAmount(addClaimDate.toLocalDate, claimAmountEntered).toContext
               journey <- store.update[SubsidyJourney](_.setClaimAmount(claimAmountEntered)).toContext
               redirect <- journey.next.toContext
@@ -264,8 +263,7 @@ class SubsidyController @Inject() (
       case EUR => Future.successful(None)
     }
 
-  // TODO - give this a better name
-  private def validateClaimAmount(date: LocalDate, claimAmount: ClaimAmount)(implicit hc: HeaderCarrier): Future[Option[ClaimAmount]] =
+  private def validateClaimAmount(date: LocalDate, claimAmount: ClaimAmount)(implicit hc: HeaderCarrier) =
     claimAmount.currencyCode match {
       case GBP =>
         for {

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/types/package.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/types/package.scala
@@ -21,13 +21,13 @@ import shapeless.tag.@@
 
 package object types extends SimpleJson {
 
-  val MAX_INPUT_VALUE = 999999.99
+  private val MaxInputValue = 999999.99
 
   type IndustrySectorLimit = BigDecimal @@ IndustrySectorLimit.Tag
   object IndustrySectorLimit extends ValidatedType[BigDecimal] {
     override def validateAndTransform(in: BigDecimal): Option[BigDecimal] =
       Some(in).filter { x =>
-        (x <= MAX_INPUT_VALUE) && (x.scale <= 2)
+        (x <= MaxInputValue) && (x.scale <= 2)
       }
   }
 
@@ -35,7 +35,7 @@ package object types extends SimpleJson {
   object PositiveSubsidyAmount extends ValidatedType[BigDecimal] {
     override def validateAndTransform(in: BigDecimal): Option[BigDecimal] =
       Some(in).filter { x =>
-        (x >= 0) && (x <= MAX_INPUT_VALUE) && (x.scale <= 2)
+        (x >= 0) && (x <= MaxInputValue) && (x.scale <= 2)
       }
   }
 
@@ -43,7 +43,7 @@ package object types extends SimpleJson {
   object SubsidyAmount extends ValidatedType[BigDecimal] {
     override def validateAndTransform(in: BigDecimal): Option[BigDecimal] =
       Some(in).filter { x =>
-        (x >= -MAX_INPUT_VALUE) && (x <= MAX_INPUT_VALUE) && (x.scale <= 2)
+        (x >= -MaxInputValue) && (x <= MaxInputValue) && (x.scale <= 2)
       }
     val Zero: SubsidyAmount = SubsidyAmount(BigDecimal(0))
   }


### PR DESCRIPTION
Summary of changes
* added in validation of the result of converting GBP to EUR to ensure the EUR amount does not exceed the maximum allowed value - if it does the `tooBig` form error will be shown
* added / revised tests
* other minor tidying