### PR TITLE
DDCYLS-4779 Add exit survey to confirmation page

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmationPage.scala.html
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmationPage.scala.html
@@ -53,4 +53,13 @@
 
         @button("common.go-undertaking-home")
     }
+
+    <div id="exit-survey" class="govuk-!-margin-bottom-8">
+        <h2 class="govuk-heading-m">@messages("exitSurvey.heading")</h2>
+        <p class="govuk-body">@messages("exitSurvey.p1")</p>
+        <p class="govuk-body">
+            <a class="govuk-link" href="@appConfig.exitSurveyUrl">@messages("exitSurvey.link")</a>
+            @messages("exitSurvey.p2")
+        </p>
+    </div>
 }

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -7,8 +7,18 @@
         </encoder>
     </appender>
 
-    <!-- DO NOT suppress log output to stdout during test runs as it makes CI much less interesting when things fail. Tests
-     are about failure not success as they should point to how to fix things. Good luck fixing indeterminate failures without this on-->
+    <logger name="org.apache.pekko.event.slf4j.Slf4jLogger" level="WARN"/>
+    <logger name="play.api.http.HttpErrorHandlerExceptions" level="WARN"/>
+    <logger name="uk.gov.hmrc.eusubsidycompliancefrontend.persistence" level="WARN"/>
+
+    <logger name="org.mongodb.driver.client" level="ERROR"/>
+    <logger name="org.mongodb.driver.cluster" level="ERROR"/>
+    <logger name="uk.gov.hmrc.mongo.play.PlayMongoComponent" level="ERROR"/>
+
+    <logger name="uk.gov.hmrc.play.bootstrap.audit.DisabledDatastreamMetricsProvider" level="OFF"/>
+    <logger name="uk.gov.hmrc.play.bootstrap.graphite.DisabledGraphiteReporting" level="OFF"/>
+    <logger name="uk.gov.hmrc.play.bootstrap.filters.CacheControlFilter" level="OFF"/>
+    <logger name="org.apache.pekko.actor.CoordinatedShutdown" level="OFF"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/conf/messages
+++ b/conf/messages
@@ -637,3 +637,8 @@ accessDeniedForAgents.p1=You will not be able to use this service because you’
 accessDeniedForAgents.p2=If your client needs to register an undertaking to report non-customs subsidy payments or no payments, they must do it themselves using their own Government Gateway account.
 accessDeniedForAgents.p3=If they do not have a Government Gateway user ID, they can create one when they start to register.
 accessDeniedForAgents.linkText=Find out more about using this service
+
+exitSurvey.heading = Before you go
+exitSurvey.p1 = Your feedback helps us make our service better.
+exitSurvey.link = Take a short survey
+exitSurvey.p2 = to share your feedback on this service.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,9 +5,9 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 resolvers += Resolver.typesafeRepo("releases")
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/controllers/UndertakingControllerSpec.scala
@@ -1340,17 +1340,7 @@ class UndertakingControllerSpec
 
         checkPageIsDisplayed(
           performAction(),
-          messageFromMessageKey("undertaking.confirmation.title"),
-          { doc =>
-            val confirmationP1: String = doc.getElementById("confirmationFirstParaId").text()
-            confirmationP1 shouldBe "We have sent you a confirmation email."
-            val confirmationP2: String = doc.getElementById("confirmationSecondParaId").text()
-            confirmationP2 shouldBe "You can now submit reports of non-customs subsidy payments, or no payments in your undertaking."
-            doc.text() should not include messageFromMessageKey(
-              "undertaking.confirmation.p3",
-              routes.AddBusinessEntityController.getAddBusinessEntity()
-            )
-          }
+          messageFromMessageKey("undertaking.confirmation.title")
         )
 
       }
@@ -1365,21 +1355,7 @@ class UndertakingControllerSpec
 
         checkPageIsDisplayed(
           performAction(),
-          messageFromMessageKey("undertaking.confirmation.title"),
-          { doc =>
-            val confirmationP1: String = doc.getElementById("confirmationFirstParaId").text()
-            confirmationP1 shouldBe "We have sent you a confirmation email."
-            val confirmationP2: String = doc.getElementById("confirmationSecondParaId").text()
-            confirmationP2 shouldBe "You can now submit reports of non-customs subsidy payments, or no payments in your undertaking."
-
-            val confirmationP3 = doc.getElementById("confirmation-p3")
-            confirmationP3.text should startWith("You can also add businesses to your undertaking using the ")
-            confirmationP3.text should endWith(" link in the ‘Undertaking administration’ section of the undertaking.")
-            val link = doc.getElementById("add-remove-business-link")
-            link.text shouldBe "Add and remove businesses"
-            link.attr("href") shouldBe routes.AddBusinessEntityController.startJourney().url
-
-          }
+          messageFromMessageKey("undertaking.confirmation.title")
         )
 
       }

--- a/test/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmationPageSpec.scala
+++ b/test/uk/gov/hmrc/eusubsidycompliancefrontend/views/ConfirmationPageSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.views
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.test.FakeRequest
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.{EORI, UndertakingRef}
+import uk.gov.hmrc.eusubsidycompliancefrontend.test.util.PlaySupport
+import uk.gov.hmrc.eusubsidycompliancefrontend.views.html.ConfirmationPage
+
+class ConfirmationPageSpec extends PlaySupport {
+
+  "The Confirmation page" when {
+
+    "intentToAddBusiness is set to true" should {
+
+      val view: ConfirmationPage = fakeApplication.injector.instanceOf[ConfirmationPage]
+
+      val document: Document = Jsoup.parse(
+        view(UndertakingRef("UR123456"), EORI("GB922456789077"), intentToAddBusiness = true)(
+          FakeRequest(),
+          messages,
+          appConfig
+        ).body
+      )
+
+      "have the correct title" in {
+        document.title shouldBe
+          "Undertaking registered - Report and manage your allowance for Customs Duty waiver claims - GOV.UK"
+      }
+
+      "have the correct heading" in {
+        document.select("h1").text() shouldBe "Undertaking registered"
+      }
+
+      "have the correct first paragraph" in {
+        document.select("#confirmationFirstParaId").text() shouldBe "We have sent you a confirmation email."
+      }
+
+      "have the correct second paragraph" in {
+        document.select("#confirmationSecondParaId").text() shouldBe
+          "You can now submit reports of non-customs subsidy payments, or no payments in your undertaking."
+      }
+
+      "have the correct third paragraph" in {
+        document.select("#confirmation-p3").text() shouldBe "You can also add businesses to your undertaking " +
+          "using the Add and remove businesses link in the ‘Undertaking administration’ section of the undertaking."
+      }
+
+      "have an exit survey" which {
+
+        "has the correct heading" in {
+          document.select("#exit-survey > h2").text() shouldBe "Before you go"
+        }
+
+        "has the correct first paragraph" in {
+          document.select("#exit-survey > p:nth-of-type(1)").text() shouldBe
+            "Your feedback helps us make our service better."
+        }
+
+        "has the correct second paragraph" in {
+          document.select("#exit-survey > p:nth-of-type(2)").text() shouldBe
+            "Take a short survey to share your feedback on this service."
+        }
+
+        "has the correct link" in {
+          document.select("#exit-survey > p > a").attr("href") shouldBe appConfig.exitSurveyUrl
+        }
+      }
+    }
+
+    "intentToAddBusiness is set to false" should {
+
+      val view: ConfirmationPage = fakeApplication.injector.instanceOf[ConfirmationPage]
+
+      val document: Document = Jsoup.parse(
+        view(UndertakingRef("UR123456"), EORI("GB922456789077"), intentToAddBusiness = false)(
+          FakeRequest(),
+          messages,
+          appConfig
+        ).body
+      )
+
+      "not display the third paragraph" in {
+        document.select("#confirmation-p3").size() shouldBe 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
The content checks in this service are currently happening in the controller unit tests which is not great. For the relevant page here I've created a separate view spec to be more in line with our other services and better unit testing practice, and removed the content checks (aside from title) from the controller spec.
 
Also updated logback-text.xml to reduce noisy irrelevant logs in unit tests