### PR TITLE
DDCYLS-6418 - New EORI customs-data-store email end point

### DIFF
--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/CustomsDataStoreConnector.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/connectors/CustomsDataStoreConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.eusubsidycompliancefrontend.connectors
 import com.google.inject.{Inject, Singleton}
 import play.api.http.Status
 import play.api.libs.json.Json
-import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.UpdateEmailRequest
+import uk.gov.hmrc.eusubsidycompliancefrontend.models.email.{RetrieveEmail, UpdateEmailRequest}
 import uk.gov.hmrc.eusubsidycompliancefrontend.models.types.EORI
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -36,13 +36,15 @@ class CustomsDataStoreConnector @Inject() (override protected val http: HttpClie
 
   lazy private val cdsURL: String = servicesConfig.baseUrl("cds")
 
-  private def getUri(eori: EORI) = url"$cdsURL/customs-data-store/eori/$eori/verified-email"
+  def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+    val url = url"$cdsURL/customs-data-store/eori/verified-email-third-party"
+    val body = Json.toJson(RetrieveEmail(eori))
 
-  def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier): ConnectorResult =
-    makeRequest(
-      _.get(getUri(eori))
-        .execute[HttpResponse]
-    )
+    http
+      .post(url)
+      .withBody(body)
+      .execute[HttpResponse]
+  }
 
   def updateEmailForEori(eori: EORI, emailAddress: String, timestamp: LocalDateTime = LocalDateTime.now())(implicit
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/RetrieveEmail.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/models/email/RetrieveEmail.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.eusubsidycompliancefrontend.models.email
+
+import play.api.libs.json.{Json, OFormat}
+
+case class RetrieveEmail(eori: String)
+
+object RetrieveEmail {
+  implicit val format: OFormat[RetrieveEmail] = Json.format[RetrieveEmail]
+}

--- a/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailService.scala
+++ b/app/uk/gov/hmrc/eusubsidycompliancefrontend/services/EmailService.scala
@@ -96,17 +96,15 @@ class EmailService @Inject() (
   }
 
   def retrieveEmailByEORI(eori: EORI)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RetrieveEmailResponse] =
-    customsDataStoreConnector.retrieveEmailByEORI(eori).map {
-      case Left(error) => throw error
-      case Right(value: HttpResponse) =>
-        value.status match {
-          case NOT_FOUND => RetrieveEmailResponse(EmailType.UnVerifiedEmail, None)
-          case OK =>
-            value
-              .parseJSON[EmailAddressResponse]
-              .fold(_ => sys.error("Error in parsing Email Address"), handleEmailAddressResponse)
-          case _ => sys.error("Error in retrieving Email Address Response")
-        }
+    customsDataStoreConnector.retrieveEmailByEORI(eori).map { value =>
+      value.status match {
+        case NOT_FOUND => RetrieveEmailResponse(EmailType.UnVerifiedEmail, None)
+        case OK =>
+          value
+            .parseJSON[EmailAddressResponse]
+            .fold(_ => sys.error("Error in parsing Email Address"), handleEmailAddressResponse)
+        case _ => sys.error("Error in retrieving Email Address Response")
+      }
     }
 
   def hasVerifiedEmail(eori: EORI)(implicit


### PR DESCRIPTION
Swapping out old GET Eori end point with new POST end point. Updating unit tests to match new method (Using Future[httpsresponse] rather than Either)