### PR TITLE
ESC-850 - remove duplicate 90 logic from account controller

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountController.scala
@@ -55,8 +55,6 @@ class AccountController @Inject() (
 
   import actionBuilders._
 
-  private val dueDays = 90
-
   def getAccountPage: Action[AnyContent] =
     enrolled.async { implicit request =>
       implicit val eori: EORI = request.eoriNumber
@@ -100,18 +98,12 @@ class AccountController @Inject() (
   private def renderAccountPage(undertaking: Undertaking, undertakingSubsidies: UndertakingSubsidies)(implicit r: AuthenticatedEnrolledRequest[AnyContent]) = {
     implicit val eori: EORI = r.eoriNumber
 
-    val currentDay = timeProvider.today
-
-    val lastSubmitted = undertakingSubsidies.lastSubmitted.orElse(undertaking.lastSubsidyUsageUpdt)
-
-    val isTimeToReport = ReportReminderHelpers.isTimeToReport(lastSubmitted, currentDay)
-    val dueDate = ReportReminderHelpers.dueDateToReport(lastSubmitted)
-      .getOrElse(currentDay.plusDays(dueDays))
-      .toDisplayFormat
-    val isOverdue = ReportReminderHelpers.isOverdue(lastSubmitted, currentDay)
-
     val today = timeProvider.today
 
+    val lastSubmitted = undertakingSubsidies.lastSubmitted.orElse(undertaking.lastSubsidyUsageUpdt)
+    val isTimeToReport = ReportReminderHelpers.isTimeToReport(lastSubmitted, today)
+    val dueDate = ReportReminderHelpers.dueDateToReport(lastSubmitted.getOrElse(today)).toDisplayFormat
+    val isOverdue = ReportReminderHelpers.isOverdue(lastSubmitted, today)
     val startDate = today.toEarliestTaxYearStart
 
     val summary = FinancialDashboardSummary.fromUndertakingSubsidies(

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/ReportReminderHelpers.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/util/ReportReminderHelpers.scala
@@ -27,7 +27,7 @@ object ReportReminderHelpers {
   def isTimeToReport(od: Option[LocalDate], currentDate: LocalDate): Boolean =
     od.exists { lastUpdated =>
       lastUpdated.plusDays(OneDayBeforeRemdinderDay).isBefore(currentDate) &&
-      lastUpdated.plusDays(OneDayAfterDueDay).isAfter(currentDate)
+        lastUpdated.plusDays(OneDayAfterDueDay).isAfter(currentDate)
     }
 
   def dueDateToReport(od: Option[LocalDate]): Option[LocalDate] = od.map(dueDateToReport)

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/AccountControllerSpec.scala
@@ -85,7 +85,6 @@ class AccountControllerSpec
             mockGetOrCreate[UndertakingJourney](eori1)(Right(UndertakingJourney()))
             mockRetrieveAllSubsidies(undertakingRef)(undertakingSubsidies.toFuture)
             mockTimeProviderToday(fixedDate)
-            mockTimeProviderToday(fixedDate)
             mockGetOrCreate(eori1)(Right(nilJourneyCreate))
           }
           checkPageIsDisplayed(
@@ -138,7 +137,6 @@ class AccountControllerSpec
 
             mockRetrieveAllSubsidies(undertakingRef)(undertakingSubsidies.copy(nonHMRCSubsidyUsage = subsidies).toFuture)
 
-            mockTimeProviderToday(currentDate)
             mockTimeProviderToday(currentDate)
             mockGetOrCreate[NilReturnJourney](eori1)(Right(nilJourneyCreate))
           }
@@ -212,7 +210,6 @@ class AccountControllerSpec
               mockGetOrCreate[EligibilityJourney](eori4)(Right(eligibilityJourneyComplete))
               mockGetOrCreate[UndertakingJourney](eori4)(Right(UndertakingJourney()))
               mockRetrieveAllSubsidies(undertakingRef)(undertakingSubsidies.toFuture)
-              mockTimeProviderToday(fixedDate)
               mockTimeProviderToday(fixedDate)
             }
 


### PR DESCRIPTION
Clean up the account controller so we don't duplicate the 90 day logic. Also simplified the code and the tests, removing a redundant time provider call, and simplifying the booleans used in some of the test methods. 