### PR TITLE
ESC-835 bump play versions and remove unnecessary play json extensions

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailSendResult.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailSendResult.scala
@@ -16,19 +16,16 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
 
-import ai.x.play.json.Jsonx
-import play.api.libs.json.Format
-import ai.x.play.json.SingletonEncoder.simpleName
-import ai.x.play.json.implicits.formatSingleton
+import enumeratum._
 
-sealed trait EmailSendResult extends Product with Serializable
+sealed trait EmailSendResult extends EnumEntry
 
-object EmailSendResult {
+object EmailSendResult extends Enum[EmailSendResult] {
 
   case object EmailSent extends EmailSendResult
   case object EmailSentFailure extends EmailSendResult
   case object EmailNotSent extends EmailSendResult
 
-  implicit val format: Format[EmailSendResult] = Jsonx.formatSealed[EmailSendResult]
+  override val values = findValues
 
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailType.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/EmailType.scala
@@ -16,22 +16,16 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
 
-import ai.x.play.json.Jsonx
-import ai.x.play.json.SingletonEncoder.simpleName
-import ai.x.play.json.implicits.formatSingleton
-import cats.Eq
-import play.api.libs.json.Format
+import enumeratum._
 
-sealed trait EmailType extends Product with Serializable
-object EmailType {
+sealed trait EmailType extends EnumEntry
+
+object EmailType extends Enum[EmailType] {
 
   case object VerifiedEmail extends EmailType
-
   case object UnDeliverableEmail extends EmailType
-
   case object UnVerifiedEmail extends EmailType
 
-  implicit val eq: Eq[EmailType] = Eq.fromUniversalEquals
+  override val values = findValues
 
-  implicit val format: Format[EmailType] = Jsonx.formatSealed[EmailType]
 }

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/RetrieveEmailResponse.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/RetrieveEmailResponse.scala
@@ -16,11 +16,6 @@
 
 package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
 
-import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.EmailAddress
 
 case class RetrieveEmailResponse(emailType: EmailType, emailAddress: Option[EmailAddress])
-
-object RetrieveEmailResponse {
-  implicit val format: OFormat[RetrieveEmailResponse] = Json.format
-}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,7 +14,6 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.14.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % hmrcMongoVersion,
     "org.typelevel"     %% "cats-core"                     % "2.7.0",
-    "ai.x"              %% "play-json-extensions"          % "0.42.0",
     "com.chuusai"       %% "shapeless"                     % "2.3.9",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.11.0-play-28",
     "com.beachape"      %% "enumeratum"                    % enumeratumVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,17 +5,17 @@ import sbt._
 
 object AppDependencies {
 
-  val bootStrapVersion = "5.23.0"
-  val hmrcMongoVersion = "0.68.0"
+  val bootStrapVersion = "7.11.0"
+  val hmrcMongoVersion = "0.74.0"
   val enumeratumVersion = "1.7.0"
 
   val compile = Seq(
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % bootStrapVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.14.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.33.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % hmrcMongoVersion,
     "org.typelevel"     %% "cats-core"                     % "2.7.0",
     "com.chuusai"       %% "shapeless"                     % "2.3.9",
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.11.0-play-28",
+    "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.12.0-play-28",
     "com.beachape"      %% "enumeratum"                    % enumeratumVersion,
     "com.beachape"      %% "enumeratum-play-json"          % enumeratumVersion
   )

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/BecomeLeadControllerSpec.scala
@@ -152,7 +152,7 @@ class BecomeLeadControllerSpec
     "handling request to post Become Lead Eori" must {
 
       def performAction(data: (String, String)*) = controller
-        .postBecomeLeadEori(FakeRequest().withFormUrlEncodedBody(data: _*))
+        .postBecomeLeadEori(FakeRequest(POST, "/").withFormUrlEncodedBody(data: _*))
 
       "throw technical error" when {
 
@@ -394,7 +394,7 @@ class BecomeLeadControllerSpec
     val verificationUrl = routes.BecomeLeadController.getVerifyEmail("SomeId").url
 
     def performAction(data: (String, String)*) =
-      controller.postConfirmEmail(FakeRequest().withFormUrlEncodedBody(data: _*))
+      controller.postConfirmEmail(FakeRequest(POST, "/").withFormUrlEncodedBody(data: _*))
 
     "redirect to the correct page" when {
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/EligibilityControllerSpec.scala
@@ -99,7 +99,7 @@ class EligibilityControllerSpec
 
     "handling request to get do you claim" must {
 
-      def performAction() = controller.getDoYouClaim(FakeRequest())
+      def performAction() = controller.getDoYouClaim(FakeRequest(POST, "/"))
 
       "display the page" in {
 
@@ -133,7 +133,7 @@ class EligibilityControllerSpec
     "handling request to post do you claim" must {
       def performAction(data: (String, String)*) = controller
         .postDoYouClaim(
-          FakeRequest(GET, routes.EligibilityController.getDoYouClaim().url)
+          FakeRequest(POST, routes.EligibilityController.getDoYouClaim().url)
             .withFormUrlEncodedBody(data: _*)
             .withHeaders("Referer" -> routes.EligibilityController.getDoYouClaim().url)
         )
@@ -212,7 +212,7 @@ class EligibilityControllerSpec
 
       def performAction(data: (String, String)*) = controller
         .postWillYouClaim(
-          FakeRequest(GET, routes.EligibilityController.getWillYouClaim().url)
+          FakeRequest(POST, routes.EligibilityController.getWillYouClaim().url)
             .withFormUrlEncodedBody(data: _*)
         )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/NoClaimNotificationControllerSpec.scala
@@ -129,7 +129,7 @@ class NoClaimNotificationControllerSpec
 
       def performAction(data: (String, String)*) = controller
         .postNoClaimNotification(
-          FakeRequest()
+          FakeRequest(POST, "/")
             .withFormUrlEncodedBody(data: _*)
         )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/SelectNewLeadControllerSpec.scala
@@ -135,7 +135,7 @@ class SelectNewLeadControllerSpec
 
       def performAction(data: (String, String)*) = controller
         .postSelectNewLead(
-          FakeRequest()
+          FakeRequest(POST, "/")
             .withFormUrlEncodedBody(data: _*)
         )
 

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -1172,7 +1172,7 @@ class UndertakingControllerSpec
     "handling request to Post Confirmation page" must {
 
       def performAction(data: (String, String)*) =
-        controller.postConfirmation(FakeRequest().withFormUrlEncodedBody(data: _*))
+        controller.postConfirmation(FakeRequest(POST, "/").withFormUrlEncodedBody(data: _*))
       def update(u: UndertakingJourney) = u.copy(confirmation = UndertakingConfirmationFormPage(value = true.some))
 
       val undertakingJourney =


### PR DESCRIPTION
Summary of changes
* removed `ai.x.play-json-extensions` since it's not needed (we don't serialise the email enums)
* redefined the email enums using `enumeratum` for consistency
* bumped the hmrc play library versions to pull in the latest play version
* updated tests to set the correct request method now this is being validated